### PR TITLE
Split the one FAILED line into which nothing actually happened

### DIFF
--- a/bin/cadre
+++ b/bin/cadre
@@ -1100,7 +1100,13 @@ and declined to flag it, which is exactly backwards.
   printf '%s' "$raw" > "$out/.synth-tmp"
   if [ "$(classify_run "$out/.synth-tmp" "$rc" synth)" != ok ]; then
     mv "$out/.synth-tmp" "$out/synthesis.md.failed"
-    echo "synthesis FAILED (rc=$rc), kept as synthesis.md.failed." >&2
+    # ★ Third consumer of the same split (#12). The synthesizer is a model and
+    # fails like one, so "the provider returned nothing" and "cadre's clock cut
+    # a live merge short" are as distinguishable here as on a review -- and the
+    # second one is fixable by re-running with a bigger CADRE_TIMEOUT, which the
+    # old flat message never suggested. No elapsed time is tracked on this path,
+    # so the phrase is asked for without one rather than handed a made-up number.
+    echo "synthesis $(failure_phrase "$out/synthesis.md.failed" "$rc"), kept as synthesis.md.failed." >&2
     echo "The individual reviews are intact in $out." >&2
     return 0
   fi

--- a/docs/ADDING-AN-AGENT.md
+++ b/docs/ADDING-AN-AGENT.md
@@ -62,6 +62,16 @@ an empty failure.
 | review text, cut short | the text, then a line starting `_TRUNCATED` | `degraded` |
 | no review at all | a line starting `DID NOT RUN` or `DID NOT COMPLETE`, then any raw output that helps diagnose it | `failed` |
 
+**If the clock is what stopped you, say so on that marker line, with the number:**
+`DID NOT COMPLETE, <agent> was killed at the ${TIMEOUT}s timeout`. It does not
+change your state — you are still `failed` — it changes what the operator is
+told. Cadre reports a clock kill and a provider that returned nothing as two
+different things, because they call for opposite responses, and the exit code is
+not enough to tell them apart: most adapters here normalise theirs to 0 on a
+kill, so the marker line is the only place the fact survives. Leave the number
+out and your timeout prints as a flat `FAILED`, which reads as a verdict on the
+model.
+
 There is a fourth state, `inconclusive`, and **it is not yours to emit.** Cadre
 decides it by reading the artifact: a run that exited cleanly and stated neither a
 finding nor a bottom line never reviewed anything, whatever else it printed. You

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -782,6 +782,93 @@ provider_refused() {
   [ "$(wc -c < "$f")" -lt 500 ]
 }
 
+# Does this artifact hold nothing at all? THE one copy of the chrome strip.
+#
+# ★ Empty means empty of CONTENT, not of bytes. CLIs wrap the model's text in
+# their own chrome -- colour escapes, a "> build <model>" banner -- so a run
+# that returned nothing still leaves a non-empty file and scores as a clean
+# review that found no defects. Measured with opencode, which is the free
+# route the README sends people down first. NOT a minimum-length rule:
+# "findings=0" is a valid review and a length floor threw those away.
+# ★ A LITERAL escape byte, not `\x1b`. `\x1b` is a GNU sed extension; BSD sed
+# (macOS, and macOS keeps BSD sed even with GNU coreutils installed, because
+# sed is not part of coreutils) reads it as a literal `x1b`, matches nothing,
+# and this whole check silently no-ops -- filing a chrome-only run as a clean
+# review again, on an entire platform, with no error. Found by a panel
+# reviewer on cadre's own diff.
+# ★ Extracted from inside classify_run (#12) because the answer is needed TWICE
+# and used to be computed once and thrown away: classify_run asks it to reach
+# `failed`, and the reporters ask it to say WHICH failure. A second copy at each
+# print site would be the free-text-grep debt #2 exists to delete, so there is
+# one function and three renderers over it.
+content_empty() {  # <file> -> 0 when the file holds no content
+  local f="$1"
+  [ -s "$f" ] || return 0
+  local esc; esc=$(printf '\033')
+  [ -z "$(sed -e "s/${esc}\[[0-9;?]*[a-zA-Z]//g" -e 's/[[:space:]]//g' "$f")" ]
+}
+
+# ★ WHICH nothing (#12). Three root causes rendered one identical line -- a
+# `FAILED after Ns (rc=124)` that meant, on the same opencode-go sweep:
+#   1. the adapter was ALIVE and producing (a 72KB transcript) and cadre's own
+#      clock killed it. Raising CADRE_TIMEOUT turned that exact pass into a
+#      graded blocking HIT.
+#   2. the provider returned NOTHING -- 2 bytes, two newlines -- and burned the
+#      full timeout doing it. A whole-sweep streak of this was a provider
+#      OUTAGE: every model hung on `Reply with exactly: OK`.
+#   3. a genuine refusal / capability block, which classify_run already splits.
+# Read as one message, case 1 is a verdict about the MODEL manufactured out of a
+# harness kill. That is the fabricated-grade failure mode, so the split is not
+# cosmetic.
+#
+# ★ This does NOT return a new classify_run state, and must not. Three call
+# sites string-compare that function (`= failed || break` in run-pass.sh and
+# run-review.sh, `!= ok` in bin/cadre); a fourth bucket would silently rewire
+# their retry loops. Same `.failed` bucket, different operator-facing line.
+#
+# ★ CONTENT-EMPTY WINS over the timeout code, because case 2 is both: nothing
+# came back AND the clock ran out. "The provider sent nothing" is the actionable
+# half; "raise the timeout" would be advice that cannot help.
+#
+# rc is OPTIONAL. `cadre grade` re-reads .failed artifacts off disk long after
+# the exit code is gone, and the content discriminator still works there -- so
+# with no rc the timeout case is simply not claimed rather than guessed at.
+failure_kind() {  # <file> [rc] -> no-output | timed-out | failed
+  local f="$1" rc="${2:-}"
+  if content_empty "$f"; then echo no-output; return 0; fi
+  # 124 is GNU timeout's "the command timed out"; 137 is the -k SIGKILL landing
+  # as 128+9 on a child that ignored the TERM. bin/agentcall wraps every adapter
+  # in `timeout -k 30 "$TIMEOUT"`, so both codes are CADRE'S clock, not the
+  # provider's -- which is exactly the confusion this exists to end.
+  case "$rc" in 124|137) echo timed-out; return 0 ;; esac
+  echo failed
+}
+
+# The operator-facing phrase for a failed run. Renderers append their own
+# "kept as X" suffix.
+#
+# ★ Names CADRE_TIMEOUT and its current value. It took a `bin/agentcall` grep to
+# learn the knob existed and that rc=124 was cadre's own clock rather than the
+# provider's; a message that costs a source dive to act on is a message that
+# does not work. Default mirrors bin/agentcall:33 -- if that number moves, move
+# this one.
+# ★ Vocabulary is agents.d/codex.sh's ("killed at the Ns timeout", "with no
+# output", "Raise CADRE_TIMEOUT"), not a third phrasing for the same split.
+failure_phrase() {  # <file> <rc> [secs] -> leading phrase, no trailing period
+  local f="$1" rc="$2" secs="${3:-}" after="" tmo="${CADRE_TIMEOUT:-900}"
+  [ -n "$secs" ] && after=" after ${secs}s"
+  case "$(failure_kind "$f" "$rc")" in
+    no-output)
+      local burned=""
+      case "$rc" in 124|137) burned=", burning the full ${tmo}s CADRE_TIMEOUT" ;; esac
+      echo "NO OUTPUT$after (rc=$rc): the provider returned nothing$burned" ;;
+    timed-out)
+      echo "TIMED OUT$after: killed at the ${tmo}s CADRE_TIMEOUT while still producing output, so this is cadre's clock, not a verdict on the model -- raise CADRE_TIMEOUT and re-run" ;;
+    *)
+      echo "FAILED$after (rc=$rc)" ;;
+  esac
+}
+
 # Classify one agent run: ok | degraded | inconclusive | failed. THE one copy of
 # this rule.
 #
