### PR TITLE
Coverage-per-changeset: score the files a review never mentioned

### DIFF
--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -199,6 +199,69 @@ cost_per_hit() {
   echo $(( bytes / 4 / hits ))
 }
 
+# ---- coverage-per-changeset (#5) --------------------------------------------
+# Deterministic, uncorrelated signal the judges never produce: which files the
+# change touched that a reviewer never mentioned. Scores what the reviewer
+# DIDN'T look at, not what it found.
+#
+# ★ Every rail here exists because the naive version manufactures a false
+# "you skipped files", and a false skip is worse than a missed real one:
+#  - CREDITING a mention is the SAFE direction. Over-crediting only ever shrinks
+#    the accusation; it never invents one. So the full-path test is a generous
+#    substring, and the aim throughout is to under-accuse, never over-accuse.
+#  - Basename matches ONLY as a bare token. `grep -F index.ts` fires inside
+#    `src/a/index.ts`, so one full-path mention would silently credit every
+#    changed file named index.ts. A shared basename cannot identify a file, so
+#    both sharers go to an AMBIGUOUS bucket, counted in neither covered nor
+#    uncovered rather than guessed into one.
+#  - The escape covers EVERY non-word char. A filename with `+ ( ) { } ? | .`
+#    (Next.js `(group)`/`[id]`) would otherwise be read as a regex and an
+#    unbalanced `(` would error grep, dropping a real file to `uncovered`.
+#  - `case`, never `printf | grep`, for the substring test: under `pipefail` a
+#    `grep -q` that exits early SIGPIPEs the producer (exit 141), which on a
+#    large review flips a real mention into a false "never mentioned".
+#  - Empty denominator (no base, git failure, zero changed files) is "-", never
+#    0/0 -- same rule cost_per_hit follows: a number would be a claim the
+#    measurement does not support.
+# ★ DEFERRED (issue #5, criterion b): anchor/position-drift validation. A first
+# cut manufactured false drift four ways (substring file mis-attribution, an
+# anchor regex that fragments metachar paths, range anchors tested only at their
+# start, and pure-deletion files judged against another file's hunks). Left out
+# rather than shipped noisy; it is its own follow-up.
+# ★ NAMED NON-GOAL: mention detection is TEXT matching, not comprehension. A
+# reviewer can name a file without reviewing it. Coverage bounds attention from
+# below (never mentioned => never reviewed); it does not certify a read.
+changed_files() {  # <dir> <base> <sha> -> relative paths; empty on any failure
+  local dir="$1" base="$2" sha="$3"
+  [ -n "$base" ] || return 0
+  git -C "$dir" diff --name-only "$base...$sha" 2>/dev/null
+}
+
+# coverage_scan <review-file> <changed-newline>; sets COV_* for the caller.
+coverage_scan() {
+  local review="$1" changed="$2"
+  COV_TOTAL=0 COV_COVERED=0 COV_AMBIG=0 COV_UNCOVERED=0 COV_UNCOVERED_LIST=""
+  [ -n "$changed" ] || return 0          # empty denominator -> caller prints "-"
+  local body; body=$(cat "$review" 2>/dev/null)
+  local f bn ebn nshare
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    COV_TOTAL=$((COV_TOTAL + 1))
+    bn=${f##*/}
+    ebn=$(printf '%s' "$bn" | sed 's/[^[:alnum:]_-]/\\&/g')
+    if case "$body" in *"$f"*) true ;; *) false ;; esac; then
+      COV_COVERED=$((COV_COVERED + 1))
+    elif grep -qE -- "(^|[^A-Za-z0-9_/.-])$ebn([^A-Za-z0-9]|\$)" <<<"$body"; then
+      nshare=$(printf '%s\n' "$changed" | awk -v b="$bn" 'BEGIN{n=0}{p=$0;sub(/.*\//,"",p);if(p==b)n++}END{print n}')
+      if [ "$nshare" -ge 2 ]; then COV_AMBIG=$((COV_AMBIG + 1))
+      else COV_COVERED=$((COV_COVERED + 1)); fi
+    else
+      COV_UNCOVERED=$((COV_UNCOVERED + 1))
+      COV_UNCOVERED_LIST="${COV_UNCOVERED_LIST:+$COV_UNCOVERED_LIST, }$f"
+    fi
+  done <<< "$changed"
+}
+
 # Which band a hit count falls in. Named so the range logic can ask the question
 # at both ends and compare, rather than duplicating the thresholds.
 #
