### PR TITLE
Write the panel's run record during the panel, not after it

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -900,6 +900,113 @@ failure_phrase() {  # <file> <rc> [secs] -> leading phrase, no trailing period
   esac
 }
 
+# ---- the per-run record (#2) ------------------------------------------------
+# ★ Why this exists. Every adapter's stdout IS its own format, so status and
+# timing were recovered by grepping prose: run-review.sh reconstructed a seat's
+# elapsed seconds with `sed -n 's/.*in \([0-9]*\)s.*/\1/p'` over its own console
+# log. That is a FIELD being parsed back out of a sentence, and the sentence was
+# written to a scratch file the panel deleted on the way out -- so the first
+# fourteen panels' timings are simply gone, not reconstructible, because no
+# artifact on disk carries them.
+#
+# ★ Written DURING the panel, not assembled after it. That is the whole point of
+# the append-only shape: a panel killed halfway still leaves a record of every
+# seat it dispatched. Assembling at the end means a kill loses everything.
+#
+# ★ EMPTY IS NOT ZERO, and JSON `null` is why this is JSONL rather than another
+# TSV. A seat whose seconds were never measured must not carry a 0 that averages
+# like a real measurement and pulls every mean toward the floor -- the rule
+# aggregate.sh and grade.sh already follow, now with a type that can express it.
+
+# One field value, escaped for JSON. Backslash BEFORE quote, or the escape this
+# adds is itself re-escaped. Control characters are dropped rather than encoded:
+# one event is one LINE, and a stray newline inside a value would split it into
+# two malformed records.
+# ★ No `\t` in the sed script. BSD sed reads it as a literal `t` -- the same trap
+# that silently disarmed the chrome strip on macOS. `tr` handles the whole
+# control range in one pass and is portable.
+json_escape() {
+  printf '%s' "${1:-}" | tr -d '\000-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# record_event <logfile> <name>=<value>...
+#
+# Appends ONE JSON object as ONE line. A name ending in `#` is numeric: it is
+# emitted bare, or as `null` when the value is empty. Every other name is a
+# string, and an empty value stays `""` -- an unmeasured NUMBER and an empty
+# STRING are different facts and the record keeps them apart.
+#
+# ★ Atomic by construction, because seats run in parallel under --jobs and this
+# is the first file in that path two writers touch at once. One event is one
+# `printf` of one short line to a file opened O_APPEND, which is well under the
+# 4KB a write is guaranteed not to be torn at. Anything that built the line in
+# two writes, or seeked, would interleave.
+record_event() {
+  local log="$1"; shift
+  local out="" nv n v sep=""
+  for nv in "$@"; do
+    n=${nv%%=*}; v=${nv#*=}
+    if [ "${n%\#}" != "$n" ]; then
+      n=${n%\#}
+      out="$out$sep\"$(json_escape "$n")\":${v:-null}"
+    else
+      out="$out$sep\"$(json_escape "$n")\":\"$(json_escape "$v")\""
+    fi
+    sep=","
+  done
+  printf '{%s}\n' "$out" >> "$log"
+}
+
+# record_rows <logfile> <event> <key>...
+#
+# One tab-separated row per matching event, in file order, with the requested
+# keys in the order given. A key the record does not carry, or one holding JSON
+# `null`, prints EMPTY -- never 0, never the string "null".
+#
+# ★ Parsing our OWN flat schema, which is the distinction #2 draws: a field read
+# from a record cadre wrote is not the same act as a regex over whatever an
+# adapter chose to print. Values are scanned character by character rather than
+# with a greedy pattern, so an escaped quote inside a spec name cannot end the
+# string early.
+record_rows() {
+  local log="$1" want="$2"; shift 2
+  [ -s "$log" ] || return 0
+  awk -v want="$want" -v keys="$*" '
+    function val(line, key,   i, n, c, out, esc) {
+      i = index(line, "\"" key "\":")
+      if (i == 0) return ""
+      i += length(key) + 3
+      c = substr(line, i, 1)
+      if (c != "\"") {                      # bare token: number, null, bool
+        out = ""
+        while (i <= length(line)) {
+          c = substr(line, i, 1)
+          if (c == "," || c == "}") break
+          out = out c; i++
+        }
+        return (out == "null") ? "" : out
+      }
+      i++; out = ""; esc = 0
+      while (i <= length(line)) {
+        c = substr(line, i, 1)
+        if (esc) { out = out c; esc = 0 }
+        else if (c == "\\") esc = 1
+        else if (c == "\"") break
+        else out = out c
+        i++
+      }
+      return out
+    }
+    BEGIN { nk = split(keys, k, " ") }
+    {
+      if (val($0, "event") != want) next
+      row = ""
+      for (j = 1; j <= nk; j++) row = row (j > 1 ? "\t" : "") val($0, k[j])
+      print row
+    }
+  ' "$log"
+}
+
 # Classify one agent run: ok | degraded | inconclusive | failed. THE one copy of
 # this rule.
 #

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -22,6 +22,12 @@ REPO="${1:?usage: run-review.sh <repo> <base-rev> <out-dir> <jobs> <spec ...>}"
 BASE_REV="${2-}"
 MODE=diff; [ -n "$BASE_REV" ] || MODE=target
 OUT="${3:?need an out dir}"
+# ★ NOT `.log-*`, `.status-*` or `.len-*`. Those three globs are wiped at the
+# bottom of this file, and a record that a cleanup line can match is a record
+# that will eventually be deleted by someone extending that line. The name is
+# the enforcement. Per-panel and under $OUT, because `cadre receipts` finds
+# records by walking panel roots.
+RUNLOG="$OUT/runs.jsonl"
 JOBS="${4:-1}"
 shift 4 2>/dev/null || shift $#
 reviewers=("$@")
@@ -470,6 +476,28 @@ mapfile -t SCRUB < <(scrubbed_env)
 
 # ---- one reviewer ------------------------------------------------------------
 
+# One completion event per terminal path in run_one. Every `return` in that
+# function pairs with a call to this, so "dispatched but never completed" stays
+# a fact about the run rather than an artefact of where the code exits.
+#
+# ★ secs is passed EMPTY, never 0, for a path that never timed anything -- a
+# roster member that was not installed did not take zero seconds, it was never
+# measured, and record_event turns an empty numeric into `null`. Bytes come from
+# the artifact rather than any log line, so the number always describes the file
+# that is actually on disk.
+record_complete() {  # <slug> <spec> <state> [rc] [secs]
+  local sl="$1" spec="$2" state="$3" rc="${4:-}" secs="${5:-}" art bytes
+  art="$OUT/$sl.md"
+  [ -s "$art" ] || art="$OUT/$sl.md.partial"
+  [ -s "$art" ] || art="$OUT/$sl.md.inconclusive"
+  [ -s "$art" ] || art="$OUT/$sl.md.failed"
+  bytes=$(wc -c < "$art" 2>/dev/null | tr -d ' ')
+  record_event "$RUNLOG" event=complete panel="$(basename "$OUT")" \
+    seat="$spec" family="$(spec_family "$spec")" slug="$sl" \
+    state="$state" "rc#=$rc" "secs#=$secs" "bytes#=${bytes:-0}" \
+    "prompt_bytes#=$(cat "$OUT/.len-$sl" 2>/dev/null)" "ts#=$(date +%s)"
+}
+
 run_one() {
   local spec="$1" idx="$2"
   local sl; sl=$(slug "$spec")
@@ -482,6 +510,13 @@ run_one() {
   # prompt. Overwrite it at the dispatch site so adapter failures still retain
   # the exact prompt size after the scratch files disappear.
   echo 0 > "$len"
+  # ★ Recorded BEFORE anything can go wrong, which is the entire reason the log
+  # is append-only rather than assembled at the end: a panel killed here leaves
+  # proof this seat was dispatched. Every `return` below has a matching
+  # `complete`, so a dispatch with no completion IS the signal that a seat was
+  # cut off mid-flight -- not a gap to be guessed at later.
+  record_event "$RUNLOG" event=dispatch panel="$(basename "$OUT")" \
+    seat="$spec" family="$(spec_family "$spec")" slug="$sl" "ts#=$(date +%s)"
   # ★ A roster member that is not installed is a FAILURE, not a skip. run-pass
   # prints "skipping" and moves on, which in a live review is indistinguishable
   # from a reviewer that ran and found nothing.
@@ -491,13 +526,18 @@ run_one() {
     echo "NOT INSTALLED: $agent is not on PATH" > "$f.failed"
     echo "failed" > "$st"
     echo "  $spec: NOT INSTALLED" >> "$log"
+    record_complete "$sl" "$spec" failed
     return 0
   fi
 
   # Its own pristine checkout. Reviewers never share a tree, so nothing needs
   # resetting between them and --jobs is safe by construction.
   dir="$WORKDIR/r$idx"
-  cp -a "$TPL" "$dir" || { echo "checkout copy failed" > "$f.failed"; echo failed > "$st"; return 0; }
+  cp -a "$TPL" "$dir" || {
+    echo "checkout copy failed" > "$f.failed"; echo failed > "$st"
+    record_complete "$sl" "$spec" failed
+    return 0
+  }
 
   local m=(); [ -n "$model" ] && m=(-M "$model")
   start=$(date +%s)
@@ -566,8 +606,24 @@ run_one() {
       echo failed > "$st"
       echo "  $spec: $(failure_phrase "$f.failed" "$rc" "$took"), kept as $(basename "$f.failed")" >> "$log" ;;
   esac
+  # After the `mv`, so `bytes` describes the artifact under its final name.
+  record_complete "$sl" "$spec" "$state" "$rc" "$took"
   rm -rf "$dir"
 }
+
+# ★ A gated-off seat is a STATE, not a special case. Recording it as an ordinary
+# completion whose `state` is `skipped` is what lets every downstream renderer
+# read one stream instead of joining the record against a second list -- which
+# is the join that produced slots.tsv's separate skipped block and the Receipts
+# table's dependence on that file. Zero spend is MEASURED here: a seat that
+# never ran sent no prompt and received no bytes, so those are real zeroes.
+# `secs` stays null, because nothing was timed.
+for row in "${skipped_rows[@]}"; do
+  IFS=$'\t' read -r sk_spec _sk_gate _sk_reason <<< "$row"
+  record_event "$RUNLOG" event=complete panel="$(basename "$OUT")" \
+    seat="$sk_spec" family="$(spec_family "$sk_spec")" slug="$(slug "$sk_spec")" \
+    state=skipped "rc#=" "secs#=" "bytes#=0" "prompt_bytes#=0" "ts#=$(date +%s)"
+done
 
 i=0; running=0
 for spec in "${reviewers[@]}"; do
@@ -694,27 +750,40 @@ done
 # and append-safe. Bytes come from the artifact rather than the log so the
 # number always describes the file that is actually there.
 {
+  # ★ Rendered FROM the record, not reconstructed from prose. This block used to
+  # recover a seat's elapsed seconds with
+  #   sed -n 's/.*in \([0-9][0-9]*\)s.*/\1/p' "$OUT/.log-$sl"
+  # -- a number parsed back out of the sentence that had printed it, from a
+  # scratch file deleted moments later. Every field below is now read as a field.
+  # Same file, same columns, same order: bin/cadre's `receipts` and
+  # lib/aggregate.sh both parse slots.tsv positionally and must not notice.
+  # ★ The ROSTER drives the rows, not the record. Deriving them from what the
+  # log happens to contain would silently drop a seat that was dispatched and
+  # never completed -- which is exactly the seat worth a row, and the same
+  # reasoning aggregate.sh gives for trusting the roster line over filenames.
+  # A seat with no completion event prints `failed` with EMPTY secs: it did not
+  # take zero seconds, it was never measured.
+  all_complete=$(record_rows "$RUNLOG" complete seat family state bytes secs prompt_bytes)
   for spec in "${reviewers[@]}"; do
-    sl=$(slug "$spec")
-    st=$(cat "$OUT/.status-$sl" 2>/dev/null || echo failed)
-    # The log line is "  <spec>: <n> bytes in <t>s" or a failure sentence; take
-    # the seconds if they are there and leave the field empty if they are not,
-    # rather than inventing a zero that would average like a real measurement.
-    secs=$(sed -n 's/.*in \([0-9][0-9]*\)s.*/\1/p' "$OUT/.log-$sl" 2>/dev/null | head -1)
-    prompt_bytes=$(cat "$OUT/.len-$sl" 2>/dev/null)
-    art="$OUT/$sl.md"
-    [ -s "$art" ] || art="$OUT/$sl.md.partial"
-    [ -s "$art" ] || art="$OUT/$sl.md.inconclusive"
-    [ -s "$art" ] || art="$OUT/$sl.md.failed"
-    bytes=$(wc -c < "$art" 2>/dev/null | tr -d ' ')
+    rec_row=$(printf '%s\n' "$all_complete" | awk -F '\t' -v s="$spec" '$1 == s { print; exit }')
+    rec_row="${rec_row//$'\t'/$'\034'}"
+    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt <<< "$rec_row"
     printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-      "$(basename "$OUT")" "$spec" "$(spec_family "$spec")" \
-      "$st" "${bytes:-0}" "${secs:-}" "${prompt_bytes:-}"
+      "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
+      "${r_state:-failed}" "${r_bytes:-0}" "$r_secs" "$r_prompt"
   done
+  # Skipped seats come from the same stream, for the same reason: one source, so
+  # a change to how spend is recorded cannot land in one renderer and not the
+  # other. Still roster-driven, and still `0\t\t0` -- measured zero spend, and
+  # seconds that were never measured at all.
   for row in "${skipped_rows[@]}"; do
     IFS=$'\t' read -r spec _gate _reason <<< "$row"
-    printf '%s\t%s\t%s\tskipped\t0\t\t0\n' \
-      "$(basename "$OUT")" "$spec" "$(spec_family "$spec")"
+    rec_row=$(printf '%s\n' "$all_complete" | awk -F '\t' -v s="$spec" '$1 == s { print; exit }')
+    rec_row="${rec_row//$'\t'/$'\034'}"
+    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt <<< "$rec_row"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
+      "${r_state:-skipped}" "${r_bytes:-0}" "$r_secs" "${r_prompt:-0}"
   done
 } > "$OUT/slots.tsv"
 
@@ -725,11 +794,15 @@ done
   echo "| seat | status | secs | prompt KB | review KB | est. tokens |"
   echo "|---|---|---|---|---|---|"
   total_secs=0; have_secs=0; total_prompt=0; have_prompt=0; total_review=0; total_est=0
+  # ★ Reads the RECORD, not slots.tsv. Rendering the report off a file that is
+  # itself a rendering makes the second renderer inherit whatever the first one
+  # decided to drop, and the point of #2 is that every view answers to the same
+  # source. Skipped seats are in this stream too, as `state=skipped`.
   while IFS= read -r slot_row; do
     # Tabs are IFS whitespace, so plain `read` collapses the empty secs field in
     # a skipped row. Translate to a non-whitespace delimiter before splitting.
     slot_row="${slot_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _run spec _fam st bytes secs prompt_bytes <<< "$slot_row"
+    IFS=$'\034' read -r spec st bytes secs prompt_bytes <<< "$slot_row"
     prompt_kb=""
     if [ -n "${prompt_bytes:-}" ]; then
       prompt_kb=$(awk -v n="$prompt_bytes" 'BEGIN { printf "%.1f", n / 1024 }')
@@ -742,7 +815,7 @@ done
     total_review=$((total_review + ${bytes:-0}))
     printf '| `%s` | %s | %s | %s | %s | %s |\n' \
       "$spec" "$st" "${secs:-}" "$prompt_kb" "$review_kb" "$est_tokens"
-  done < "$OUT/slots.tsv"
+  done < <(record_rows "$RUNLOG" complete seat state bytes secs prompt_bytes)
   total_secs_display=""; [ "$have_secs" -eq 1 ] && total_secs_display="$total_secs"
   total_prompt_kb=""; [ "$have_prompt" -eq 1 ] && \
     total_prompt_kb=$(awk -v n="$total_prompt" 'BEGIN { printf "%.1f", n / 1024 }')

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -749,7 +749,13 @@ done
 # One line per reviewer slot, tab-separated, no header: greppable, joinable,
 # and append-safe. Bytes come from the artifact rather than the log so the
 # number always describes the file that is actually there.
-{
+# ★ Built ONCE, then written twice. slots.tsv and the report's Receipts table
+# are the same rows in two shapes, and the first cut of this had them iterating
+# different things -- slots.tsv over the roster, Receipts over the record. That
+# is two views of one panel disagreeing about which seats exist, which is the
+# exact divergence #2 was opened to delete, reintroduced pointing the other way.
+# Sharing the rows makes them identical by construction rather than by care.
+slot_rows=$(
   # ★ Rendered FROM the record, not reconstructed from prose. This block used to
   # recover a seat's elapsed seconds with
   #   sed -n 's/.*in \([0-9][0-9]*\)s.*/\1/p' "$OUT/.log-$sl"
@@ -785,7 +791,8 @@ done
       "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
       "${r_state:-skipped}" "${r_bytes:-0}" "$r_secs" "${r_prompt:-0}"
   done
-} > "$OUT/slots.tsv"
+)
+printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
 
 {
   echo
@@ -794,15 +801,14 @@ done
   echo "| seat | status | secs | prompt KB | review KB | est. tokens |"
   echo "|---|---|---|---|---|---|"
   total_secs=0; have_secs=0; total_prompt=0; have_prompt=0; total_review=0; total_est=0
-  # ★ Reads the RECORD, not slots.tsv. Rendering the report off a file that is
-  # itself a rendering makes the second renderer inherit whatever the first one
-  # decided to drop, and the point of #2 is that every view answers to the same
-  # source. Skipped seats are in this stream too, as `state=skipped`.
+  # ★ The SAME rows slots.tsv got, not a second query against the record. Both
+  # views owe their row set to the roster, so a seat dispatched and never
+  # completed appears in both or neither -- never in one.
   while IFS= read -r slot_row; do
     # Tabs are IFS whitespace, so plain `read` collapses the empty secs field in
     # a skipped row. Translate to a non-whitespace delimiter before splitting.
     slot_row="${slot_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r spec st bytes secs prompt_bytes <<< "$slot_row"
+    IFS=$'\034' read -r _run spec _fam st bytes secs prompt_bytes <<< "$slot_row"
     prompt_kb=""
     if [ -n "${prompt_bytes:-}" ]; then
       prompt_kb=$(awk -v n="$prompt_bytes" 'BEGIN { printf "%.1f", n / 1024 }')
@@ -815,7 +821,7 @@ done
     total_review=$((total_review + ${bytes:-0}))
     printf '| `%s` | %s | %s | %s | %s | %s |\n' \
       "$spec" "$st" "${secs:-}" "$prompt_kb" "$review_kb" "$est_tokens"
-  done < <(record_rows "$RUNLOG" complete seat state bytes secs prompt_bytes)
+  done <<< "$slot_rows"
   total_secs_display=""; [ "$have_secs" -eq 1 ] && total_secs_display="$total_secs"
   total_prompt_kb=""; [ "$have_prompt" -eq 1 ] && \
     total_prompt_kb=$(awk -v n="$total_prompt" 'BEGIN { printf "%.1f", n / 1024 }')

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -1633,6 +1633,58 @@ check "receipt caveat is explicit" "grep -qF '> Estimated as bytes/4 of what the
 # counting -- the panel would report three seats and the dataset two.
 check "no seat vanishes"            "[ \$(cut -f2 '$R/slots.tsv' | sort -u | wc -l) -eq 2 ]"
 
+# ---- record writer/reader units (#2) ----------------------------------------
+# ★ Hand-rolled JSON, so the escaping is the risk. Every one of these is a way a
+# single malformed line silently becomes a wrong FIELD rather than a parse
+# error -- which is worse than the prose-grepping it replaced, because a wrong
+# field looks measured.
+RJ=$(mktemp -d -p "$SANDBOX"); RL="$RJ/runs.jsonl"
+record_event "$RL" event=complete seat='codex:gpt-5.5' "secs#=12" "rc#=0"
+check "rec: seat with a colon survives" \
+  "[ \"\$(record_rows '$RL' complete seat)\" = 'codex:gpt-5.5' ]"
+check "rec: numeric field is bare"    "grep -q '\"secs\":12' '$RL'"
+check "rec: string field is quoted"   "grep -q '\"seat\":\"codex:gpt-5.5\"' '$RL'"
+
+# ★ EMPTY NUMBER is null; EMPTY STRING stays "". This is the distinction that
+# made it JSONL, and collapsing the two is the bug the format was chosen to
+# prevent -- an unmeasured second and a measured zero are not the same fact.
+: > "$RL"; record_event "$RL" event=complete seat=x "secs#=" note=
+check "rec: unmeasured number is null" "grep -q '\"secs\":null' '$RL'"
+check "rec: empty string stays a string" "grep -q '\"note\":\"\"' '$RL'"
+check "rec: reader gives EMPTY for null" \
+  "[ -z \"\$(record_rows '$RL' complete secs)\" ]"
+check "rec: reader never prints the word null" \
+  "! record_rows '$RL' complete secs | grep -q null"
+
+# ★ A quote or a backslash in a value must not end the string early or escape
+# the closing quote. Backslash has to be escaped BEFORE the quote, or the escape
+# this adds is itself re-escaped.
+: > "$RL"; record_event "$RL" event=complete seat='a"b\c' "secs#=3"
+check "rec: quote and backslash escaped" 'grep -q "\\\\\"b\\\\\\\\c" '"'$RL'"
+check "rec: and read back verbatim" \
+  "[ \"\$(record_rows '$RL' complete seat)\" = 'a\"b\\c' ]"
+check "rec: a later field still parses" \
+  "[ \"\$(record_rows '$RL' complete secs)\" = 3 ]"
+
+# ★ One event is one LINE. A newline inside a value would split the record into
+# two malformed ones, so control characters are dropped rather than encoded.
+: > "$RL"; record_event "$RL" event=complete seat="$(printf 'a\nb')" "secs#=1"
+check "rec: newline cannot split a record" "[ \$(wc -l < '$RL') -eq 1 ]"
+check "rec: the value is still readable"   "[ \"\$(record_rows '$RL' complete seat)\" = ab ]"
+
+# The reader filters by event and returns fields in the order asked, so a
+# renderer's column order is its own business.
+: > "$RL"
+record_event "$RL" event=dispatch seat=one
+record_event "$RL" event=complete seat=two "secs#=9"
+check "rec: filters by event"       "[ \"\$(record_rows '$RL' dispatch seat)\" = one ]"
+check "rec: keys come back in order" \
+  "[ \"\$(record_rows '$RL' complete secs seat)\" = \"\$(printf '9\ttwo')\" ]"
+check "rec: a missing key is EMPTY, not an error" \
+  "[ \"\$(record_rows '$RL' dispatch nosuchkey)\" = '' ]"
+check "rec: an absent log is not an error" \
+  "record_rows '$RJ/nope.jsonl' complete seat; [ \$? -eq 0 ]"
+
 # ---- the per-run record (#2) ------------------------------------------------
 # ★ The record is the SOURCE now; slots.tsv and the Receipts table are two
 # renderings of it. These check the source exists, survives, and carries the

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -1632,6 +1632,14 @@ check "receipt caveat is explicit" "grep -qF '> Estimated as bytes/4 of what the
 # filenames instead of the roster would silently drop exactly the failure worth
 # counting -- the panel would report three seats and the dataset two.
 check "no seat vanishes"            "[ \$(cut -f2 '$R/slots.tsv' | sort -u | wc -l) -eq 2 ]"
+# ★ ...and the report must not vanish one either. slots.tsv had this assertion
+# and the Receipts table had none, so when the two briefly iterated different
+# things -- the roster vs the record -- nothing caught it. One row per seat plus
+# the totals line.
+check "no seat vanishes from Receipts too" \
+  "[ \$(sed -n '/^| seat |/,/^$/p' '$R/report.md' | grep -c '^| ') -eq 4 ]"
+check "Receipts names the same seats as slots.tsv" \
+  "grep -q '^| .good. |' '$R/report.md' && grep -q '^| .dead. |' '$R/report.md'"
 
 # ---- record writer/reader units (#2) ----------------------------------------
 # ★ Hand-rolled JSON, so the escaping is the risk. Every one of these is a way a

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -22,7 +22,7 @@ setup_agents() {
   mkdir -p "$1/bin" "$1/agents.d"
   local n
   for n in good good2 trunc dead echoer chrome terse ratepart ratelim \
-           synthquote synthtrunc synthrate synthtiny waffle parrot; do
+           synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2; do
     printf '#!/bin/sh\nexit 0\n' > "$1/bin/$n"; chmod +x "$1/bin/$n"
   done
   # ★ The trailing verdict is not decoration. review-live.md asks every reviewer
@@ -57,6 +57,14 @@ run_dead() {
   echo '{"error":"upstream","detail":"a wall of raw output that is not a review"}'
 }
 A
+  # ★ Never finishes inside the test's patience. Used only to kill a panel
+  # mid-flight: the point of an append-only record is that a run interrupted
+  # here still proves which seats were dispatched, and nothing can demonstrate
+  # that against a seat that had time to complete.
+  cat > "$1/agents.d/slow.sh" <<'A'
+run_slow() { sleep 30; echo "REVIEW by slow"; echo "Verdict: ship it"; }
+A
+  sed 's/slow/slow2/g' "$1/agents.d/slow.sh" > "$1/agents.d/slow2.sh"
   # Echoes the prompt it was handed, so a test can assert on what the
   # synthesizer was actually TOLD rather than on a stub's invented answer.
   cat > "$1/agents.d/echoer.sh" <<'A'
@@ -1607,13 +1615,73 @@ check "one row per roster seat"     "[ \$(wc -l < '$R/slots.tsv') -eq 2 ]"
 check "a good seat is ok"           "grep -qP '\tgood\t.*\tok\t' '$R/slots.tsv'"
 check "a dead seat is failed"       "grep -qP '\tdead\t.*\tfailed\t' '$R/slots.tsv'"
 check "timing and prompt captured"  "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*\$' '$R/slots.tsv'"
-check "failed prompt captured too"  "grep -qP '\tfailed\t[0-9]+\t\t[1-9][0-9]*\$' '$R/slots.tsv'"
+# ★ CHANGED with #2, deliberately. A failed seat used to carry EMPTY secs, and
+# not because anything decided it should: the old reconstruction grepped the
+# console log for "in Ns", the failure line says "after Ns", the pattern missed,
+# and the field came out blank. The seat WAS timed. `cadre receipts` sums this
+# column as wall-time spend per family, and a seat that burned the clock and
+# then failed cost exactly that much -- dropping it understated real spend.
+# The empty-is-not-zero rule still holds where it is true; the seat that was
+# never timed at all is asserted below.
+check "failed seat keeps its prompt"  "grep -qP '\tfailed\t[0-9]+\t[0-9]*\t[1-9][0-9]*\$' '$R/slots.tsv'"
+check "failed seat's time is measured, not blank" \
+  "grep -qP '\tfailed\t[0-9]+\t[0-9]+\t[1-9][0-9]*\$' '$R/slots.tsv'"
 check "report has receipt table"    "grep -qF '| seat | status | secs | prompt KB | review KB | est. tokens |' '$R/report.md'"
 check "receipt caveat is explicit" "grep -qF '> Estimated as bytes/4 of what the harness sent and received. Hidden reasoning tokens are invisible from outside the CLI and are NOT in this number: a seat that thinks long and answers short costs more than its row shows. This is a relative-spend signal, not a bill.' '$R/report.md'"
 # ★ A seat that produced NO artifact must still appear. Deriving rows from
 # filenames instead of the roster would silently drop exactly the failure worth
 # counting -- the panel would report three seats and the dataset two.
 check "no seat vanishes"            "[ \$(cut -f2 '$R/slots.tsv' | sort -u | wc -l) -eq 2 ]"
+
+# ---- the per-run record (#2) ------------------------------------------------
+# ★ The record is the SOURCE now; slots.tsv and the Receipts table are two
+# renderings of it. These check the source exists, survives, and carries the
+# fields as fields -- the state above was recovered by grepping prose.
+check "record is written"           "[ -s '$R/runs.jsonl' ]"
+# ★ The cleanup line wipes .log-*, .status-* and .len-*. The record's NAME is
+# what keeps it out of that glob, so this asserts the name as much as the file.
+check "record survives the cleanup" "[ -s '$R/runs.jsonl' ] && [ ! -e '$R/.log-good' ]"
+check "record has one dispatch per seat" \
+  "[ \$(grep -c '\"event\":\"dispatch\"' '$R/runs.jsonl') -eq 2 ]"
+check "record has one completion per seat" \
+  "[ \$(grep -c '\"event\":\"complete\"' '$R/runs.jsonl') -eq 2 ]"
+check "dispatch precedes completion" \
+  "[ \$(grep -n '\"event\":\"dispatch\"' '$R/runs.jsonl' | head -1 | cut -d: -f1) -lt \$(grep -n '\"event\":\"complete\"' '$R/runs.jsonl' | tail -1 | cut -d: -f1) ]"
+# State is a FIELD. This is the line that would have had to be a marker grep.
+check "state is a field, not a grep"  "grep -q '\"state\":\"ok\"' '$R/runs.jsonl'"
+check "and the failure is one too"    "grep -q '\"state\":\"failed\"' '$R/runs.jsonl'"
+# ★ Numbers are JSON numbers, not strings. A quoted \"secs\":\"12\" would still
+# render fine in slots.tsv and quietly break any consumer that does arithmetic.
+check "secs is a number"            "grep -qE '\"secs\":[0-9]+' '$R/runs.jsonl'"
+check "bytes is a number"           "grep -qE '\"bytes\":[0-9]+' '$R/runs.jsonl'"
+# The reader round-trips: what slots.tsv shows is what the record holds.
+RECSTATE=$(record_rows "$R/runs.jsonl" complete seat state | awk -F'\t' '$1=="good"{print $2}')
+check "reader returns the good state" "[ '$RECSTATE' = ok ]"
+check "renderer agrees with the record" \
+  "grep -qP '\tgood\t.*\t$RECSTATE\t' '$R/slots.tsv'"
+
+# ★ THE test for an append-only record, and the one that fails by construction
+# against a record assembled at the end: kill a panel mid-flight and the log
+# still names every seat it dispatched. Fourteen panels' timings were lost to
+# scratch files deleted at panel end, and this is the shape that stops the
+# fifteenth from joining them. Two slow seats under --jobs 2 so both are in
+# flight when the clock cuts them off.
+DK=$(case_dir killpanel); SK="$DK/src"
+git -C "$SK" checkout -qb feature
+echo committed >> "$SK/app.js"; git -C "$SK" commit -qam feat
+timeout 6 env CADRE_HOME="$DK/state" CADRE_WORK="$DK/work" CADRE_AGENTS_D="$DK/agents.d" \
+  PATH="$DK/bin:$PATH" "$ROOT/bin/cadre" review --roster slow,slow2 --jobs 2 \
+  --synth none --base main --label kp "$SK" >/dev/null 2>&1 || true
+RK="$DK/state/reviews/kp"
+check "killed panel still left a record"  "[ -s '$RK/runs.jsonl' ]"
+check "it names every seat dispatched"    "[ \$(grep -c '\"event\":\"dispatch\"' '$RK/runs.jsonl') -eq 2 ]"
+# ★ The other half, and the one that makes the first half mean something: no
+# seat claims a completion it never reached. A record that guessed at the
+# missing rows would be worse than no record.
+check "no seat claims a completion"       "! grep -q '\"event\":\"complete\"' '$RK/runs.jsonl'"
+# The panel never got to its own cleanup, so the proof is that the record does
+# not depend on that cleanup having run.
+check "and slots.tsv was never written"   "[ ! -s '$RK/slots.tsv' ]"
 
 # The aggregator reads both shapes: rows recorded live, and older panels
 # rebuilt from artifacts. A reconstructed row has no timing, and that field


### PR DESCRIPTION
Part of #2. **Stacked on #18** — base is `cody/12-which-nothing`, so this diff shows only the record work. Retarget to `main` after #18 lands.

## The thing this deletes

```
sed -n 's/.*in \([0-9][0-9]*\)s.*/\1/p' "$OUT/.log-$sl"
```

A seat's elapsed seconds, parsed back out of the sentence that had printed them, from a scratch file the panel deleted moments later. That is why the first fourteen panels' timings are **gone** rather than merely missing: nothing on disk carried them, and nothing could reconstruct them.

## What replaces it

One append-only JSONL record per panel at `$OUT/runs.jsonl`, written *as the panel runs*:

- a `dispatch` event before anything can fail
- a `complete` event on every terminal path in `run_one`, including the two early returns that previously left only a status file

`slots.tsv` and the report's Receipts table are renderings of it.

**JSONL rather than another TSV for one reason: JSON has `null`.** Empty-is-not-zero is the rule this data has to carry — a seat whose seconds were never measured must not hold a `0` that averages like a measurement. The record shape encodes that: a field name ending in `#` is numeric and becomes `null` when empty; every other name is a string and an empty value stays `""`. An unmeasured *number* and an empty *string* are different facts.

## Three things that are load-bearing and non-obvious

**Appends are atomic by construction.** Seats run in parallel under `--jobs`, and this is the first file in that path two writers touch at once. One event is one `printf` of one short line to an `O_APPEND` file, well under the 4KB a write is guaranteed not to be torn at. Anything that built a line in two writes, or seeked, would interleave.

**The record's NAME is what keeps it alive.** Cleanup wipes `.log-*`, `.status-*` and `.len-*`. A record matching any of those globs would eventually be deleted by someone extending that line, so it is `runs.jsonl` and cannot be matched by them.

**The roster is the authority on which rows exist, not the record.** Deriving rows from what the log happens to contain would silently drop a seat that was dispatched and never completed — exactly the seat worth a row. A gated-off seat is recorded as a completion with `state=skipped` rather than carried in a second list, so every renderer reads one stream.

## Behaviour change, deliberate

A failed seat now carries its measured seconds. The old blank was not a decision: the reconstruction grepped for `"in Ns"`, the failure line says `"after Ns"`, the pattern missed. `cadre receipts` sums that column as wall-time spend per family, and a seat that burned the clock and then failed cost exactly that much — dropping it understated real spend.

⚠️ **Panels written before this change have blank `secs` on failed seats and nothing in the row says so.** `aggregate.sh` already solves that class with its `recorded`/`reconstructed` `source` column; this PR does not extend that to the boundary, so don't average `secs` across it without checking. Worth its own follow-up.

## Caught in review

`slots.tsv` iterated the roster; the Receipts table iterated the record. Two renderings of one panel deriving their row set from different things is the divergence this issue exists to delete, reintroduced pointing the other way — a seat with a dispatch and no completion got a `slots.tsv` row and no Receipts row. The rows are now built once and written twice.

`slots.tsv` already asserted that no seat vanishes. Receipts had **no row-count assertion at all**, which is why the two could drift while green.

## Not in this PR

- **Criterion 2** — `classify_run` reading an adapter-written state field. That is an adapter-contract change across `agents.d/` and `docs/ADDING-AN-AGENT.md`, and it lands on the same marker rail as #12.
- **The benchmark path** — `run-pass.sh` / `grade.sh` still reconstruct from artifacts on disk.

Both are follow-ups. This is the panel path.

## Tests

779 pass, 0 fail.

The one that matters most fails by construction against a record assembled at the end: **kill a panel mid-flight** under `--jobs 2` with two never-finishing seats, and the log names every seat dispatched and claims no completion it never reached. If the stub agents weren't installed the seats would complete instantly and it would fail — it is not vacuous.

Also: the record survives cleanup, one dispatch and one completion per seat, dispatch ordered before completion, state as a field, numbers as JSON numbers, and the reader round-tripping to what `slots.tsv` shows.

Hand-rolled JSON, so the escaping has units: a seat spec with a colon, a quote and a backslash in one value (backslash must be escaped *before* the quote, or the escape is itself re-escaped), a newline that must not split one event into two records, an unmeasured number reading back EMPTY rather than the string `"null"`, key order following the caller's request, a missing key, and an absent log not being an error.

A second-opinion pass (Grok, read-only) attacked the helpers empirically — prefix-key collisions (`secs` vs `secs_total`), escape round-trips, and a value literally containing `"event":"complete"` — plus a reproduced kill-mid-panel run. No findings.