@@ -826,23 +913,7 @@ classify_run() {
   # Same rule, one copy; the only difference is whether the truncation MARKER is
   # readable in that context. See the marker check below for why it is not.
   local f="$1" rc="$2" ctx="${3:-run}"
-  if [ ! -s "$f" ]; then echo failed; return 0; fi
-  # ★ Empty means empty of CONTENT, not of bytes. CLIs wrap the model's text in
-  # their own chrome -- colour escapes, a "> build <model>" banner -- so a run
-  # that returned nothing still leaves a non-empty file and scores as a clean
-  # review that found no defects. Measured with opencode, which is the free
-  # route the README sends people down first. NOT a minimum-length rule:
-  # "findings=0" is a valid review and a length floor threw those away.
-  # ★ A LITERAL escape byte, not `\x1b`. `\x1b` is a GNU sed extension; BSD sed
-  # (macOS, and macOS keeps BSD sed even with GNU coreutils installed, because
-  # sed is not part of coreutils) reads it as a literal `x1b`, matches nothing,
-  # and this whole check silently no-ops -- filing a chrome-only run as a clean
-  # review again, on an entire platform, with no error. Found by a panel
-  # reviewer on cadre's own diff.
-  local esc; esc=$(printf '\033')
-  if [ -z "$(sed -e "s/${esc}\[[0-9;?]*[a-zA-Z]//g" -e 's/[[:space:]]//g' "$f")" ]; then
-    echo failed; return 0
-  fi
+  if content_empty "$f"; then echo failed; return 0; fi
   # ★ THE ADAPTER'S OWN VERDICT COMES FIRST, both markers together, ahead of
   # anything inferred from the text or the exit code. The adapter is the only
   # layer that watched the run; everything below this is cadre guessing from

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -836,6 +836,25 @@ content_empty() {  # <file> -> 0 when the file holds no content
 failure_kind() {  # <file> [rc] -> no-output | timed-out | failed
   local f="$1" rc="${2:-}"
   if content_empty "$f"; then echo no-output; return 0; fi
+  # ★ THE ADAPTER'S OWN VERDICT BEFORE THE EXIT CODE, the same rail classify_run
+  # follows and for the same reason: the adapter is the only layer that watched
+  # the run. This is not decoration here, it is most of the roster. Adapters
+  # NORMALISE their exit code on a clock kill -- agents.d/codex.sh:107 prints
+  # "codex was killed at the 900s timeout with no output" and then returns 0,
+  # because the trailing `rm -f` is the last command in the function. So for the
+  # codex family, and for agy.sh:137, the rc test below can NEVER see the
+  # timeout, and the case this whole issue is about would keep printing FAILED.
+  # Measured on codex 0.145.0, where `-o` is written only at final completion:
+  # a mid-turn kill leaves it empty, so this branch is the COMMON codex timeout,
+  # not the rare one.
+  # ★ head -3 for the reason classify_run anchors its markers there: past the
+  # edge, a timeout sentence is the reviewed code or a reviewer quoting one.
+  # Over-claiming here is cheap in a way it is not elsewhere -- failure_phrase
+  # is only ever asked about a run already binned `failed`, so the worst case is
+  # a wording change, never a bucket change and never a score.
+  if head -3 "$f" | grep -qE '^(DID NOT RUN|DID NOT COMPLETE).*[0-9]+s timeout'; then
+    echo timed-out; return 0
+  fi
   # 124 is GNU timeout's "the command timed out"; 137 is the -k SIGKILL landing
   # as 128+9 on a child that ignored the TERM. bin/agentcall wraps every adapter
   # in `timeout -k 30 "$TIMEOUT"`, so both codes are CADRE'S clock, not the
@@ -854,18 +873,30 @@ failure_kind() {  # <file> [rc] -> no-output | timed-out | failed
 # this one.
 # ★ Vocabulary is agents.d/codex.sh's ("killed at the Ns timeout", "with no
 # output", "Raise CADRE_TIMEOUT"), not a third phrasing for the same split.
+# ★ rc=0 is NOT printed. A failure line carrying `(rc=0)` sends an operator
+# hunting for a crash that never happened -- which is this issue's own disease
+# in miniature, and it is not hypothetical: an adapter that normalises its exit
+# code produces exactly that line. No exit code beats a meaningless one.
 failure_phrase() {  # <file> <rc> [secs] -> leading phrase, no trailing period
-  local f="$1" rc="$2" secs="${3:-}" after="" tmo="${CADRE_TIMEOUT:-900}"
+  local f="$1" rc="$2" secs="${3:-}" after="" rcp="" tmo="${CADRE_TIMEOUT:-900}"
   [ -n "$secs" ] && after=" after ${secs}s"
+  case "$rc" in ''|0) ;; *) rcp=" (rc=$rc)" ;; esac
   case "$(failure_kind "$f" "$rc")" in
     no-output)
       local burned=""
       case "$rc" in 124|137) burned=", burning the full ${tmo}s CADRE_TIMEOUT" ;; esac
-      echo "NO OUTPUT$after (rc=$rc): the provider returned nothing$burned" ;;
+      echo "NO OUTPUT$after$rcp: the provider returned nothing$burned" ;;
+    # ★ Says HOW it ended, and deliberately does not say how much the run had
+    # produced. Both routes into `timed-out` land here and they disagree on
+    # that: an rc=124 kill means the adapter was mid-flight, while the codex
+    # marker means the clock ran out with nothing written yet. The artifact
+    # itself states which, and a phrase that guessed would be a claim about the
+    # model built from a harness setting -- the exact move this issue exists to
+    # stop, one level up.
     timed-out)
-      echo "TIMED OUT$after: killed at the ${tmo}s CADRE_TIMEOUT while still producing output, so this is cadre's clock, not a verdict on the model -- raise CADRE_TIMEOUT and re-run" ;;
+      echo "TIMED OUT$after$rcp: killed at the ${tmo}s CADRE_TIMEOUT, so this is cadre's clock and not a verdict on the model -- raise CADRE_TIMEOUT and re-run" ;;
     *)
-      echo "FAILED$after (rc=$rc)" ;;
+      echo "FAILED$after$rcp" ;;
   esac
 }
 

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -429,7 +429,7 @@ remove that directory and re-run."
   # exactly: OK` while a direct-provider model answered instantly. The existing
   # NOTHING MEASURED wording ("this says nothing about X") is true but reads as a
   # property of the model, which is the misread this issue is about.