@@ -369,6 +432,13 @@ remove that directory and re-run."
   # driver ends up treating an ollama hiccup at hour two as a reason to abandon
   # hour three onward.
   local pass_reviews=0 grading_failed=""
+  # ★ Coverage is aggregated PER PASS, never pooled across passes: the whole
+  # hypothesis is that coverage degrades as a changeset grows, so pooling a
+  # 3-file pass with a 40-file one lets the big pass swamp the signal being
+  # measured. cov_pct_sum/cov_npass is the mean of per-pass ratios; the worst
+  # pass is named alongside. CLEAN passes are excluded from this aggregate, the
+  # same rail cost-per-hit honours (a CLEAN probe is a different measurement).
+  local cov_npass=0 cov_pct_sum=0 cov_worst=101 cov_worst_frac="" cov_worst_label=""
 
   {
     if [ -n "$scoped" ]; then
@@ -476,6 +546,10 @@ remove that directory and re-run."
     echo "==> $label: grading"
     graded_passes=$((graded_passes + 1))
     pass_usable=0; pass_reviews=0
+    # Changed-file set for this pass, computed once. Empty (no base resolvable,
+    # git failure) leaves every coverage line a "-".
+    local pass_changed passcov_runs=0 passcov_pctsum=0
+    pass_changed=$(changed_files "$target" "$base" "$sha")
     # ref-* = public repo = contaminated. Warn in the report. passes/README.md.
     case "$label" in ref-*) reference_used=1 ;; esac
     # A clean pass measures the opposite thing from a keyed one, so it is tracked
@@ -538,6 +612,26 @@ remove that directory and re-run."
         echo "- run $n: **★ SUSPECT, quotes $leaked key items verbatim**, this reviewer" >> "$report"
         echo "  probably read the answer key rather than finding the defects. NOT scored." >> "$report"
         continue
+      fi
+
+      # ---- coverage of the changeset by THIS review (#5) ----------------------
+      # Runs after the leak gate, so a SUSPECT review (which `continue`d above)
+      # never earns coverage credit for files it may have read from the key.
+      coverage_scan "$rf" "$pass_changed"
+      local cov_denom=$((COV_COVERED + COV_UNCOVERED))
+      if [ "$COV_TOTAL" -eq 0 ] || [ "$cov_denom" -eq 0 ]; then
+        # No changeset, or every changed file was ambiguous: "-", never 0/0 (a
+        # ratio the measurement cannot support), same rule cost_per_hit follows.
+        local why="no changeset to measure against"
+        [ "$COV_TOTAL" -gt 0 ] && why="all $COV_AMBIG changed file(s) ambiguous by shared basename"
+        echo "- run $n coverage: — ($why)" >> "$report"
+      else
+        local cov_line="- run $n coverage: $COV_COVERED/$cov_denom changed files mentioned"
+        [ "$COV_AMBIG" -gt 0 ] && cov_line="$cov_line ($COV_AMBIG ambiguous, shared basename)"
+        echo "$cov_line" >> "$report"
+        [ "$COV_UNCOVERED" -gt 0 ] && echo "  - never mentioned: $COV_UNCOVERED_LIST" >> "$report"
+        passcov_runs=$((passcov_runs + 1))
+        passcov_pctsum=$((passcov_pctsum + (100 * COV_COVERED / cov_denom)))
       fi
 
       # ---- grade this run with EVERY judge ------------------------------------
@@ -789,6 +883,18 @@ remove that directory and re-run."
         done
       done
     done
+    # Per-pass coverage into the candidate mean. KEYED passes only (a CLEAN
+    # probe is a different measurement and stays out of the aggregate, the same
+    # rail cost-per-hit follows); worst pass tracked with its own denominator so
+    # the summary can name where coverage was thinnest, not just the average.
+    if [ -z "$pass_clean" ] && [ "$passcov_runs" -gt 0 ]; then
+      local pass_pct=$((passcov_pctsum / passcov_runs))
+      cov_npass=$((cov_npass + 1)); cov_pct_sum=$((cov_pct_sum + pass_pct))
+      if [ "$pass_pct" -lt "$cov_worst" ]; then
+        cov_worst=$pass_pct; cov_worst_label="$label"; cov_worst_frac="$pass_pct%"
+      fi
+    fi
+
     # ★ A pass whose every run was UNUSABLE is a pass that did not happen. It
     # belongs with the missing keys and the deleted checkouts, because it has
     # exactly their effect on the arithmetic: nothing in the numerator, nothing