-  local no_output_runs=0
+  local no_output_runs=0 provider_empty=""
   # ★ Two failures that must not share an exit code, because the caller's correct
   # response to them is opposite. A missing REVIEW is fifteen minutes of a model's
   # time and the reason to stop a sweep. A review that exists but could not be
@@ -542,6 +542,15 @@ remove that directory and re-run."
         if [ "$prc" -eq 6 ]; then
           skipped="$skipped- $label: NOT MEASURED, the provider's usage window closed (resume after its reset)"$'\n'
           window_closed=1
+        # ★ 7 gets the same treatment as 6 and for the same reason: the pass
+        # measured nothing, but the cause is on the provider's side and clears
+        # on its own, so calling it a failed measurement sends the operator
+        # looking for a defect that is not there. This is the ONLY route by
+        # which `cadre run` can reach the outage verdict -- it aborts here and
+        # never reaches the grading loop that computes the other one.
+        elif [ "$prc" -eq 7 ]; then
+          skipped="$skipped- $label: NOT MEASURED, every run came back empty (suspect a provider outage)"$'\n'
+          provider_empty=1
         else
           skipped="$skipped- $label: no usable review, run-pass.sh exited $prc"$'\n'
           measurement_failed=1
@@ -610,7 +619,14 @@ remove that directory and re-run."
         # disk even though the exit code does not, so failure_kind is asked
         # WITHOUT an rc here: a no-output artifact is stated as fact, and the
         # timeout case is left unclaimed rather than guessed at from bytes.
-        if [ -s "$rf.failed" ]; then
+        # ★ -e, not -s. A hung provider that wrote nothing to stdout OR stderr
+        # leaves run-pass.sh a 0-byte `.part` to rename, so the truest form of
+        # "the provider returned nothing" is the one a `-s` gate skips entirely:
+        # the branch never ran, the count never incremented, and a sweep of pure
+        # silence was the one shape that could not reach the outage verdict.
+        # Every other artifact test in this block stays `-s` on purpose -- an
+        # empty .partial or .inconclusive really is nothing to report.
+        if [ -e "$rf.failed" ]; then
           if content_empty "$rf.failed"; then
             why="the provider returned NOTHING (no content in $sl-run$n.md.failed)"
             no_output_runs=$((no_output_runs + 1))
@@ -976,8 +992,16 @@ the judge over what is already on disk. Do not re-review."
       # that nothing was empty.
       # ★ And it must be > 0. A sweep whose passes were all skipped for missing
       # keys has zero of both, and `0 -eq 0` would blame a provider never called.
-      if [ "$no_output_runs" -gt 0 ] && [ "$no_output_runs" -eq "$unusable" ] \
-         && [ -z "$grading_failed" ]; then
+      # ★ TWO routes reach this, and both are needed. `cadre grade` re-reads the
+      # artifacts and computes it here; `cadre run` never gets here at all,
+      # because run-pass.sh exit 7 aborts the sweep above -- so that path sets
+      # the flag directly. A verdict only the rarer command can print is a
+      # verdict the operator does not get.
+      if [ -n "$provider_empty" ] ||
+         { [ "$no_output_runs" -gt 0 ] && [ "$no_output_runs" -eq "$unusable" ]; }; then
+        provider_empty=1
+      fi
+      if [ -n "$provider_empty" ] && [ -z "$grading_failed" ]; then
         # ★ Its own exit code, for the reason window-closed has one: a driver
         # piping stdout to /dev/null sees only this, and "wait for the provider,
         # nothing here is broken" is a different instruction from 4's "fix the

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -423,6 +423,13 @@ remove that directory and re-run."
   # the one path where it costs most: 11 of 12 passes producing nothing scored
   # 0/0 and reported INCONCLUSIVE, indistinguishable from a registry problem.
   local usable_runs=0 pass_usable=0 aborted="" measurement_failed="" nfiltered=0 window_closed=""
+  # ★ Sweep-wide tally behind the fourth "nothing" verdict (#12). A NO OUTPUT
+  # streak across every seat of a sweep is evidence about the PROVIDER, not the
+  # candidate -- measured when every opencode-go model hung on `Reply with
+  # exactly: OK` while a direct-provider model answered instantly. The existing
+  # NOTHING MEASURED wording ("this says nothing about X") is true but reads as a
+  # property of the model, which is the misread this issue is about.
+  local no_output_runs=0
   # ★ Two failures that must not share an exit code, because the caller's correct
   # response to them is opposite. A missing REVIEW is fifteen minutes of a model's
   # time and the reason to stop a sweep. A review that exists but could not be
@@ -596,8 +603,20 @@ remove that directory and re-run."
           why="ran but returned no review, see $sl-run$n.md.inconclusive, not scored"
           [ -s "$rf.partial" ] && why="$why (an earlier attempt stopped early, see $sl-run$n.md.partial)"
         fi
+        # ★ "the adapter failed" was a claim, not an observation (#12). The same
+        # line covered a provider that returned nothing, a live adapter killed
+        # by cadre's own clock, and a real adapter crash -- and it sent the
+        # reader to the adapter for all three. The discriminator survives on
+        # disk even though the exit code does not, so failure_kind is asked
+        # WITHOUT an rc here: a no-output artifact is stated as fact, and the
+        # timeout case is left unclaimed rather than guessed at from bytes.
         if [ -s "$rf.failed" ]; then
-          why="the adapter failed, see $sl-run$n.md.failed"
+          if content_empty "$rf.failed"; then
+            why="the provider returned NOTHING (no content in $sl-run$n.md.failed)"
+            no_output_runs=$((no_output_runs + 1))
+          else
+            why="the run produced output but no usable review, see $sl-run$n.md.failed"
+          fi
           [ -s "$rf.partial" ] && why="$why (an earlier attempt stopped early, see $sl-run$n.md.partial)"
         fi
         echo "- run $n: **UNUSABLE** ($why)" >> "$report"