@@ -968,6 +1074,15 @@ ambiguous. Tighten the key and re-grade. Do not pick a judge."
       echo "- blocking items hit: **$blocking_hit / $blocking_total**"
     fi
     echo "- est. tokens per blocking item hit: **$cost_per**$partial_note"
+    # ★ Coverage sits beside the hit rate: a seat that hits every planted defect
+    # while never mentioning half the diff is a different bet from one that read
+    # all of it. Mean of per-pass ratios (not pooled), worst pass named. "-" when
+    # no keyed pass had a resolvable changeset -- never a fabricated 0%.
+    if [ "$cov_npass" -gt 0 ]; then
+      echo "- changed-file coverage (mean over $cov_npass keyed pass(es)): **$((cov_pct_sum / cov_npass))%**, thinnest on \`$cov_worst_label\` at $cov_worst_frac$partial_note"
+    else
+      echo "- changed-file coverage: **-** (no keyed pass had a resolvable changeset)"
+    fi
     echo "- all items hit: $total_hit / $total_items$([ "$total_unresolved" -gt 0 ] && echo " ($total_unresolved UNRESOLVED)")"
     echo "- deferred on a blocking item: $defer_on_blocking"
     echo "- unusable runs: $unusable"

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -2760,6 +2760,158 @@ R=$(ls "$D/home"/report-*.md | head -1)
 check "cost: partial denominator named" \
   "grep -qE 'est\. tokens per blocking item hit: \*\*[0-9]+\*\* \(partial denominator\)' '$R'"
 
+# ============================================================================
+# coverage-per-changeset (#5): what the reviewer never looked at.
+# ============================================================================
+
+# ---- unit tests on the helpers (grade.sh is already sourced above, line ~542),
+# because the metric ACCUSES and a wrong bucket is a false "you skipped a file". ----
+CR=$(mktemp -d -p "$SANDBOX"); CRR="$CR/repo"; mkdir -p "$CRR/src/a" "$CRR/src/b"
+git -C "$CRR" init -q; git -C "$CRR" config user.email t@t; git -C "$CRR" config user.name t
+printf 'v0\n' > "$CRR/src/a/index.ts"; printf 'v0\n' > "$CRR/src/b/index.ts"; printf 'v0\n' > "$CRR/src/keep.ts"
+git -C "$CRR" add -A; git -C "$CRR" commit -qm base
+CBASE=$(git -C "$CRR" rev-parse HEAD)
+printf 'v1\nl2\nl3\n' > "$CRR/src/a/index.ts"; printf 'v1\n' > "$CRR/src/b/index.ts"; printf 'v1\n' > "$CRR/src/keep.ts"
+git -C "$CRR" add -A; git -C "$CRR" commit -qm change
+CSHA=$(git -C "$CRR" rev-parse HEAD)
+CH=$(changed_files "$CRR" "$CBASE" "$CSHA")
+
+# A full path credits ONLY its file; a sibling sharing the basename is NOT
+# credited off it (the grep -F index.ts trap). keep.ts is a unique basename.
+printf 'bug in src/a/index.ts, and keep.ts is fine. see localhost:3000, node:18\n' > "$CR/rev1"
+coverage_scan "$CR/rev1" "$CH"
+check "cov unit: full-path + unique basename => covered=2" "[ $COV_COVERED -eq 2 ]"
+check "cov unit: sibling index.ts stays uncovered=1"       "[ $COV_UNCOVERED -eq 1 ]"
+check "cov unit: names the uncovered file"     "printf %s '$COV_UNCOVERED_LIST' | grep -q 'src/b/index.ts'"
+
+# Bare shared basename cannot identify a file => BOTH sharers ambiguous, in
+# neither covered nor uncovered. This is the test that keeps the trap fixed.
+printf 'issue in index.ts somewhere. keep.ts is fine.\n' > "$CR/rev2"
+coverage_scan "$CR/rev2" "$CH"
+check "cov unit: shared bare basename => ambiguous=2" "[ $COV_AMBIG -eq 2 ]"
+check "cov unit: ambiguous not folded into covered"   "[ $COV_COVERED -eq 1 ]"
+
+# ★ Empty denominator (base == sha) is "-", never 0/0. Mutation guard: the rule
+# is COV_TOTAL stays 0 so the caller dashes. A version that treated an empty
+# changeset as "all covered" would set COV_TOTAL and hand up a ratio.
+CH0=$(changed_files "$CRR" "$CSHA" "$CSHA")
+coverage_scan "$CR/rev1" "$CH0"
+check "cov unit: empty changeset => COV_TOTAL=0 (caller prints -)" "[ $COV_TOTAL -eq 0 ]"
+
+# ★ pipefail SIGPIPE regression: a real mention on line 1 of a LARGE review must
+# not flip to uncovered because grep -q exits early and SIGPIPEs a `printf |`
+# producer. `case` matching removes the pipe. 200 KiB is well past the ~128 KiB
+# where the pipe version was measured to fail.
+{ printf 'the fix is in src/keep.ts here\n'; head -c 204800 /dev/zero | tr '\0' 'x'; } > "$CR/revbig"
+coverage_scan "$CR/revbig" "$CH"
+check "cov unit: huge review, line-1 mention still covered (no SIGPIPE flip)" \
+  "! printf %s '$COV_UNCOVERED_LIST' | grep -q 'src/keep.ts'"
+
+# ★ ERE metachars in a filename must not break the basename match into a false
+# "uncovered". A bare mention of `a+(x).ts` under a naive escape reads as the
+# regex a+(x) and never matches the literal name (and an unbalanced ( errors the
+# whole grep). Next.js (group)/[id] names are the realistic trigger.
+MRD=$(mktemp -d -p "$SANDBOX"); MR="$MRD/r"; mkdir -p "$MR/src"
+git -C "$MR" init -q; git -C "$MR" config user.email t@t; git -C "$MR" config user.name t
+printf 'v0\n' > "$MR/src/a+(x).ts"; git -C "$MR" add -A; git -C "$MR" commit -qm base
+MB=$(git -C "$MR" rev-parse HEAD)
+printf 'v1\nl2\n' > "$MR/src/a+(x).ts"; git -C "$MR" add -A; git -C "$MR" commit -qm change
+MS=$(git -C "$MR" rev-parse HEAD); MCH=$(changed_files "$MR" "$MB" "$MS")
+printf 'the bug is in a+(x).ts near the top\n' > "$CR/revm"
+coverage_scan "$CR/revm" "$MCH"
+check "cov unit: ERE-metachar filename covered by bare basename, not false-uncovered" \
+  "[ $COV_COVERED -eq 1 ] && [ $COV_UNCOVERED -eq 0 ]"
+
+# ---- end to end: a real multi-file diff, a review mentioning HALF of it, and
+# the report has to name the skipped files and a 50% mean. ----
+cov_case() {  # cov_case <dir> <review-body>
+  local d="$1" body="$2" sl base sha
+  mkdir -p "$d/home/p1"; setup_agents "$d"
+  git init -q "$d/checkout"
+  git -C "$d/checkout" config user.email t@t; git -C "$d/checkout" config user.name t
+  mkdir -p "$d/checkout/src/a" "$d/checkout/src/b"
+  printf 'v0\n' > "$d/checkout/src/a/index.ts"; printf 'v0\n' > "$d/checkout/src/b/index.ts"
+  printf 'v0\n' > "$d/checkout/src/keep.ts";    printf 'v0\n' > "$d/checkout/src/other.ts"
+  git -C "$d/checkout" add -A; git -C "$d/checkout" commit -qm base
+  base=$(git -C "$d/checkout" rev-parse HEAD)
+  printf 'v1\nl2\nl3\n' > "$d/checkout/src/a/index.ts"; printf 'v1\n' > "$d/checkout/src/b/index.ts"
+  printf 'v1\n' > "$d/checkout/src/keep.ts";           printf 'v1\n' > "$d/checkout/src/other.ts"
+  git -C "$d/checkout" add -A; git -C "$d/checkout" commit -qm change
+  sha=$(git -C "$d/checkout" rev-parse HEAD)
+  printf '#### K1 blocking - the write is dropped\ntext\n\n#### K2 blocking - the token leaks\ntext\n' > "$d/home/k.md"
+  printf 'p1|%s|%s|%s|%s\n' "$sha" "$d/checkout" "$base" "$d/home/k.md" > "$d/home/passes.conf"
+  sl=$(slug terse)
+  printf '%s\n' "$body" > "$d/home/p1/$sl-run1.md"
+  local ja jb; ja=$(slug good); jb=$(slug good2)
+  printf '%s\n' "$HITBOTH" > "$d/home/p1/$sl-run1.by-$ja.grade.json"
+  printf '%s\n' "$HITBOTH" > "$d/home/p1/$sl-run1.by-$jb.grade.json"
+}
+D=$(mktemp -d -p "$SANDBOX")
+# Mentions src/a/index.ts (full path) + keep.ts (unique basename); never names
+# src/b/index.ts or src/other.ts. 2 of 4 changed files => 50%.
+cov_case "$D" 'blocking - the write is dropped in src/a/index.ts
+blocking - the token leaks, see keep.ts
+Verdict: ship it'
+OUT=$(run_gaunt "$D" good,good2 terse)
+R=$(ls "$D/home"/report-*.md | head -1)
+check "cov e2e: per-run line, 2/4 mentioned"   "grep -qF 'run 1 coverage: 2/4 changed files mentioned' '$R'"
+check "cov e2e: names skipped src/b/index.ts"  "grep -q 'never mentioned:.*src/b/index.ts' '$R'"
+check "cov e2e: names skipped src/other.ts"    "grep -q 'never mentioned:.*src/other.ts' '$R'"
+check "cov e2e: candidate summary is 50%"      "grep -qF 'changed-file coverage (mean over 1 keyed pass(es)): **50%**' '$R'"
+check "cov e2e: names the thinnest pass"        "grep -q 'thinnest on .p1. at 50%' '$R'"
+
+# ---- all-ambiguous pass: per-run is "—" and the candidate summary is "-", never
+# a fabricated 0/0 or 0%. Two changed files sharing basename index.ts, review
+# names only the bare basename. ----
+DA=$(mktemp -d -p "$SANDBOX"); mkdir -p "$DA/home/p1"; setup_agents "$DA"
+git init -q "$DA/checkout"; git -C "$DA/checkout" config user.email t@t; git -C "$DA/checkout" config user.name t
+mkdir -p "$DA/checkout/a" "$DA/checkout/b"
+printf 'v0\n' > "$DA/checkout/a/index.ts"; printf 'v0\n' > "$DA/checkout/b/index.ts"
+git -C "$DA/checkout" add -A; git -C "$DA/checkout" commit -qm base; ABASE=$(git -C "$DA/checkout" rev-parse HEAD)
+printf 'v1\n' > "$DA/checkout/a/index.ts"; printf 'v1\n' > "$DA/checkout/b/index.ts"
+git -C "$DA/checkout" add -A; git -C "$DA/checkout" commit -qm ch; ASHA=$(git -C "$DA/checkout" rev-parse HEAD)
+printf '#### K1 blocking - the write is dropped\ntext\n\n#### K2 blocking - the token leaks\ntext\n' > "$DA/home/k.md"
+printf 'p1|%s|%s|%s|%s\n' "$ASHA" "$DA/checkout" "$ABASE" "$DA/home/k.md" > "$DA/home/passes.conf"
+SLA=$(slug terse)
+printf 'blocking - the write is dropped in index.ts\nblocking - the token leaks in index.ts\nVerdict: ship it\n' > "$DA/home/p1/$SLA-run1.md"
+printf '%s\n' "$HITBOTH" > "$DA/home/p1/$SLA-run1.by-$(slug good).grade.json"
+printf '%s\n' "$HITBOTH" > "$DA/home/p1/$SLA-run1.by-$(slug good2).grade.json"
+run_gaunt "$DA" good,good2 terse >/dev/null 2>&1
+RA=$(ls "$DA/home"/report-*.md | head -1)
+check "cov e2e: all-ambiguous per-run is a dash"  "grep -q 'run 1 coverage: — (all 2 changed' '$RA'"
+check "cov e2e: all-ambiguous summary is a dash"  "grep -qF 'changed-file coverage: **-**' '$RA'"
+
+# ---- two passes of different sizes: the candidate summary is the MEAN of
+# per-pass ratios, NOT pooled over files (which lets the big pass swamp the
+# small one -- the exact signal #5 measures). Small 1/2=50%, large 4/4=100%
+# => mean 75% (pooled would be 5/6=83%). Worst pass named. ----
+DT=$(mktemp -d -p "$SANDBOX"); mkdir -p "$DT/home/pA" "$DT/home/pB"; setup_agents "$DT"
+git init -q "$DT/ca"; git -C "$DT/ca" config user.email t@t; git -C "$DT/ca" config user.name t
+printf 'v0\n' > "$DT/ca/one.ts"; printf 'v0\n' > "$DT/ca/two.ts"
+git -C "$DT/ca" add -A; git -C "$DT/ca" commit -qm base; TAB=$(git -C "$DT/ca" rev-parse HEAD)
+printf 'v1\n' > "$DT/ca/one.ts"; printf 'v1\n' > "$DT/ca/two.ts"
+git -C "$DT/ca" add -A; git -C "$DT/ca" commit -qm ch; TAS=$(git -C "$DT/ca" rev-parse HEAD)
+git init -q "$DT/cb"; git -C "$DT/cb" config user.email t@t; git -C "$DT/cb" config user.name t
+for x in w x y z; do printf 'v0\n' > "$DT/cb/$x.ts"; done
+git -C "$DT/cb" add -A; git -C "$DT/cb" commit -qm base; TBB=$(git -C "$DT/cb" rev-parse HEAD)
+for x in w x y z; do printf 'v1\n' > "$DT/cb/$x.ts"; done
+git -C "$DT/cb" add -A; git -C "$DT/cb" commit -qm ch; TBS=$(git -C "$DT/cb" rev-parse HEAD)
+printf '#### K1 blocking - the write is dropped\ntext\n\n#### K2 blocking - the token leaks\ntext\n' > "$DT/home/k.md"
+{ printf 'pA|%s|%s|%s|%s\n' "$TAS" "$DT/ca" "$TAB" "$DT/home/k.md"
+  printf 'pB|%s|%s|%s|%s\n' "$TBS" "$DT/cb" "$TBB" "$DT/home/k.md"; } > "$DT/home/passes.conf"
+SLT=$(slug terse)
+printf 'blocking - the write is dropped in one.ts\nblocking - the token leaks\nVerdict: ship it\n' > "$DT/home/pA/$SLT-run1.md"
+printf 'blocking - dropped in w.ts x.ts\nblocking - leaks in y.ts z.ts\nVerdict: ship it\n' > "$DT/home/pB/$SLT-run1.md"
+for p in pA pB; do
+  printf '%s\n' "$HITBOTH" > "$DT/home/$p/$SLT-run1.by-$(slug good).grade.json"
+  printf '%s\n' "$HITBOTH" > "$DT/home/$p/$SLT-run1.by-$(slug good2).grade.json"
+done
+run_gaunt_all "$DT" good,good2 terse >/dev/null 2>&1
+RT=$(ls "$DT/home"/report-*.md | head -1)
+check "cov e2e: 2-pass mean is 75% (per-pass, not pooled 83%)" \
+  "grep -qF 'changed-file coverage (mean over 2 keyed pass(es)): **75%**' '$RT'"
+check "cov e2e: names thinnest as pA at 50%"    "grep -q 'thinnest on .pA. at 50%' '$RT'"
+
 echo
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes part of #5 (criterion a). Keeps #5 open for the deferred criteria.