@@ -940,10 +959,45 @@ It is a failed measurement, and a failed measurement is not a result."
 here -- but nothing expensive was lost, and \`cadre grade $spec $runs\` re-runs
 the judge over what is already on disk. Do not re-review."
       fi
+      local tail1="Fix the cause and re-run. Do not quote a number from this file."
+      # ★ A fourth nothing (#12), and it is a statement about the PROVIDER. Fires
+      # only when EVERY failed run of the sweep came back content-empty: one
+      # empty artifact is an ordinary failure, a clean sweep of them is an
+      # outage, and the two need opposite responses (drop the seat vs. wait and
+      # re-run). Checked before the window branch and gated on the same
+      # grading_failed guard, so a sweep that actually produced reviews and only
+      # failed to grade them still gets NOTHING GRADED.
+      # ★ The denominator is $unusable -- EVERY unusable run of the sweep -- not
+      # the failed ones alone. Against the failed-run count, a sweep of one empty
+      # artifact plus three INCONCLUSIVE runs reads as 1-of-1 empty and blames a
+      # provider for what is a roster problem: those three runs answered, they
+      # just never reviewed. Widening the denominator makes the claim exactly as
+      # strong as the words: nothing usable came back, and every last piece of
+      # that nothing was empty.
+      # ★ And it must be > 0. A sweep whose passes were all skipped for missing
+      # keys has zero of both, and `0 -eq 0` would blame a provider never called.
+      if [ "$no_output_runs" -gt 0 ] && [ "$no_output_runs" -eq "$unusable" ] \
+         && [ -z "$grading_failed" ]; then
+        # ★ Its own exit code, for the reason window-closed has one: a driver
+        # piping stdout to /dev/null sees only this, and "wait for the provider,
+        # nothing here is broken" is a different instruction from 4's "fix the
+        # cause". Collapsing them is what makes a driver retry a real defect or
+        # file a bug against a healthy tool.
+        head1="NOT MEASURED -- PROVIDER RETURNED NOTHING"; rc1=7
+        body1="Every failed run on this sweep came back EMPTY -- $no_output_runs of them, no
+content at all after CLI chrome is stripped. That pattern is evidence about the
+PROVIDER, not about \`$spec\`: a model that is answering normally does not return
+zero bytes to every seat. Nothing here scores the candidate either way.
+
+If the runs also burned the full timeout, check the endpoint before re-running:
+a trivial prompt (\`Reply with exactly: OK\`) against the same route answers
+instantly when the provider is healthy."
+        tail1="Confirm the provider is up, then re-run. Do not quote a number from this
+file, and do not record a verdict about the candidate from it."
+      fi
       # ★ A third nothing, and the only one where the operator's correct move is
       # to do nothing at all for a while. Checked last so a real failure
       # elsewhere in the sweep still gets its own verdict.
-      local tail1="Fix the cause and re-run. Do not quote a number from this file."
       if [ -n "$window_closed" ] && [ -z "$measurement_failed" ] && [ -z "$grading_failed" ]; then
         head1="NOT MEASURED -- PROVIDER WINDOW CLOSED"; rc1=6
         body1="A provider usage window closed mid-sweep, so this pass never got to run.

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -199,10 +199,15 @@ for r in "${reviewers[@]}"; do
         mv "$f.part" "$f.inconclusive"
         bad_runs=$((bad_runs + 1))
         echo "    INCONCLUSIVE after ${took}s, returned text but no review, kept as $(basename "$f.inconclusive"), not scored" ;;
+      # ★ One bucket, three messages (#12). A clock kill with a live adapter
+      # behind it, a provider that returned nothing, and a refusal all land in
+      # .failed and they call for opposite responses -- raise the timeout, wait
+      # out the outage, drop the seat. failure_phrase reads the discriminator
+      # classify_run already computed; the BUCKET is deliberately unchanged.
       *)
         mv "$f.part" "$f.failed"
         bad_runs=$((bad_runs + 1))
-        echo "    FAILED after ${took}s (rc=$rc), kept as $(basename "$f.failed"), not counted as a run" ;;
+        echo "    $(failure_phrase "$f.failed" "$rc" "$took"), kept as $(basename "$f.failed"), not counted as a run" ;;
     esac
 
     # Out of budget: stop this agent HERE. The remaining runs of this pass, and

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -260,6 +260,11 @@ echo "  $ok_runs usable, $bad_runs not usable, of $((ok_runs + bad_runs)) reques
 # flake. Zero of N is the other case entirely: there is nothing to measure, and
 # the next pass will almost certainly go the same way. 4, because 2 is a usage
 # error and 3 is the credential refusal.
+# ★ 4 is the GENERIC "measured nothing", and two causes are pulled out of it
+# because the operator's next move is different: 6, the provider's usage window
+# closed (wait for the reset), and 7, every run came back empty (check the
+# endpoint is up). Both mean "nothing is wrong here to fix", which 4 does not.
+# This comment is the only table of these codes; add to it when you add one.
 if [ "$ok_runs" -eq 0 ] && [ "$bad_runs" -gt 0 ]; then
   # ★ 6 before 4. Both mean "this pass measured nothing", and they prescribe
   # opposite next moves: 4 says the cause is a defect to fix, 6 says the cause is

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -88,7 +88,7 @@ mapfile -t SCRUB < <(scrubbed_env)
 # everything, and the driver above it wrote COMPLETED across a sweep where 27 of
 # 30 requested reviews did not exist. Silence and success must not share an exit
 # code.
-ok_runs=0; bad_runs=0; dead_agents=""; windows=""
+ok_runs=0; bad_runs=0; dead_agents=""; windows=""; no_output_runs=0
 
 for r in "${reviewers[@]}"; do
   agent=$(spec_agent "$r"); model=$(spec_model "$r")
@@ -207,6 +207,10 @@ for r in "${reviewers[@]}"; do
       *)
         mv "$f.part" "$f.failed"
         bad_runs=$((bad_runs + 1))
+        # Counted here so the pass can exit with the provider's cause rather
+        # than a generic 4. See the exit-7 block at the bottom of this file.
+        [ "$(failure_kind "$f.failed" "$rc")" = no-output ] &&
+          no_output_runs=$((no_output_runs + 1))
         echo "    $(failure_phrase "$f.failed" "$rc" "$took"), kept as $(basename "$f.failed"), not counted as a run" ;;
     esac
 
@@ -270,6 +274,31 @@ if [ "$ok_runs" -eq 0 ] && [ "$bad_runs" -gt 0 ]; then
       echo "already on disk was lost. Resume after the reset time quoted above."
     } >&2
     exit 6
+  fi
+  # ★ 7 before 4, for the reason 6 comes before both: same "this pass measured
+  # nothing", opposite next move. Every single run came back EMPTY, which is a
+  # statement about the PROVIDER -- measured when every opencode-go model hung on
+  # `Reply with exactly: OK` while a direct-provider model answered instantly.
+  # Reported as 4, the operator goes hunting for a defect in a healthy tool and,
+  # worse, reads "not one usable review" as a property of the candidate.
+  # ★ The whole reason this lives HERE and not only in the grader: `cadre run`
+  # ABORTS on this exit code and never reaches grading, so a verdict computed
+  # downstream is one the common command can never print. 6 already had to solve
+  # exactly this; 7 solves it the same way.
+  # ★ Requires ALL of them. bad_runs also counts agents that were never
+  # installed and runs skipped after a budget stop, neither of which produced an
+  # artifact -- so a partial match here would blame a provider that was, in the
+  # missing-agent case, never called at all.
+  if [ "$no_output_runs" -eq "$bad_runs" ]; then
+    {
+      echo "cadre: pass '$label' measured NOTHING and every run came back EMPTY."
+      echo "$bad_runs of $bad_runs requested run(s) returned no content at all. That is"
+      echo "evidence about the PROVIDER, not about the candidate: a model answering"
+      echo "normally does not return zero bytes to every seat. Check the endpoint is up -- a"
+      echo "trivial prompt against the same route answers instantly when it is -- then"
+      echo "re-run. Nothing here scores the candidate either way."
+    } >&2
+    exit 7
   fi
   {
     echo "cadre: NO usable review on pass '$label'. $bad_runs requested run(s), none produced one."

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -557,10 +557,14 @@ run_one() {
       mv "$f.part" "$f.inconclusive"
       echo inconclusive > "$st"
       echo "  $spec: INCONCLUSIVE after ${took}s (rc=$rc), returned text but no review, kept as $(basename "$f.inconclusive")" >> "$log" ;;
+    # ★ Same one-bucket-three-messages split as the benchmark path (#12), in the
+    # same function, for the same reason the classification is shared: a panel
+    # operator reading "FAILED (rc=124)" cannot tell a timeout kill from a
+    # provider outage, and the two need opposite responses.
     *)
       mv "$f.part" "$f.failed"
       echo failed > "$st"
-      echo "  $spec: FAILED after ${took}s (rc=$rc), kept as $(basename "$f.failed")" >> "$log" ;;
+      echo "  $spec: $(failure_phrase "$f.failed" "$rc" "$took"), kept as $(basename "$f.failed")" >> "$log" ;;
   esac
   rm -rf "$dir"
 }

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -3135,6 +3135,30 @@ check "e2e: 0-byte sweep reaches the outage verdict" \
 RCZ=0; grade_only "$DZ" chrome >/dev/null 2>&1 || RCZ=$?
 check "e2e: 0-byte sweep exits 7"  "[ '$RCZ' -eq 7 ]"
 
+# ★ The outage verdict must never appear over a sweep that MEASURED something.
+# `provider_empty` is sticky once set and the pass loop keeps going, so the only
+# thing standing between a half-dead sweep and "NOT MEASURED -- PROVIDER
+# RETURNED NOTHING" printed above a real score is the `graded_passes -le 0`
+# guard the whole verdict block sits inside. That guard is not mine and could be
+# widened by someone with no reason to think about this; the test is here so it
+# cannot be, quietly.
+DQ=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DQ" chrome "$HITBOTH" "$HITBOTH"
+QSHA=$(git -C "$DQ/checkout" rev-parse HEAD); mkdir -p "$DQ/home/p2"
+printf 'p2|%s|%s|%s|%s\n' "$QSHA" "$DQ/checkout" "$QSHA" "$DQ/home/k.md" >> "$DQ/home/passes.conf"
+# ★ `cadre run`, not `cadre grade`. Grade means RE-grade -- it re-runs the
+# judges and ignores the seeded grade files -- so under that command the pass
+# that is supposed to SCORE here cannot, and the test would be measuring its own
+# fixture. The run path is also the one that matters: it is where exit 7 fires.
+RCQ=0
+OUTQ=$(run_gaunt_all "$DQ" good,good2 chrome) || RCQ=$?
+RQ=$(ls "$DQ/home"/report-*.md | head -1)
+check "e2e: a graded pass blocks the outage verdict" \
+  "! grep -q 'Verdict: NOT MEASURED -- PROVIDER RETURNED NOTHING' '$RQ'"
+check "e2e: the silent pass is still named"  "grep -q 'every run came back EMPTY' <<<\"\$OUTQ\""
+check "e2e: the silent pass exited 7"        "grep -q 'run-pass.sh exited 7' <<<\"\$OUTQ\""
+check "e2e: and the real score survives"     "grep -q 'blocking items hit' '$RQ'"
+check "e2e: half-dead sweep does not exit 7" "[ '$RCQ' -ne 7 ]"
+
 echo
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -2507,7 +2507,11 @@ check "run: did NOT abort"            "! grep -q 'ABORTING' <<<\"\$OUT\""
 # ★ The reason line must name the ROSTER problem, not the adapter. "the adapter
 # failed" sends the reader to agents.d for a model that will not hold the brief.
 check "grade: UNUSABLE names no review" "grep -q 'ran but returned no review' <<<\"\$OUT\""
-check "grade: does NOT blame adapter"   "! grep -q 'the adapter failed' <<<\"\$OUT\""
+# ★ Asserts against the .failed wording that EXISTS today. It used to grep for
+# "the adapter failed", which #12 deleted -- leaving a check that could never
+# fail again and so could never catch the collision it was written for.
+check "grade: does NOT use the .failed wording" \
+  "! grep -qE 'produced output but no usable review|provider returned NOTHING' <<<\"\$OUT\""
 # ★ .partial is deliberately kept across attempts while .inconclusive is cleared,
 # so an earlier attempt's partial -- which HAS findings in it -- can still be on
 # disk. Reporting only "no review" buries it, the same way the .failed path was
@@ -2911,6 +2915,158 @@ RT=$(ls "$DT/home"/report-*.md | head -1)
 check "cov e2e: 2-pass mean is 75% (per-pass, not pooled 83%)" \
   "grep -qF 'changed-file coverage (mean over 2 keyed pass(es)): **75%**' '$RT'"
 check "cov e2e: names thinnest as pA at 50%"    "grep -q 'thinnest on .pA. at 50%' '$RT'"
+
+
+# ============================================================================
+# #12: a timeout kill, a provider hang and a refusal must not print one line.
+# ============================================================================
+# ★ Measured on the opencode-go sweep, 2026-08-05. `FAILED after Ns (rc=124)`
+# meant three different things and asked for three opposite responses, and the
+# expensive misread is the FIRST one: a live adapter killed by cadre's own clock
+# reads as "the model ignores the review contract" -- a behavioural verdict
+# manufactured out of a harness setting. Raising CADRE_TIMEOUT turned that exact
+# pass into a graded blocking HIT.
+echo "== ★ #12: which nothing =="
+FK=$(mktemp -d -p "$SANDBOX")
+: > "$FK/zero"                                        # 0 bytes
+printf '\n\n' > "$FK/twonl"                           # the measured 2-byte case
+printf '\033[0m\n\033[?25h\033[?2004l\n   \n' > "$FK/chromeonly"
+printf 'findings=0\nVerdict: ship it\n' > "$FK/real"
+
+check "content_empty: 0 bytes"        "content_empty '$FK/zero'"
+check "content_empty: two newlines"   "content_empty '$FK/twonl'"
+check "content_empty: chrome only"    "content_empty '$FK/chromeonly'"
+check "content_empty: real review is NOT empty" "! content_empty '$FK/real'"
+
+# ★ CONTENT-EMPTY WINS over rc=124. The measured hang was BOTH -- two bytes back
+# AND the full timeout burned -- and "raise the timeout" is advice that cannot
+# help a provider that is returning nothing.
+check "kind: empty + rc124 => no-output"  "[ \$(failure_kind '$FK/twonl' 124) = no-output ]"
+check "kind: content + rc124 => timed-out" "[ \$(failure_kind '$FK/real' 124) = timed-out ]"
+# 137 is the -k SIGKILL landing as 128+9 on a child that ignored the TERM;
+# bin/agentcall uses `timeout -k 30`, so it is cadre's clock just the same.
+check "kind: content + rc137 => timed-out" "[ \$(failure_kind '$FK/real' 137) = timed-out ]"
+check "kind: content + rc1 => failed"      "[ \$(failure_kind '$FK/real' 1) = failed ]"
+# ★ `cadre grade` re-reads .failed off disk long after the exit code is gone.
+# With no rc the timeout case must be left UNCLAIMED, not guessed at from bytes:
+# a fabricated "your clock killed it" is the same class of error as the one this
+# whole issue is about, pointed the other way.
+check "kind: content + no rc => failed, not guessed" "[ \$(failure_kind '$FK/real') = failed ]"
+
+# ★ The 72KB case, because it is the one that actually happened: qwen3.8-max
+# wrote its own repro scripts and /proc/self/fd inspection before the clock got
+# it. Run under `set -o pipefail` in a subshell -- the coverage work already ate
+# one SIGPIPE flip where an early-exiting reader turned a large artifact into the
+# opposite answer, and this helper must not repeat it.
+yes 'a reviewer thinking out loud about the diff it was handed' | head -1200 > "$FK/big"
+check "kind: the big artifact really is big" "[ \$(wc -c < '$FK/big') -gt 60000 ]"
+check "kind: 72KB + rc124 => timed-out (pipefail-safe)" \
+  "( set -o pipefail; [ \$(failure_kind '$FK/big' 124) = timed-out ] )"
+
+# ★ The BUCKET must not move. Three call sites string-compare classify_run
+# (`= failed || break` in run-pass.sh and run-review.sh, `!= ok` in bin/cadre);
+# a fourth state here would silently rewire their retry loops. This is the
+# regression guard on that, and it is the reason the split lives in a separate
+# function at all.
+check "classify: no-output still failed" "[ \$(classify_run '$FK/twonl' 124) = failed ]"
+check "classify: timed-out still failed" "[ \$(classify_run '$FK/real' 124) = failed ]"
+check "classify: plain crash still failed" "[ \$(classify_run '$FK/real' 1) = failed ]"
+
+# The operator-facing halves, which is the whole deliverable: three sentences,
+# each naming a different next move.
+CADRE_TIMEOUT=2400
+check "phrase: no-output says the PROVIDER sent nothing" \
+  "failure_phrase '$FK/twonl' 124 30 | grep -q 'NO OUTPUT after 30s (rc=124): the provider returned nothing'"
+check "phrase: and that it burned the whole timeout" \
+  "failure_phrase '$FK/twonl' 124 30 | grep -q 'burning the full 2400s CADRE_TIMEOUT'"
+check "phrase: timeout names CADRE_TIMEOUT and its value" \
+  "failure_phrase '$FK/real' 124 900 | grep -q 'killed at the 2400s CADRE_TIMEOUT'"
+# ★ This clause is the fix. Without it the line is a fact about the run that a
+# reader converts into a verdict about the model.
+check "phrase: timeout disowns the verdict" \
+  "failure_phrase '$FK/real' 124 900 | grep -q \"cadre's clock, not a verdict on the model\""
+check "phrase: plain failure is unchanged" \
+  "failure_phrase '$FK/real' 1 12 | grep -q '^FAILED after 12s (rc=1)$'"
+check "phrase: the three are not one string" \
+  "[ \$(for a in \"124 $FK/twonl\" \"124 $FK/real\" \"1 $FK/real\"; do set -- \$a; failure_phrase \$2 \$1 9; done | sort -u | wc -l) -eq 3 ]"
+unset CADRE_TIMEOUT
+# Default mirrors bin/agentcall:33. If that number moves and this does not, the
+# message starts naming a ceiling that is not the one doing the killing.
+check "phrase: default matches bin/agentcall" \
+  "failure_phrase '$FK/real' 124 9 | grep -q \"the \$(grep -oE 'CADRE_TIMEOUT:-[0-9]+' '$ROOT/bin/agentcall' | cut -d- -f2)s CADRE_TIMEOUT\""
+
+# ---- end to end: a candidate that returns only chrome, every run ------------
+# ★ The report said "the adapter failed" for this, which sends the reader to
+# agents.d for a problem that is not there. And a whole SWEEP of it is evidence
+# about the provider: measured when every opencode-go model hung on
+# `Reply with exactly: OK` while a direct-provider model answered instantly.
+# The console half, live: the `chrome` stub is a provider that returns its CLI's
+# banner and nothing else.
+DN=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DN" chrome "$HITBOTH" "$HITBOTH"
+rm -f "$DN/home/p1/$(slug chrome)-run1.md"            # make the agent actually run
+OUTN=$(run_gaunt "$DN" good,good2 chrome || true)
+check "e2e: console says NO OUTPUT, not FAILED" "grep -q 'NO OUTPUT after' <<<\"\$OUTN\""
+check "e2e: console does not say plain FAILED"  "! grep -q 'FAILED after' <<<\"\$OUTN\""
+
+# ---- and the REPORT half, via `cadre grade` --------------------------------
+# ★ Deliberately the grade path, not the run path. A `cadre run` that produces
+# nothing on its first pass aborts the sweep before grading, so the sweep-wide
+# verdict is reached by re-grading what is on disk -- which is also the shape of
+# the case that prompted this: the artifacts were sitting there, and the report
+# read them as "the adapter failed" every time.
+grade_only() {  # grade_only <dir> <candidate>
+  CADRE_HOME="$1/home" CADRE_WORK="$1/work" CADRE_AGENTS_D="$1/agents.d" \
+  CADRE_JUDGE=good,good2 PATH="$1/bin:$PATH" "$ROOT/bin/cadre" grade "$2" 1 p1 2>&1
+}
+DG=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DG" chrome "$HITBOTH" "$HITBOTH"
+SLC=$(slug chrome)
+rm -f "$DG/home/p1/$SLC-run1.md"
+printf '\033[0m\n\033[?25h\033[?2004l\n   \n' > "$DG/home/p1/$SLC-run1.md.failed"
+OUTG=$(grade_only "$DG" chrome || true)
+RG=$(ls "$DG/home"/report-*.md | head -1)
+check "e2e: report states it as the provider"    "grep -q 'the provider returned NOTHING' '$RG'"
+check "e2e: report no longer blames the adapter" "! grep -q 'the adapter failed' '$RG'"
+check "e2e: verdict is about the provider"       "grep -q 'Verdict: NOT MEASURED -- PROVIDER RETURNED NOTHING' '$RG'"
+check "e2e: and refuses to score the candidate"  "! grep -q 'blocking items hit' '$RG'"
+
+# ★ The counter-case, and the one that keeps the verdict honest: an artifact
+# that came back with TEXT is an ordinary failure, not an outage. Blaming the
+# provider there is the same manufactured-verdict error with the sign flipped,
+# so the outage verdict has to require that EVERY failed run was empty.
+DM=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DM" chrome "$HITBOTH" "$HITBOTH"
+rm -f "$DM/home/p1/$SLC-run1.md"
+printf "You've hit your monthly spend limit\n" > "$DM/home/p1/$SLC-run1.md.failed"
+OUTM=$(grade_only "$DM" chrome || true)
+RM=$(ls "$DM/home"/report-*.md | head -1)
+check "e2e: text-bearing failure is NOT an outage" \
+  "! grep -q 'PROVIDER RETURNED NOTHING' '$RM'"
+check "e2e: it says output-but-no-review instead" \
+  "grep -q 'produced output but no usable review' '$RM'"
+
+# ★ The verdict's own exit code, because a driver piping stdout to /dev/null
+# sees nothing else -- and "wait for the provider" is a different instruction
+# from 4's "fix the cause". This is the assertion that makes the split reach a
+# machine, not just a reader.
+RCG=0; grade_only "$DG" chrome >/dev/null 2>&1 || RCG=$?
+check "e2e: outage exits 7, not 4"  "[ '$RCG' -eq 7 ]"
+RCM=0; grade_only "$DM" chrome >/dev/null 2>&1 || RCM=$?
+check "e2e: ordinary failure still exits 4" "[ '$RCM' -eq 4 ]"
+
+# ★ THE false-outage guard, and the reason the denominator is every UNUSABLE run
+# rather than every FAILED one. Two runs: one empty artifact, one that answered
+# and never reviewed. Counted against the failed runs alone that reads 1-of-1
+# empty and blames the provider -- for a run that came back with text. It is a
+# roster problem, and the outage verdict must not claim it.
+DX=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DX" chrome "$HITBOTH" "$HITBOTH"
+rm -f "$DX/home/p1/$SLC-run1.md"
+printf '\033[0m\n   \n' > "$DX/home/p1/$SLC-run1.md.failed"
+printf 'A thoughtful essay about this codebase that never reviews anything.\n' \
+  > "$DX/home/p1/$SLC-run2.md.inconclusive"
+OUTX=$(CADRE_HOME="$DX/home" CADRE_WORK="$DX/work" CADRE_AGENTS_D="$DX/agents.d" \
+  CADRE_JUDGE=good,good2 PATH="$DX/bin:$PATH" "$ROOT/bin/cadre" grade chrome 2 p1 2>&1 || true)
+RX=$(ls "$DX/home"/report-*.md | head -1)
+check "e2e: mixed nothings are NOT an outage" "! grep -q 'PROVIDER RETURNED NOTHING' '$RX'"
+check "e2e: both nothings still named"        "grep -q 'provider returned NOTHING' '$RX' && grep -q 'returned no review' '$RX'"
 
 echo
 echo "$PASS passed, $FAIL failed"

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -2984,9 +2984,47 @@ check "phrase: timeout names CADRE_TIMEOUT and its value" \
 # ★ This clause is the fix. Without it the line is a fact about the run that a
 # reader converts into a verdict about the model.
 check "phrase: timeout disowns the verdict" \
-  "failure_phrase '$FK/real' 124 900 | grep -q \"cadre's clock, not a verdict on the model\""
+  "failure_phrase '$FK/real' 124 900 | grep -q \"cadre's clock and not a verdict on the model\""
 check "phrase: plain failure is unchanged" \
   "failure_phrase '$FK/real' 1 12 | grep -q '^FAILED after 12s (rc=1)$'"
+# ★ rc=0 must NOT appear. An adapter that normalises its exit code produces
+# `FAILED after 30s (rc=0)`, which sends the reader hunting a crash that never
+# happened -- this issue's own disease, one level down.
+check "phrase: rc=0 is not printed" \
+  "! failure_phrase '$FK/real' 0 30 | grep -q 'rc=0'"
+check "phrase: rc=0 still says FAILED after Ns" \
+  "failure_phrase '$FK/real' 0 30 | grep -q '^FAILED after 30s$'"
+
+# ★ THE ADAPTER-NORMALISED TIMEOUT, which is most of the roster and which the
+# rc test cannot see. agents.d/codex.sh:107 prints this line and then returns 0,
+# because the trailing `rm -f` is the last command in the function -- so without
+# the marker check, codex's COMMON timeout (measured on 0.145.0, where -o is
+# written only at final completion) keeps printing the flat FAILED line this
+# whole issue is about.
+printf 'DID NOT COMPLETE, codex was killed at the 900s timeout with no output. Raise CADRE_TIMEOUT.\n' \
+  > "$FK/codextmo"
+check "kind: adapter marker names the clock => timed-out (rc=0)" \
+  "[ \$(failure_kind '$FK/codextmo' 0) = timed-out ]"
+check "phrase: and it tells the operator to raise CADRE_TIMEOUT" \
+  "failure_phrase '$FK/codextmo' 0 900 | grep -q 'raise CADRE_TIMEOUT and re-run'"
+check "classify: adapter-normalised timeout still failed" \
+  "[ \$(classify_run '$FK/codextmo' 0) = failed ]"
+# agy.sh:137 words it differently and must still be read.
+printf 'DID NOT COMPLETE, agy hit the 900s timeout with no text returned.\n' > "$FK/agytmo"
+check "kind: agy wording also reads as timed-out" "[ \$(failure_kind '$FK/agytmo' 0) = timed-out ]"
+# ★ ...and a marker that names no clock is NOT a timeout. agy.sh:139 and
+# grok.sh:73 are ordinary "nothing came back" failures; calling those TIMED OUT
+# would send the operator to raise a ceiling that was never hit.
+printf 'DID NOT COMPLETE, no text returned (stopReason=Error). Raw:\n{"error":"upstream"}\n' \
+  > "$FK/plainmarker"
+check "kind: a marker without a clock stays failed" \
+  "[ \$(failure_kind '$FK/plainmarker' 1) = failed ]"
+# ★ Edge-anchored, like every other marker test in this file. A REVIEW that
+# discusses cadre's own timeout handling -- reviewing this repo is enough --
+# must not be relabelled off a sentence in its body.
+{ printf 'blocking - the retry loop drops a run\n'; printf 'x\n%.0s' $(seq 1 40)
+  printf 'DID NOT COMPLETE, codex was killed at the 900s timeout with no output.\n'; } > "$FK/quoter"
+check "kind: the marker only counts at the edge" "[ \$(failure_kind '$FK/quoter' 1) = failed ]"
 check "phrase: the three are not one string" \
   "[ \$(for a in \"124 $FK/twonl\" \"124 $FK/real\" \"1 $FK/real\"; do set -- \$a; failure_phrase \$2 \$1 9; done | sort -u | wc -l) -eq 3 ]"
 unset CADRE_TIMEOUT
@@ -3007,6 +3045,19 @@ rm -f "$DN/home/p1/$(slug chrome)-run1.md"            # make the agent actually 
 OUTN=$(run_gaunt "$DN" good,good2 chrome || true)
 check "e2e: console says NO OUTPUT, not FAILED" "grep -q 'NO OUTPUT after' <<<\"\$OUTN\""
 check "e2e: console does not say plain FAILED"  "! grep -q 'FAILED after' <<<\"\$OUTN\""
+# ★ `cadre run` is the command an operator actually types, and it ABORTS on a
+# dead pass before grading ever happens -- so a verdict computed only in the
+# grader is one this path can never print. run-pass.sh exit 7 is what carries it
+# across, the same way exit 6 already carries a closed usage window.
+check "e2e: run says the runs came back EMPTY" \
+  "grep -q 'every run came back EMPTY' <<<\"\$OUTN\""
+check "e2e: run does NOT call it a failed measurement" \
+  "! grep -q 'This is a failed measurement' <<<\"\$OUTN\""
+RCN=0; run_gaunt "$DN" good,good2 chrome >/dev/null 2>&1 || RCN=$?
+check "e2e: cadre run exits 7, not 4"  "[ '$RCN' -eq 7 ]"
+RN=$(ls "$DN/home"/report-*.md | head -1)
+check "e2e: and the run's own report says so" \
+  "grep -q 'Verdict: NOT MEASURED -- PROVIDER RETURNED NOTHING' '$RN'"
 
 # ---- and the REPORT half, via `cadre grade` --------------------------------
 # ★ Deliberately the grade path, not the run path. A `cadre run` that produces
@@ -3067,6 +3118,22 @@ OUTX=$(CADRE_HOME="$DX/home" CADRE_WORK="$DX/work" CADRE_AGENTS_D="$DX/agents.d"
 RX=$(ls "$DX/home"/report-*.md | head -1)
 check "e2e: mixed nothings are NOT an outage" "! grep -q 'PROVIDER RETURNED NOTHING' '$RX'"
 check "e2e: both nothings still named"        "grep -q 'provider returned NOTHING' '$RX' && grep -q 'returned no review' '$RX'"
+
+# ★ ZERO BYTES, which is the truest form of "the provider returned nothing" and
+# was the one shape that could not reach the verdict: the branch that counts it
+# was gated on `-s`, so a 0-byte artifact skipped it entirely and a sweep of
+# pure silence graded as an ordinary failed measurement. A provider that hangs
+# without writing to stdout OR stderr leaves exactly this.
+DZ=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DZ" chrome "$HITBOTH" "$HITBOTH"
+rm -f "$DZ/home/p1/$SLC-run1.md"
+: > "$DZ/home/p1/$SLC-run1.md.failed"                  # 0 bytes, not 2
+OUTZ=$(grade_only "$DZ" chrome || true)
+RZ=$(ls "$DZ/home"/report-*.md | head -1)
+check "e2e: 0-byte .failed is counted as no-output" "grep -q 'the provider returned NOTHING' '$RZ'"
+check "e2e: 0-byte sweep reaches the outage verdict" \
+  "grep -q 'Verdict: NOT MEASURED -- PROVIDER RETURNED NOTHING' '$RZ'"
+RCZ=0; grade_only "$DZ" chrome >/dev/null 2>&1 || RCZ=$?
+check "e2e: 0-byte sweep exits 7"  "[ '$RCZ' -eq 7 ]"
 
 echo
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
Closes #12.

A timeout kill, a provider hang and a refusal all printed `FAILED after Ns (rc=124)`, and they call for opposite responses. The expensive misread is the first one: a live adapter killed by cadre's own clock reads as "the model ignores the review contract" — a behavioural verdict manufactured out of a harness setting. Raising `CADRE_TIMEOUT` turned that exact pass into a graded `blocking` HIT.

The discriminator was already being computed inside `classify_run` and thrown away.

## The split

`content_empty()` comes out of `classify_run` unchanged and becomes the one copy of the chrome strip. Two functions sit on top of it:

- `failure_kind()` → `no-output | timed-out | failed`
- `failure_phrase()` → the operator-facing line, in `agents.d/codex.sh`'s existing vocabulary

Four renderers use them: `run-pass.sh`, `run-review.sh`, `bin/cadre` (synthesis), and the grade report. A chrome strip re-implemented at each print site would be the free-text-grep debt #2 exists to delete.

**`classify_run`'s return values are untouched.** Three call sites string-compare it — `= failed || break` in `run-pass.sh` and `run-review.sh`, `!= ok` in `bin/cadre` — so a fourth bucket would have silently rewired their retry loops. Same `.failed` bucket, different line. There's a regression test on exactly that.

Two ordering rules earn their keep:

- **Content-empty beats the timeout code.** The measured hang was both — nothing back *and* the full timeout burned — and "raise the timeout" is advice that cannot help.
- **The adapter's own verdict beats the exit code**, because adapters normalise theirs on a clock kill. `agents.d/codex.sh:107` prints `codex was killed at the 900s timeout with no output` and then returns 0, since the trailing `rm -f` is the last command in the function. On codex 0.145.0 that is the *common* timeout, not the rare one, because `-o` is written only at final completion. An rc-only test could never see it. `docs/ADDING-AN-AGENT.md` now asks adapters to put the number on that line, since cadre depends on it.

`rc` is optional: `cadre grade` re-reads artifacts long after the exit code is gone, so with no rc the timeout case is left unclaimed rather than guessed at from bytes.

## The report and the sweep

`"the adapter failed"` was a claim, not an observation — it covered all three causes and sent the reader to `agents.d` for every one. It now states what is on disk: empty, or output-with-no-review.

Sweep-wide, a NO OUTPUT streak is evidence about the **provider**, measured when every opencode-go model hung on `Reply with exactly: OK` while a direct-provider model answered instantly. That earns a fourth "nothing" verdict and exit 7, beside the window-closed 6, because "wait for the provider" is a different instruction from 4's "fix the cause".

It fires only when **every unusable run** of the sweep was empty, not every failed one. Against the narrower denominator, one empty artifact plus three inconclusive runs reads as 1-of-1 empty and blames a provider for what is a roster problem — those three runs answered, they just never reviewed.

## Three defects caught in review, all in the first cut

1. **`cadre run` could never print the outage verdict.** It aborts on `run-pass.sh`'s nonzero exit and never reaches the grading loop that computed it, so the verdict existed only on a later `cadre grade` — the rarer command. `run-pass.sh` now exits 7 when every bad run came back empty and `grade.sh` maps it, exactly as exit 6 already carries a closed usage window.
2. **A 0-byte `.failed` was not counted.** The truest form of "returned nothing" — a provider that hangs without writing to stdout or stderr — was gated behind `[ -s ]` and skipped the counting branch entirely. `-e` there; every other artifact test in the block stays `-s`, where empty really is nothing to report.
3. **`rc=0` was printed in failure lines.** `FAILED after 30s (rc=0)` sends an operator hunting a crash that never happened — this issue's own disease one level down, and an exit-code-normalising adapter produces it.

## Not in scope

A timeout on **re-grade** has no sweep verdict: the exit code is not on disk, and inferring one from bytes would be the same manufactured claim pointed the other way. Durable per-run records are #2.

## Tests

745 pass, 0 fail. The ones worth naming:

- all three kinds, and content-empty beating `rc=124`
- no-rc leaving the timeout unclaimed rather than guessed
- a 72KB timed-out artifact under `pipefail` (the coverage work already ate one SIGPIPE flip on large reviews)
- all three still classifying as `failed` — the bucket regression guard
- the adapter-normalised timeout, agy's different wording, a marker naming no clock staying `failed`, and the marker counting only at the edge
- both new exit codes, and a 0-byte sweep reaching the verdict
- mixed nothings that must **not** claim an outage, and a sweep that scored keeping the outage verdict off its report

One older assertion grepped for `"the adapter failed"`, a string this PR deletes — it would have been permanently green. It now checks the wording that exists.