A deterministic signal beside the hit rate: per pass, which changed files a reviewer never named. Three buckets — covered / ambiguous-by-shared-basename / uncovered — a per-pass MEAN that is never pooled (so a large diff cannot swamp a small one, the whole point), the worst pass named, and `-` on an empty or all-ambiguous changeset rather than a fabricated 0/0.

Every rail exists because the naive version manufactures a false "you skipped a file", which is worse than missing a real skip: mention-crediting is the safe direction; a shared basename cannot identify a file so both sharers go ambiguous; the escape covers every non-word char so a `(group)`/`[id]` filename cannot error grep into a false uncovered; and `case` not `printf | grep`, so a large review cannot SIGPIPE a real mention into "never mentioned".

**Deferred, so #5 stays open:** criterion b (cited-anchor / position-drift validation) — a first cut manufactured false drift four ways, and a false accusation is the one thing this metric must not produce; criterion c (matrix cell) — `cadre panel` still parses only K-items, a separate smaller change once the report line format settles.

Tests (692 total, 0 failed): the three buckets, the shared-basename collision, ERE-metachar filenames, the pipefail flip on a >128KB review, the all-ambiguous dash, and a two-pass fixture pinning the per-pass mean (75%) against the pooled number it must not report (83%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added changed-file coverage metrics to review reports, including per-run, per-pass, average, and lowest-pass coverage.
  * Reviews now identify covered, skipped, and ambiguous changed files.
  * Coverage is excluded for suspect and clean runs and displays `-` when no files can be evaluated.

* **Tests**
  * Added comprehensive coverage checks for file matching, ambiguous names, empty changesets, special filenames, and aggregation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->