### PR TITLE
Finish the run record: the benchmark path, and state as a declared field

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,9 +19,22 @@ current LICENSE now extends the same terms to everything committed since.
 THIRD-PARTY CODE
 ----------------
 
-This project vendors no third-party source code. It shells out to external AI
-coding CLIs, which it does not distribute and which carry their own licenses
-and terms of service.
+This project vendors no third-party source code, with one documented exception
+below. It shells out to external AI coding CLIs, which it does not distribute
+and which carry their own licenses and terms of service.
+
+The exception: docs/CHECKS-SECURITY-RELIABILITY.md is a derivative work. It is
+adapted from the category C and F check tables of goshipit
+(https://github.com/Capta1nRaj/goshipit) at v0.1.3, copyright its contributors,
+licensed under the Apache License 2.0, and it remains under Apache-2.0 while
+the rest of this repository is MIT. The wording of individual checks, their
+severities, and the set of checks included were all changed: severities were
+reassigned to this project's blocking/should-fix/nit rubric, references to
+goshipit's "Stack Profile" were inlined, and seven checks were dropped because
+they cannot be answered from a checkout or are not defects in the code under
+review. Source check IDs are retained in that file so the adaptation can be
+audited against the original. A copy of the Apache License 2.0 is at
+https://www.apache.org/licenses/LICENSE-2.0.
 
 Ideas and prior art that informed the design, including work this project
 explicitly does not claim to have invented, are credited in

--- a/bin/agentcall
+++ b/bin/agentcall
@@ -58,6 +58,45 @@ AGENTS=$(printf '%s\n' $AGENTS | sort | tr '\n' ' ')
 export -n CADRE_HOME CADRE_ROOT CADRE_AGENTS_D 2>/dev/null || true
 unset CADRE_JUDGE CADRE_PASS_DIR CADRE_STACK CADRE_TEST_CMD CADRE_ALLOW_SECRETS
 
+# ★ An adapter's way to DECLARE what happened, out of band (#2 criterion 2).
+#
+# Until now the only channel was a marker in the review text, which cadre then
+# edge-matched back out -- and text a model controls can collide with text the
+# contract reserves. Both known collisions are that shape: a synthesis asked to
+# discuss which reviewers were truncated quotes `_TRUNCATED` and classifies
+# ITSELF as truncated, and a short review that merely mentions rate limiting
+# trips the keyword scan. A field written by the ADAPTER, on a channel the model
+# never touches, cannot be forged by anything the model says.
+#
+# Optional, and deliberately so. Adapters that say nothing keep working exactly
+# as before: the dispatch layer falls back to the marker contract, which is
+# still the documented way to signal and is what every shipped adapter uses.
+# This is for an adapter that KNOWS -- it read a stopReason, it caught its own
+# timeout -- and should not have to spell that knowledge into prose and hope.
+#
+# ★ No-op when CADRE_RUN_META is unset, which is the case for every direct
+# `agentcall` invocation. agentcall is a standalone tool and must not require
+# cadre to be driving it.
+# ★ export -n, and CADRE_RUN_META is on the scrub list: the path is a file cadre
+# owns, and handing an agent a writable path into cadre's own bookkeeping is
+# exactly the containment the scrub exists to keep. Adapters run as functions in
+# THIS shell, so they can still see it; the spawned CLI cannot.
+export -n CADRE_RUN_META 2>/dev/null || true
+cadre_state() {  # cadre_state <ok|degraded|inconclusive|failed> [note]
+  [ -n "${CADRE_RUN_META:-}" ] || return 0
+  case "${1:-}" in
+    ok|degraded|inconclusive|failed) ;;
+    # A typo must not silently become a state. Refusing leaves the marker
+    # contract in charge, which is the safe direction: a wrong FIELD outranks
+    # the text and would be believed, where a missing one just falls back.
+    *) echo "agentcall: cadre_state got '${1:-}', which is not a state; ignored" >&2
+       return 0 ;;
+  esac
+  printf 'state=%s\n' "$1" >> "$CADRE_RUN_META"
+  [ -n "${2:-}" ] && printf 'note=%s\n' "$(printf '%s' "$2" | tr -d '\000-\037')" >> "$CADRE_RUN_META"
+  return 0
+}
+
 # --print-command: print the native invocation instead of running it.
 DRY="${AGENTCALL_DRY:-}"
 _run() {

--- a/bin/cadre
+++ b/bin/cadre
@@ -1164,11 +1164,16 @@ cmd_receipts() {
     NF < 5 || $3 == "" { next }
     {
       fam = $3
-      # ★ A missing or empty column 8 is UNKNOWN, printed "?", never defaulted to
-      # a version. Those rows straddle the change this grouping exists to keep
-      # apart, and calling them by any version number would assert the one thing
-      # nothing on disk can tell us.
-      v = (NF >= 8 && $8 != "") ? $8 : "?"
+      # ★ A missing, empty or NON-NUMERIC column 8 is UNKNOWN, printed "?", never
+      # defaulted to a version. Those rows straddle the change this grouping
+      # exists to keep apart, and calling them by any version number would assert
+      # the one thing nothing on disk can tell us.
+      # ★ The numeric test is not belt-and-braces. A dataset written by the old
+      # lib/aggregate.sh puts `source` in column 8, so `recorded` and
+      # `reconstructed` arrived here as two schema names and split every family
+      # in the table -- receipts accepts any directory, and a stale dataset dir
+      # is a directory.
+      v = (NF >= 8 && $8 ~ /^[0-9]+$/) ? $8 : "?"
       key = fam SUBSEP v
       if (!(key in keys)) { keys[key] = 1; famof[key] = fam; vof[key] = v; nver[fam]++ }
       seats[key]++

--- a/bin/cadre
+++ b/bin/cadre
@@ -1139,8 +1139,16 @@ cmd_review() {
 # Sum only what slots.tsv measured. Old and reconstructed rows have no prompt
 # length, and a receipt command that guesses one would turn missing history into
 # a confident spend number.
+#
+# ★ Rows are grouped by (family, SCHEMA), not by family (#20). `secs` changed
+# meaning for one class of row -- a failed seat used to carry a blank and now
+# carries its measured seconds -- and neither value is wrong, so the totals are
+# not wrong either; a single total over both is. Splitting the row is the
+# strongest available answer: there is no unqualified number to misread, and a
+# family that appears twice is itself the notice. Nothing is dropped, so panels
+# that predate the column stay readable, which is the other half of the ask.
 cmd_receipts() {
-  local roots=() d f raw rows missing tab=$'\t'
+  local roots=() d f raw rows missing spanning harness_list nharness no_harness tab=$'\t'
   if [ "$#" -eq 0 ]; then roots=("$CADRE_HOME/reviews")
   else roots=("$@")
   fi
@@ -1156,50 +1164,98 @@ cmd_receipts() {
     NF < 5 || $3 == "" { next }
     {
       fam = $3
-      seats[fam]++
-      run_key = fam SUBSEP FILENAME SUBSEP $1
-      if (!(run_key in seen)) { seen[run_key] = 1; runs[fam]++ }
-      if      ($4 == "ok")           ok[fam]++
-      else if ($4 == "degraded")     degraded[fam]++
-      else if ($4 == "inconclusive") inconclusive[fam]++
-      else if ($4 == "skipped")      skipped[fam]++
-      else                             failed[fam]++
+      # ★ A missing or empty column 8 is UNKNOWN, printed "?", never defaulted to
+      # a version. Those rows straddle the change this grouping exists to keep
+      # apart, and calling them by any version number would assert the one thing
+      # nothing on disk can tell us.
+      v = (NF >= 8 && $8 != "") ? $8 : "?"
+      key = fam SUBSEP v
+      if (!(key in keys)) { keys[key] = 1; famof[key] = fam; vof[key] = v; nver[fam]++ }
+      seats[key]++
+      run_key = key SUBSEP FILENAME SUBSEP $1
+      if (!(run_key in seen)) { seen[run_key] = 1; runs[key]++ }
+      if      ($4 == "ok")           ok[key]++
+      else if ($4 == "degraded")     degraded[key]++
+      else if ($4 == "inconclusive") inconclusive[key]++
+      else if ($4 == "skipped")      skipped[key]++
+      else                             failed[key]++
       review = ($5 ~ /^[0-9]+$/) ? $5 : 0
-      review_bytes[fam] += review
-      if ($6 ~ /^[0-9]+$/) { secs[fam] += $6; have_secs[fam] = 1 }
+      review_bytes[key] += review
+      if ($6 ~ /^[0-9]+$/) { secs[key] += $6; have_secs[key] = 1 }
       prompt = 0
       if (NF < 7 || $7 == "") missing_prompt++
-      else if ($7 ~ /^[0-9]+$/) { prompt = $7; prompt_bytes[fam] += prompt }
+      else if ($7 ~ /^[0-9]+$/) { prompt = $7; prompt_bytes[key] += prompt }
       else missing_prompt++
-      est_tokens[fam] += int((prompt + review) / 4)
+      est_tokens[key] += int((prompt + review) / 4)
+      # Harness identity is a property of the COMPARISON, not of a family, so it
+      # is counted across every row the command was pointed at (#37).
+      if (NF >= 11 && $11 != "") { if (!($11 in harness)) harness[$11] = 1 }
+      else no_harness++
     }
     END {
-      for (fam in seats) {
-        sec = have_secs[fam] ? secs[fam] : ""
-        printf "R\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%d\t%d\n", \
-          fam, runs[fam], seats[fam], ok[fam], degraded[fam], \
-          inconclusive[fam], failed[fam], skipped[fam], sec, prompt_bytes[fam], \
-          review_bytes[fam], est_tokens[fam]
+      for (key in keys) {
+        sec = have_secs[key] ? secs[key] : ""
+        printf "R\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\n", \
+          famof[key], runs[key], seats[key], ok[key], degraded[key], \
+          inconclusive[key], failed[key], skipped[key], sec, prompt_bytes[key], \
+          review_bytes[key], est_tokens[key], vof[key], nver[famof[key]]
       }
       printf "M\t%d\n", missing_prompt
+      for (h in harness) printf "H\t%s\n", h
+      printf "N\t%d\n", no_harness + 0
     }
   ' "${slot_files[@]}")
 
   missing=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "M" { print $2 }')
+  # -k14 breaks the tie so a family split across schemas prints in a stable
+  # order; without it the two halves swap between runs and a diff of two
+  # receipts reads as a change.
   rows=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "R"' \
-    | sort -t "$tab" -k13,13nr -k2,2)
+    | sort -t "$tab" -k13,13nr -k2,2 -k14,14)
 
-  printf '%-24s %5s %5s %4s %8s %12s %6s %7s %8s %10s %10s %11s\n' \
-    FAMILY RUNS SEATS OK DEGRADED INCONCLUSIVE FAILED SKIPPED SECS PROMPT_KB REVIEW_KB 'EST. TOKENS'
+  printf '%-24s %5s %5s %4s %8s %12s %6s %7s %8s %10s %10s %11s %7s\n' \
+    FAMILY RUNS SEATS OK DEGRADED INCONCLUSIVE FAILED SKIPPED SECS PROMPT_KB REVIEW_KB 'EST. TOKENS' SCHEMA
   printf '%s\n' "$rows" | awk -v FS="$tab" '
     $1 == "R" {
-      printf "%-24s %5d %5d %4d %8d %12d %6d %7d %8s %10.1f %10.1f %11d\n", \
-        $2, $3, $4, $5, $6, $7, $8, $9, $10, $11 / 1024, $12 / 1024, $13
+      printf "%-24s %5d %5d %4d %8d %12d %6d %7d %8s %10.1f %10.1f %11d %7s\n", \
+        $2, $3, $4, $5, $6, $7, $8, $9, $10, $11 / 1024, $12 / 1024, $13, $14
     }
   '
   if [ "${missing:-0}" -gt 0 ]; then
     echo
     echo "$missing rows predate prompt-byte capture; their prompt spend is not counted."
+  fi
+
+  spanning=$(printf '%s\n' "$rows" | awk -v FS="$tab" '$1 == "R" && $15 > 1 { print $2 }' \
+    | sort -u | paste -sd, - | sed 's/,/, /g')
+  if [ -n "$spanning" ]; then
+    echo
+    echo "Listed on more than one row, one per slots.tsv schema: $spanning."
+    echo "Those rows are NOT comparable and were not added together. Schema ? predates the column and spans the change to what a failed seat's SECS means."
+  fi
+
+  harness_list=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "H" { print $2 }' \
+    | sort | paste -sd, - | sed 's/,/, /g')
+  nharness=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "H"' | grep -c . || true)
+  no_harness=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "N" { print $2 }')
+  # ★ Said out loud on BOTH branches. The agreement case is the one worth
+  # printing: an absent warning is indistinguishable from a check that never
+  # ran, and this line is the only place the comparison's harness identity
+  # surfaces at all.
+  if [ "${nharness:-0}" -gt 1 ]; then
+    echo
+    echo "Harness: these rows span ${nharness} versions ($harness_list). Seats measured under different harnesses are not a like-for-like comparison."
+  elif [ "${nharness:-0}" -eq 1 ]; then
+    echo
+    if [ "${no_harness:-0}" -eq 0 ]; then
+      echo "Harness: every row ran against $harness_list."
+    else
+      echo "Harness: every row that names one ran against $harness_list."
+    fi
+  fi
+  if [ "${no_harness:-0}" -gt 0 ]; then
+    [ "${nharness:-0}" -gt 0 ] || echo
+    echo "Harness: ${no_harness} row(s) name none, so whether they match the rest is unknown."
   fi
 }
 

--- a/docs/ADDING-AN-AGENT.md
+++ b/docs/ADDING-AN-AGENT.md
@@ -82,6 +82,36 @@ wrong, say `DID NOT RUN` and get `failed`, which is stronger information. What
 and the *model* declined the job. One of the three measured examples was an
 unmarked truncation, so no `_TRUNCATED` was ever coming.
 
+### Declaring the state directly, when you know it
+
+The markers above are text, and cadre reads them back out of the artifact. That
+works, and every shipped adapter uses it. It has one weakness: text a *model*
+controls can collide with text the contract reserves. A synthesis asked to say
+which reviewers were truncated quotes `_TRUNCATED` and classifies itself as
+truncated; a short review that merely discusses rate limiting trips the keyword
+scan. No text test can tell those apart, because both are legitimate.
+
+If your adapter *knows* — it read a `stopReason`, it caught its own timeout —
+say so out of band:
+
+```sh
+run_youragent() {
+  ...
+  cadre_state degraded "stopReason=MaxTokens"     # ok | degraded | inconclusive | failed
+}
+```
+
+`cadre_state` outranks the markers, the exit code, and every inference cadre
+would otherwise make. Nothing the model prints can forge one, because printing
+is not calling it.
+
+**It is optional.** Say nothing and the marker contract above is still in
+charge — that is not a deprecated path. Two things it will not do for you: an
+unknown state is ignored rather than believed (a wrong field would outrank the
+text, so falling back is the safe direction), and declaring `ok` will not
+rescue an artifact that came back empty. It is also a no-op when `agentcall`
+runs outside cadre, so it costs a standalone caller nothing.
+
 The one thing this asks of you: **do not append your own trailing summary to a
 review.** The check is edge-anchored, so a "review complete, 0 issues" footer your
 wrapper adds would satisfy it on behalf of a model that said nothing.

--- a/docs/ADDING-AN-AGENT.md
+++ b/docs/ADDING-AN-AGENT.md
@@ -105,6 +105,19 @@ run_youragent() {
 would otherwise make. Nothing the model prints can forge one, because printing
 is not calling it.
 
+**How far to trust it.** A declaration is trusted exactly as much as the
+*adapter* is, and no further. Cadre hands the adapter a path and believes what
+it finds there; it cannot tell your `cadre_state` call from anything else that
+wrote to the same file. The agent CLI you spawn runs as the same uid as cadre,
+and several of them will run a shell on request — so a model that goes looking
+can reach that file, and a declared `ok` outranks a `_TRUNCATED` marker and a
+nonzero exit. The path is a private temp directory rather than a bare temp file,
+which stops the blind `for f in /tmp/tmp.*` version, and that is a speed bump,
+not a boundary. Same posture as the rest of the environment scrub:
+mitigation, not a sandbox, docs/METHOD.md §5. The marker contract is the more
+conservative channel precisely because the adapter, not the model, appends it
+after the CLI has already exited.
+
 **It is optional.** Say nothing and the marker contract above is still in
 charge — that is not a deprecated path. Two things it will not do for you: an
 unknown state is ignored rather than believed (a wrong field would outrank the

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -98,6 +98,29 @@ no diagnostic in the pipeline.
 Tests: "by: without -a the whole review is suppressed", "by: the pre-existing
 claims survive", "by: the finding after the bad byte is claimed".
 
+**12. A published number names the inputs that produced it.** Every row of
+`slots.tsv` and every `complete` record carries a content hash for the rendered
+prompt, for the adapter file(s) that ran, and for the harness files that shape a
+review (`lib/common.sh`, `lib/run-review.sh`, `lib/run-pass.sh`, `lib/grade.sh`,
+`lib/prompts/*`). `prompt_bytes` was a size, so two prompts of equal length were
+one row; `CADRE_PROMPT_FILE` replaces the brief wholesale, which made the
+highest-leverage input the least described. The hash is EMPTY, never zero and
+never faked, when it could not be determined — a reconstructed row, a promptless
+adapter, or a box with no sha256 tool. `cadre receipts` states whether every row
+in a comparison ran against the same harness, on both branches.
+Tests: "adapter hash is per adapter", "one harness hash for the panel",
+"sha: a missing input is EMPTY", "harness: a split is called out",
+"harness: agreement is stated".
+
+**13. Receipts do not average across a schema change.** `slots.tsv` rows carry
+the schema version that wrote them, and `cadre receipts` groups by
+(family, schema) rather than by family. Rows written before the column existed
+print schema `?` — unknown, not a default — because they straddle the change to
+what `secs` means on a failed seat and nothing on disk separates the halves.
+Nothing is excluded, so older panels stay readable.
+Tests: "mixed: one row per schema", "mixed: the two secs never merge",
+"mixed: pre-#19 panels still read".
+
 ## Non-goals, named
 
 - **The preflight reads filenames, plus content for exactly four config
@@ -114,6 +137,11 @@ claims survive", "by: the finding after the bad byte is claimed".
   target-pick time.
 - **Receipts do not measure hidden reasoning tokens, provider billing, or
   in-CLI retries.** METHOD.md §6.
+- **The input hashes are provenance, not tamper-proofing.** They are computed
+  by the same tree they describe, so anyone who can edit `lib/` can edit what
+  gets hashed. What they buy is that a comparison spanning an edit becomes
+  visible instead of silent. Nothing here is a signature and nothing verifies
+  a tree against a published manifest.
 - **A scratch file in the tree is a source file to the harness.** Planning
   notes, TODO dumps and other author-written artifacts ride into the checkout
   like any other file — tracked, or untracked-but-not-gitignored (carried on

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -100,17 +100,34 @@ claims survive", "by: the finding after the bad byte is claimed".
 
 **12. A published number names the inputs that produced it.** Every row of
 `slots.tsv` and every `complete` record carries a content hash for the rendered
-prompt, for the adapter file(s) that ran, and for the harness files that shape a
-review (`lib/common.sh`, `lib/run-review.sh`, `lib/run-pass.sh`, `lib/grade.sh`,
-`lib/prompts/*`). `prompt_bytes` was a size, so two prompts of equal length were
-one row; `CADRE_PROMPT_FILE` replaces the brief wholesale, which made the
-highest-leverage input the least described. The hash is EMPTY, never zero and
-never faked, when it could not be determined — a reconstructed row, a promptless
-adapter, or a box with no sha256 tool. `cadre receipts` states whether every row
-in a comparison ran against the same harness, on both branches.
-Tests: "adapter hash is per adapter", "one harness hash for the panel",
-"sha: a missing input is EMPTY", "harness: a split is called out",
-"harness: agreement is stated".
+prompt, for the adapter code that ran, and for the harness files that shape a
+review (`bin/agentcall`, `lib/common.sh`, `lib/run-review.sh`,
+`lib/run-pass.sh`, `lib/grade.sh`, `lib/prompts/*`). `prompt_bytes` was a size,
+so two prompts of equal length were one row; `CADRE_PROMPT_FILE` replaces the
+brief wholesale, which made the highest-leverage input the least described.
+
+`adapter_sha` covers the files `agentcall` would source that define anything for
+that agent — both copies of `<agent>.sh`, and any other file in either directory
+mentioning `_<agent>(`. It sources every `*.sh` in both directories into one
+namespace, so a foreign file defining `run_<agent>()` is a different reviewer
+behind an otherwise unchanged adapter file.
+
+**The hash is EMPTY whenever it could not be fully determined** — a
+reconstructed row, a promptless adapter that received no shared brief, a box
+with no sha256 tool, an unreadable or missing input, or any hashing step that
+exits non-zero. Never a zero, never a partial digest: the digest of an empty
+read is *stable*, so two runs that both failed would compare EQUAL, which is the
+one answer this field must never give. Per-file digests are hashed rather than
+concatenated bytes, so no pair of inputs can straddle a field boundary and
+collide.
+
+`cadre receipts` states whether every row in a comparison ran against the same
+harness, on both branches — agreement and disagreement.
+Tests: "adapter hash is per adapter", "adapter hash sees a foreign override",
+"and ignores an unrelated adapter", "one harness hash for the panel",
+"harness: agentcall is hashed", "sha: an unreadable input is EMPTY",
+"sha: never the digest of nothing", "sha: file boundaries are kept",
+"harness: a split is called out", "harness: agreement is stated".
 
 **13. Receipts do not average across a schema change.** `slots.tsv` rows carry
 the schema version that wrote them, and `cadre receipts` groups by
@@ -118,8 +135,11 @@ the schema version that wrote them, and `cadre receipts` groups by
 print schema `?` — unknown, not a default — because they straddle the change to
 what `secs` means on a failed seat and nothing on disk separates the halves.
 Nothing is excluded, so older panels stay readable.
+Column 8 is read as a version only when it *reads* as one: a dataset written by
+the older `lib/aggregate.sh` carries `source` there, and `recorded` /
+`reconstructed` would otherwise have split every family into two named schemas.
 Tests: "mixed: one row per schema", "mixed: the two secs never merge",
-"mixed: pre-#19 panels still read".
+"mixed: pre-#19 panels still read", "olddata: a source word is never a schema".
 
 ## Non-goals, named
 

--- a/docs/CHECKS-SECURITY-RELIABILITY.md
+++ b/docs/CHECKS-SECURITY-RELIABILITY.md
@@ -1,0 +1,103 @@
+# Security and reliability checks
+
+A reading list for a reviewer, not a scanner and not a scoring rubric. Nothing
+here is wired into `lib/prompts/`: the review brief is kept byte-identical
+across passes so results stay comparable, and 48 injected checks would break
+that. Use this when you want a human or an agent to sweep a checkout
+deliberately, or as source material if you ever add a `--checks <file>` flag.
+
+Every row is written to be answerable **from the checkout alone**, and to be a
+defect rather than a policy preference. Checks that need deployment state, a
+live URL, or an account somewhere were dropped, as were checks that are real
+but are not defects in the code under review. The drops are listed at the
+bottom with the reason.
+
+Severity is cadre's, not the source's. It is assigned by consequence:
+
+- **blocking** — data loss or corruption, auth bypass, secret exposure, or
+  silently wrong output reaching a user.
+- **should-fix** — a real bug with a bounded blast radius: it fails loudly,
+  needs an unlikely input, or gets caught before production.
+- **nit** — cannot produce a wrong result on its own.
+
+A pattern match is not a finding. Every row below still needs the consequence
+named on the actual code before it gets reported.
+
+Adapted from [goshipit](https://github.com/Capta1nRaj/goshipit) v0.1.3,
+categories C and F. Source IDs are kept in the last column so the adaptation is
+auditable. **This file is a derivative work and remains under Apache-2.0; the
+rest of this repository is MIT.** See [../NOTICE](../NOTICE).
+
+## Security
+
+| Check | Severity | src |
+| --- | --- | --- |
+| User input reaching a DB query as string concatenation, or reaching `dangerouslySetInnerHTML` / `innerHTML` / `v-html` | blocking | C1 |
+| A protected page or endpoint with no auth check — no middleware entry, no session read, no guard in the handler | blocking | C4 |
+| CORS reflecting an arbitrary request `Origin` while `credentials: true`. Bare `Access-Control-Allow-Origin: *` on an API that carries no credentials is should-fix, not blocking — browsers already refuse to send credentials to it | blocking | C7 |
+| A webhook handler that parses the body before verifying the provider signature, or that has no signature check at all | blocking | C8 |
+| State-changing routes (POST/PUT/DELETE/PATCH) with neither a CSRF token check (`csurf`, `csrf_protect`, or the framework's built-in) nor `SameSite=Strict`/`Lax` on the session cookie. An explicit `@csrf_exempt` on a state-changing view is the same finding, stated out loud | blocking | C17 |
+| Request data written without server-side validation. Client-side-only validation is not validation. Blocking when the unvalidated value reaches a write or a permission decision; should-fix when it only reaches a read | blocking | C18 |
+| Lockfile `resolved:` URLs pointing outside the official registry, or an `.npmrc`/`.yarnrc` scoping a private registry with no auth token — dependency confusion, and it executes install scripts | blocking | C20 |
+| `md5(`, `sha1(`, or bare `sha256(` hashing a password. (The source also flags bcrypt-without-argon2; that is a preference, not a defect — bcrypt with a sane cost is fine) | blocking | C22 |
+| Multi-tenant schema (`tenantId`/`orgId`/`workspaceId`) with queries on shared tables that omit the tenant filter, or migrations with no row-level security | blocking | C26 |
+| Resource lookup by user-supplied id with no ownership filter: `findById(req.params.id)`, `.findUnique({ where: { id } })`, `WHERE id = $1` with no `AND user_id = …` — IDOR | blocking | C27 |
+| Request body passed whole into a write: `Object.assign(record, req.body)`, `Model.update(req.body)`, `create({ data: body })`, `**kwargs` into a model constructor — mass assignment, and the escalation path is a `role`/`is_admin` column | blocking | C28 |
+| Server-only env vars (`DATABASE_URL`, `JWT_SECRET`, `STRIPE_SECRET_KEY`) read in a client component, or a server-only module (`prisma`, `pg`, `mysql2`, `redis`) imported into a `'use client'` file — the value ships in the bundle | blocking | C30 |
+| User-controlled URL reaching a server-side HTTP client with no allowlist: `fetch(req.query.`, `axios.get(req.body.`, `requests.get(user_` — SSRF, and on a cloud host the first stop is the metadata endpoint | blocking | C32 |
+| User-controlled path in a filesystem call: `fs.readFile(req.params.`, `path.join(__dirname, req.`, `open(user_` with no `path.normalize` plus a `startsWith(baseDir)` confinement check | blocking | C33 |
+| `eval(`, `new Function(`, `vm.runInNewContext(`, or `exec`/`execSync` with an interpolated request value, outside test code | blocking | C34 |
+| Auth, password-reset, payment, and contact endpoints with no rate limit. On an edge runtime, a Node-only limiter (`express-rate-limit`, `ioredis`) will not run at all; off edge, `@upstash/ratelimit` without `export const runtime = 'edge'` is the mirror mistake. Applies to the broader non-auth surface too, at lower priority | should-fix | C2, C31 |
+| API error handlers returning `err.stack` or the raw driver error to the client — leaks paths, queries, and sometimes the connection string | should-fix | C3 |
+| A manifest with no committed lockfile — installs are non-deterministic, but they fail loudly rather than silently | should-fix | C6 |
+| Session cookies missing `httpOnly`, `secure`, or `sameSite`. Needs a second bug (XSS, a plaintext hop) to become an incident, which is what keeps it out of blocking | should-fix | C9 |
+| No `Content-Security-Policy`, or one with `default-src *`, or missing `object-src 'none'` | should-fix | C11 |
+| No `X-Frame-Options: DENY`/`SAMEORIGIN` and no `frame-ancestors` in CSP — clickjacking | should-fix | C12 |
+| No `X-Content-Type-Options: nosniff` | should-fix | C13 |
+| `Referrer-Policy: unsafe-url`, or absent — leaks any token that appears in a URL to third-party hosts | should-fix | C14 |
+| No `Strict-Transport-Security`, or `max-age` under 31536000, or missing `includeSubDomains` | should-fix | C16 |
+| GraphQL with `introspection: true` ungated by env, no depth or complexity limit, or subscriptions that never authenticate `connectionParams` | should-fix | C21 |
+| TLS config permitting 1.0/1.1 in a committed `nginx.conf`, `ssl.conf`, or `.htaccess` | should-fix | C23 |
+| Schema columns like `ssn`, `dob`, `card_number`, `bank_account`, `passport`, `tax_id` stored with no encryption at rest | should-fix | C25 |
+| A redirect target taken from user input with no allowlist or same-origin check. Blocking instead when the redirect carries an OAuth code or a session token, because then it is credential exfiltration | should-fix | C19 |
+| Source maps emitted in a production build (`devtool: 'source-map'` in the prod webpack config, `productionBrowserSourceMaps: true`, `sourcemap: true` in a Vite/Rollup prod build) | should-fix | C29 |
+| Upload handlers trusting the request's own `mimetype`/`contentType` with no server-side magic-byte check. Blocking when the uploaded file is later served from the application's own origin — that is stored XSS | should-fix | C35 |
+| No `Permissions-Policy` scoping camera/microphone/geolocation to `(self)` or `()` | nit | C15 |
+
+## Reliability
+
+| Check | Severity | src |
+| --- | --- | --- |
+| A migration that has already been applied being edited in place, rather than superseded by a new one — every environment past that point drifts silently | blocking | F5 |
+| A form or contact handler whose only body is `console.log` or `res.json({ ok: true })`, with no write and no send — submissions are accepted and dropped, and nothing anywhere reports it | blocking | F15 |
+| A webhook handler with no idempotency guard — no stored event id, no `processedEvents` table, no Redis `SET NX`. Providers retry by design, so this is duplicate writes and double charges, not a hypothetical | blocking | F16 |
+| No top-level error boundary: no React `ErrorBoundary`, no `+error.svelte`, no 500 template, no `recover()` in a Go handler | should-fix | F2 |
+| Error reporting present but inert — no `Sentry.init()` in the app entry, a placeholder DSN, or an init that is not gated to production | should-fix | F3 |
+| Runtime version unpinned: no `.nvmrc`, no `engines`, no `runtime.txt`, no version in `go.mod`/`pyproject.toml` | should-fix | F1 |
+| Dev-only tooling in production dependencies — test runners, type packages, linters, bundler plugins in `dependencies` rather than `devDependencies` | should-fix | F6 |
+| No SIGTERM handler draining in-flight requests and closing the DB pool. On a rolling deploy, in-flight writes are cut mid-transaction | should-fix | F7 |
+| No connection pool config — `connection_limit` in a Prisma URL, `pool` in pg/mysql2, `pool_size` in SQLAlchemy. A connection per request exhausts the database before it exhausts the app | should-fix | F12 |
+| A foreign-key column (`REFERENCES`, `@relation`, `ForeignKey`) with no index on it — cascade deletes and joins become full scans, and it gets slow only once the table is big | should-fix | F17 |
+| An `uncaughtException` or `unhandledRejection` handler that logs and lets the process continue. The defect is the swallow, not the absence: after an uncaught throw the process state is undefined, and modern Node already exits on an unhandled rejection by default. The handler should log and then exit | should-fix | F19 |
+| Two lockfiles in the same project (`package-lock.json` alongside `yarn.lock`, `yarn.lock` alongside `pnpm-lock.yaml`) — different CI runners resolve different trees | should-fix | F20 |
+| A listener registered per request or in a loop with no matching `off()`/`removeListener()` — an unbounded emitter leak. Raising `setMaxListeners(N)` silences the warning and does not fix it, so a call to it is itself a tell | should-fix | F21 |
+| Transactional email sending from an `@gmail.com`/`@hotmail.com`/`@yahoo.com` From address — no custom SPF or DKIM is possible, so delivery degrades quietly | should-fix | F11, F18 |
+| Raw `console.log` where the project already has a structured logger (Winston, Pino, `logging`, `slog`). Worth a look at what is being logged: a request body printed in full is a secret-exposure finding, not a nit | nit | F4 |
+| No `/health`, `/ping`, or `/status` endpoint | nit | F8 |
+| Missing `build`, `start`, or `test` script in `package.json`/`Makefile`/`pyproject.toml` | nit | F9 |
+
+## Dropped, and why
+
+These are in the source and are deliberately not above. A reviewer handed a
+checkout cannot answer them, and a check that cannot be answered comes back as
+a manufactured finding that adjudication then has to spend a pass discarding.
+
+| src | Check | Why dropped |
+| --- | --- | --- |
+| C5 | Run `npm audit` / `pip-audit` / `cargo audit` and flag CVEs | An instruction to run a tool, not a defect pattern. Cadre reviewers are already told they may run targeted commands |
+| C10 | GPL/AGPL packages in a commercial codebase | A licensing decision, not a defect. Belongs to whoever owns the license policy |
+| C24 | CI pipeline missing a SAST tool or an audit step | Process maturity. Real, but it is not a defect in the code under review |
+| F10 | Email-send patterns present but no transactional email library in deps | Prescribes an architecture from a grep. Sending mail without one of the named libraries is not by itself wrong |
+| F13 | No automated database backup | Deployment state. Not visible in a checkout, and absence of a backup script proves nothing about whether backups exist |
+| F14 | No uptime monitoring configured | Same — an external service, configured outside the repo |
+| F5 (part) | Unapplied migrations | The applied-vs-pending split lives in the target database, not the checkout. Only the edit-in-place half survives, above |

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -59,15 +59,21 @@ about which model reviews *better* needs that path, not this file.
   print as `?` and are listed on their own row.
 - **prompt_sha** / **adapter_sha** / **harness_sha** — 12-hex content hashes of
   the three inputs that decide what a seat saw: the rendered prompt as
-  dispatched, the adapter file(s) that ran (both the shipped one and a user
-  override, since `agentcall` sources both), and the harness files that shape a
-  review. `prompt_bytes` is a size — two prompts that differ but happen to be
+  dispatched, the adapter code that ran, and the harness files that shape a
+  review (including `bin/agentcall`, which decides whether the brief arrives on
+  stdin or in argv; `bin/cadre` is deliberately excluded, so a CLI edit does not
+  invalidate stored comparisons). `adapter_sha` covers both copies of
+  `<agent>.sh` *and* any other file in either adapter directory mentioning
+  `_<agent>(` — `agentcall` sources every `*.sh` in both into one namespace, so
+  a foreign file defining `run_<agent>()` is a different reviewer. `prompt_bytes` is a size — two prompts that differ but happen to be
   the same length are indistinguishable by it, and `CADRE_PROMPT_FILE` replaces
   the brief wholesale, so the input with the largest effect on a review was the
   one the record described least. All three are **EMPTY when undetermined** and
   never zeroed: a reconstructed row, a promptless adapter that received no
-  shared brief, or a machine with no `sha256sum`/`shasum`. This is provenance,
-  not tamper-proofing — see `docs/ASSURANCE_CASE.md`.
+  shared brief, a machine with no `sha256sum`/`shasum`, or an input that could
+  not be read in full. The digest of an empty read is *stable*, so a partial
+  answer here would make two failed runs compare equal. This is provenance, not
+  tamper-proofing — see `docs/ASSURANCE_CASE.md`.
 - **source** — `recorded` (written live by `run-review.sh`, with status and
   timing measured and prompt size present on new rows) or `reconstructed`
   (rebuilt from artifacts after the fact). Reconstructed rows have **no timing

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -25,7 +25,7 @@ about which model reviews *better* needs that path, not this file.
 
 ## slots.tsv — one row per reviewer slot
 
-    panel  slot  family  status  bytes  secs  prompt_bytes  source
+    panel  slot  family  status  bytes  secs  prompt_bytes  v  prompt_sha  adapter_sha  harness_sha  source
 
 - **status** — `ok` / `degraded` / `inconclusive` / `failed` / `skipped`.
   `skipped` means the user-declared roster gate did not hold, so no prompt was
@@ -49,13 +49,33 @@ about which model reviews *better* needs that path, not this file.
 - **prompt_bytes** — size of the exact prompt dispatched to the seat, captured
   by the harness at dispatch time. It is empty for rows that predate this field
   and for reconstructed rows; cadre never guesses it from surviving files.
+- **v** — the `slots.tsv` schema version that wrote the row: what these columns
+  mean and which rule filled them. A row **without** it is not version 1, it is
+  **unknown**, and `cadre receipts` groups on it rather than guessing. The
+  distinction it protects: `secs` on a *failed* seat used to be blank and is now
+  the measured seconds. Neither convention is wrong, and a total that spans both
+  is a number nobody can interpret. Rows that predate the column straddle that
+  change and nothing on disk can separate the halves after the fact, so they
+  print as `?` and are listed on their own row.
+- **prompt_sha** / **adapter_sha** / **harness_sha** — 12-hex content hashes of
+  the three inputs that decide what a seat saw: the rendered prompt as
+  dispatched, the adapter file(s) that ran (both the shipped one and a user
+  override, since `agentcall` sources both), and the harness files that shape a
+  review. `prompt_bytes` is a size — two prompts that differ but happen to be
+  the same length are indistinguishable by it, and `CADRE_PROMPT_FILE` replaces
+  the brief wholesale, so the input with the largest effect on a review was the
+  one the record described least. All three are **EMPTY when undetermined** and
+  never zeroed: a reconstructed row, a promptless adapter that received no
+  shared brief, or a machine with no `sha256sum`/`shasum`. This is provenance,
+  not tamper-proofing — see `docs/ASSURANCE_CASE.md`.
 - **source** — `recorded` (written live by `run-review.sh`, with status and
   timing measured and prompt size present on new rows) or `reconstructed`
   (rebuilt from artifacts after the fact). Reconstructed rows have **no timing
   or prompt size at all**: the per-slot scratch files were deleted when the
   panel finished, and fourteen panels ran before timing capture was fixed. Both
   fields are left EMPTY rather than zeroed, because a zero would average like a
-  real measurement and drag every mean toward the floor.
+  real measurement and drag every mean toward the floor. The four provenance
+  columns follow the same rule for the same reason.
 
 ## panels.tsv — one row per panel
 

--- a/docs/PRIOR-ART.md
+++ b/docs/PRIOR-ART.md
@@ -40,6 +40,16 @@ naming what we did not invent.
   programming (1971) are the same principle without the GPUs. In tooling the
   pattern already ships as Claude Code's built-in `/code-review` and
   [fresh-eyes-review](https://github.com/eai-org/agent-toolkit/blob/main/skills/fresh-eyes-review/SKILL.md).
+- **Greppable check tables as reviewer input.**
+  [goshipit](https://github.com/Capta1nRaj/goshipit) (Apache-2.0) writes its
+  checks as literal patterns to look for rather than as topics —
+  `findById(req.params.id)` with no ownership filter, not "check authorization"
+  — and resolves framework-specific names once per project instead of
+  hardcoding a framework list.
+  [CHECKS-SECURITY-RELIABILITY.md](CHECKS-SECURITY-RELIABILITY.md) is adapted
+  from its category C and F tables, with severities reassigned to the rubric
+  here. That file is a reading list; it is not wired into any prompt, because
+  the review brief has to stay identical across passes to be comparable.
 - There is a whole [survey of code-review
   benchmarks](https://arxiv.org/html/2602.13377v1). Read it before believing
   anyone's novelty claim, including this one.

--- a/lib/aggregate.sh
+++ b/lib/aggregate.sh
@@ -35,9 +35,12 @@ PANELS="$OUT_D/panels.tsv"
 # specific way: the artifacts carry status and size but NOT elapsed time or the
 # dispatched prompt size, so `secs` and `prompt_bytes` are empty for them.
 # Empty, not zero -- a zero would average like a real measurement and silently
-# pull every mean toward the floor.
+# pull every mean toward the floor. The four provenance columns (#20, #37) obey
+# the same rule and for the same reason: a reconstructed row has no schema
+# version and no input hashes, and inventing either would let it compare equal
+# to a row that was actually measured.
 {
-  printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tsource\n'
+  printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tv\tprompt_sha\tadapter_sha\tharness_sha\tsource\n'
   for d in "$REVIEWS"/*/; do
     [ -d "$d" ] || continue
     p=$(basename "$d")
@@ -46,8 +49,11 @@ PANELS="$OUT_D/panels.tsv"
       # awk preserves adjacent tab fields. Bash read treats tab as IFS whitespace
       # and collapsed an empty secs field, shifting skipped prompt_bytes=0 into
       # seconds and turning the measured zero back into missing data.
+      # A panel written before the provenance columns existed simply has no $8..$11
+      # and awk yields EMPTY for each -- which is the right answer, and the one
+      # `cadre receipts` groups on. Nothing here backfills them.
       awk -F '\t' -v OFS='\t' -v panel="$p" '
-        $2 != "" { print panel, $2, $3, $4, $5, $6, $7, "recorded" }
+        $2 != "" { print panel, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, "recorded" }
       ' "$d/slots.tsv"
       continue
     fi
@@ -87,7 +93,7 @@ PANELS="$OUT_D/panels.tsv"
       fi
       bytes=0
       [ -n "$art" ] && bytes=$(wc -c < "$art" | tr -d ' ')
-      printf '%s\t%s\t%s\t%s\t%s\t\t\treconstructed\n' \
+      printf '%s\t%s\t%s\t%s\t%s\t\t\t\t\t\t\treconstructed\n' \
         "$p" "$spec" "$(spec_family "$spec")" "$st" "$bytes"
     done
   done
@@ -108,7 +114,11 @@ PANELS="$OUT_D/panels.tsv"
     did="unknown"
     [ -n "$bt" ] && [ -n "$rt" ] && did="${bt:0:8}..${rt:0:8}"
     n=0 o=0 g=0 u=0 f=0
-    while IFS=$'\t' read -r pp _s _fam st _b _sec _prompt _src; do
+    # Only $1 and $4 are used, and both sit before the first field that can be
+    # empty -- which matters, because tab is IFS WHITESPACE and a plain read
+    # collapses the empty runs further right. The trailing names are declared to
+    # match the header, not relied on.
+    while IFS=$'\t' read -r pp _s _fam st _b _sec _prompt _v _psha _asha _hsha _src; do
       [ "$pp" = "$p" ] || continue
       # A gated-off seat is retained in slots.tsv as operational provenance but
       # was never on the reviewing panel, so it cannot pad the seat denominator.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -82,28 +82,62 @@ if command -v sha256sum >/dev/null 2>&1; then SHA_CMD="sha256sum"
 elif command -v shasum >/dev/null 2>&1; then SHA_CMD="shasum -a 256"
 fi
 
-# content_sha <file>... -- 12 hex chars over the files' bytes, concatenated in
-# the order given. EMPTY if any input is missing: a hash that silently describes
-# a subset is worse than none, because it compares equal to a run that had the
-# same subset for a different reason.
+# content_sha <file>... -- 12 hex chars identifying the files' contents, in the
+# order given. EMPTY if any input is missing, unreadable, or fails to hash.
+#
+# ★ Hashes the per-file DIGESTS, not the concatenated bytes. Concatenation has
+# no field boundary, so `#a` + `x=1` and `#` + `ax=1` both hash `#ax=1` and
+# compare EQUAL -- two adapter sets that source differently, reported as one.
+# A fixed-width hex block per file cannot run into its neighbour.
+#
+# ★ And every step is checked, because the failure mode here is not a missing
+# value, it is a CONFIDENT one. `cat -- /proc/1/mem | sha256sum` exits 0 down the
+# pipe and prints e3b0c44298fc, the digest of nothing -- stable, so two runs that
+# both failed to read an input compare equal, which is the exact opposite of
+# what these fields are for. Anything short of a full read returns EMPTY.
 content_sha() {
   [ -n "$SHA_CMD" ] || return 0
-  local f
-  for f in "$@"; do [ -f "$f" ] || return 0; done
   [ "$#" -gt 0 ] || return 0
-  # shellcheck disable=SC2086  # SHA_CMD may carry an argument (shasum -a 256)
-  cat -- "$@" | $SHA_CMD | cut -c1-12
+  local f d out=""
+  for f in "$@"; do
+    [ -f "$f" ] && [ -r "$f" ] || return 0
+    # pipefail inside the substitution's own subshell, so a read error anywhere
+    # in the pipe is a refusal rather than a digest of what got through.
+    # shellcheck disable=SC2086  # SHA_CMD may carry an argument (shasum -a 256)
+    d=$(set -o pipefail; $SHA_CMD < "$f" | cut -d' ' -f1) || return 0
+    [ -n "$d" ] || return 0
+    out="$out$d"
+  done
+  # shellcheck disable=SC2086
+  printf '%s' "$out" | $SHA_CMD | cut -c1-12
 }
 
-# The adapter files that ACTUALLY load for an agent, in agentcall's order.
-# ★ BOTH, when both exist. agentcall sources the shipped file and then the user
-# one, so hashing only the override describes half of what ran -- the same
-# partial-override shape that once left a shipped noprompt_ marker alive
-# underneath a user adapter that supported prompts.
+# The files agentcall would source that define anything for this agent, in
+# agentcall's own load order: the shipped dir first, then the user dir, each
+# glob-sorted, because content_sha is order-sensitive and so is sourcing.
+#
+# ★ BOTH copies of `<agent>.sh` when both exist. agentcall sources the shipped
+# file and then the user one, so hashing only the override describes half of
+# what ran -- the same partial-override shape that once left a shipped
+# noprompt_ marker alive underneath a user adapter that supported prompts.
+#
+# ★ And NOT only the files named after the agent. agentcall sources every *.sh
+# in both dirs into ONE namespace, so a `zzz.sh` defining run_<agent>() replaces
+# the shipped function while `<agent>.sh` is untouched -- a different reviewer,
+# an identical hash. Any file mentioning `_<agent>(` is counted in.
+# Over-inclusion is the safe direction here, the same way mention-crediting is
+# in coverage-per-changeset: a hash covering too much can only produce a false
+# "this changed", never a false "this is the same".
 adapter_files() {
-  local a="$1" d
+  local a="$1" d f
   for d in "$CADRE_ROOT/agents.d" "${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}"; do
-    if [ -f "$d/$a.sh" ]; then printf '%s\n' "$d/$a.sh"; fi
+    [ -d "$d" ] || continue
+    for f in "$d"/*.sh; do
+      [ -f "$f" ] || continue
+      if [ "$f" = "$d/$a.sh" ] || grep -qF "_$a(" "$f" 2>/dev/null; then
+        printf '%s\n' "$f"
+      fi
+    done
   done
 }
 
@@ -121,7 +155,15 @@ adapter_sha() {
 # an edit. Content, not revision.
 # sort, because find's order is filesystem-dependent and an unstable input order
 # would make the same tree hash differently on two machines.
-HARNESS_FILES=(lib/common.sh lib/run-review.sh lib/run-pass.sh lib/grade.sh)
+#
+# ★ bin/agentcall is IN. It is what actually spawns the CLI, and it decides
+# whether the brief arrives on stdin or in argv -- change it and every seat
+# receives something different while nothing else in the record moves.
+# ★ bin/cadre is deliberately OUT. It is the driver: argument parsing, the
+# report, `receipts`. Folding it in would invalidate every stored comparison on
+# any CLI edit, which is a false "these are not like-for-like" -- the one error
+# this field must not make, since its whole job is to be believed when it fires.
+HARNESS_FILES=(bin/agentcall lib/common.sh lib/run-review.sh lib/run-pass.sh lib/grade.sh)
 harness_sha() {
   local f files=()
   for f in "${HARNESS_FILES[@]}"; do files+=("$CADRE_ROOT/$f"); done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1343,7 +1343,37 @@ classify_run() {
   # Same rule, one copy; the only difference is whether the truncation MARKER is
   # readable in that context. See the marker check below for why it is not.
   local f="$1" rc="$2" ctx="${3:-run}"
+  # ★ THE ADAPTER'S DECLARED STATE, ahead of every inference below (#2). Found
+  # by CONVENTION at "$f.meta" rather than passed in, because three call sites
+  # string-compare this function's result and a new parameter would have to be
+  # threaded through all of them -- the same signature rail #12 established.
+  #
+  # This is the criterion-2 half: state read as a FIELD, with the marker
+  # edge-matching below surviving as the fallback for adapters that declare
+  # nothing and for legacy artifacts already on disk.
+  #
+  # ★ The field wins over the text, and that is the whole point: text a MODEL
+  # controls can collide with text the contract reserves, and both known
+  # collisions are that shape. A synthesis asked to discuss which reviewers were
+  # truncated quotes `_TRUNCATED` and classified ITSELF as truncated; the ctx
+  # narrowing below relocated that collision onto the exact spot the prompt
+  # drives the model toward and could not remove it, because no text test can.
+  # A declared field can: the adapter writes it on a channel the model never
+  # touches, so nothing the model says can forge one.
+  # ★ ...which is also why this is checked in BOTH contexts. A synthesizer that
+  # quotes a marker still cannot self-classify, because quoting is not writing
+  # to the meta file. The ctx narrowing stays for adapters that declare nothing.
+  # ★ EMPTY still wins. An adapter that declared `ok` and then returned nothing
+  # is describing an intention, not a result, and a chrome-only artifact scored
+  # as a clean review is the worst failure in the system.
   if content_empty "$f"; then echo failed; return 0; fi
+  if [ -s "$f.meta" ]; then
+    local declared
+    declared=$(sed -n 's/^state=//p' "$f.meta" | tail -1)
+    case "$declared" in
+      ok|degraded|inconclusive|failed) echo "$declared"; return 0 ;;
+    esac
+  fi
   # ★ THE ADAPTER'S OWN VERDICT COMES FIRST, both markers together, ahead of
   # anything inferred from the text or the exit code. The adapter is the only
   # layer that watched the run; everything below this is cadre guessing from
@@ -1498,8 +1528,14 @@ retry_wait() {
 # hands each agent its own -d.
 # NOT scrubbed: CADRE_TIMEOUT (agentcall reads it from its own environment to
 # size the timeout) and CADRE_PASS_BASE (adapters need it, it is only a git rev).
+# ★ CADRE_RUN_META is on the list even though the dispatch layer sets it
+# explicitly on the agentcall command line. Scrubbing stops an OUTER environment
+# from supplying one: it names a file cadre will read a state field out of, so a
+# value arriving from outside would let a caller pre-declare the outcome of a
+# run it does not own.
 CADRE_SCRUB_ENV=(CADRE_HOME CADRE_ROOT CADRE_JUDGE CADRE_PROMPT_FILE
                  CADRE_STACK CADRE_TEST_CMD CADRE_ALLOW_SECRETS
+                 CADRE_RUN_META
                  CADRE_PASS_DIR CADRE_AGENTS_D CADRE_WORK
                  CADRE_PRERUN CADRE_PRERUN_TIMEOUT
                  CADRE_ADJUDICATOR CADRE_LEDGER CADRE_ROSTER

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -60,6 +60,84 @@ slug() {
   printf '%s-%s' "$safe" "$h"
 }
 
+
+# ---- content identity (#37) --------------------------------------------------
+# ★ A benchmark whose inputs are not pinned is not reproducible, however careful
+# the grading is. `prompt_bytes` is a SIZE: two prompts that differ but happen to
+# be the same length are indistinguishable in the record, and CADRE_PROMPT_FILE
+# replaces the brief wholesale, so the input with the largest effect on a review
+# is the one the record described least. These hashes close that.
+#
+# Scope is PROVENANCE, not tamper-proofing. A local hash cannot stop anyone
+# editing the tree; it makes a comparison across an edit visible instead of
+# silent. docs/ASSURANCE_CASE.md says so where the guarantees are listed.
+#
+# ★ Never cksum as a substitute. It is already used for slug() where a collision
+# costs a filename, but a 32-bit CRC collides often enough that "same hash" would
+# stop meaning "same bytes" -- which is the only property these fields are for.
+# No sha256 tool on the box means EMPTY, which every consumer already reads as
+# unknown; a weaker hash under the same column name would read as measured.
+SHA_CMD=""
+if command -v sha256sum >/dev/null 2>&1; then SHA_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then SHA_CMD="shasum -a 256"
+fi
+
+# content_sha <file>... -- 12 hex chars over the files' bytes, concatenated in
+# the order given. EMPTY if any input is missing: a hash that silently describes
+# a subset is worse than none, because it compares equal to a run that had the
+# same subset for a different reason.
+content_sha() {
+  [ -n "$SHA_CMD" ] || return 0
+  local f
+  for f in "$@"; do [ -f "$f" ] || return 0; done
+  [ "$#" -gt 0 ] || return 0
+  # shellcheck disable=SC2086  # SHA_CMD may carry an argument (shasum -a 256)
+  cat -- "$@" | $SHA_CMD | cut -c1-12
+}
+
+# The adapter files that ACTUALLY load for an agent, in agentcall's order.
+# ★ BOTH, when both exist. agentcall sources the shipped file and then the user
+# one, so hashing only the override describes half of what ran -- the same
+# partial-override shape that once left a shipped noprompt_ marker alive
+# underneath a user adapter that supported prompts.
+adapter_files() {
+  local a="$1" d
+  for d in "$CADRE_ROOT/agents.d" "${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}"; do
+    if [ -f "$d/$a.sh" ]; then printf '%s\n' "$d/$a.sh"; fi
+  done
+}
+
+adapter_sha() {
+  local files=()
+  mapfile -t files < <(adapter_files "$1")
+  [ "${#files[@]}" -gt 0 ] || return 0
+  content_sha "${files[@]}"
+}
+
+# One hash over every harness file that shapes a review.
+# ★ `cadre:` in the manifest is a git short sha, and it says nothing at all
+# while lib/ is dirty -- which is the normal state of the tree whenever any of
+# this is being worked on, and exactly when a comparison is most likely to span
+# an edit. Content, not revision.
+# sort, because find's order is filesystem-dependent and an unstable input order
+# would make the same tree hash differently on two machines.
+HARNESS_FILES=(lib/common.sh lib/run-review.sh lib/run-pass.sh lib/grade.sh)
+harness_sha() {
+  local f files=()
+  for f in "${HARNESS_FILES[@]}"; do files+=("$CADRE_ROOT/$f"); done
+  while IFS= read -r f; do files+=("$f"); done \
+    < <(find "$CADRE_ROOT/lib/prompts" -type f -name '*.md' -print 2>/dev/null | LC_ALL=C sort)
+  content_sha "${files[@]}"
+}
+
+# ★ slots.tsv schema version, stamped on every row THIS harness writes (#20).
+# It describes the ROW, not the run: what the columns mean and which rule
+# produced them. A row without it is not "version 1", it is UNKNOWN -- rows
+# predating this column span the #19 change to what `secs` means on a failed
+# seat, and nothing on disk can tell those halves apart after the fact. That is
+# why `cadre receipts` groups by it instead of guessing a default.
+SLOTS_SCHEMA_V=2
+
 need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed"; }
 
 trim() { local s="$1"; s="${s#"${s%%[![:space:]]*}"}"; printf '%s' "${s%"${s##*[![:space:]]}"}"; }

--- a/lib/engine/synthesize.sh
+++ b/lib/engine/synthesize.sh
@@ -173,7 +173,19 @@ and declined to flag it, which is exactly backwards.
   fi
   local rc=0
   while :; do
-    raw=$("$CADRE_ROOT/bin/agentcall" "$a" "${mm[@]}" -d /tmp -m ro < "$pf" 2>&1); rc=$?
+    # ★ The synth slot gets the declaration channel too, and it is the slot that
+    # needs it MOST (#2). A synthesis is ASKED to report which reviewers were
+    # truncated, so its own text quoting `_TRUNCATED` is the most likely
+    # legitimate answer in the system -- which is why classify_run's `ctx=synth`
+    # narrowing ignores the marker here and falls back to the exit status. That
+    # narrowing relocated the collision rather than removing it; no text test
+    # can remove it. A field the ADAPTER writes can, because quoting a marker is
+    # not calling cadre_state. Temp path for the same reason the run paths use
+    # one: $out holds every reviewer's output.
+    smetad=$(mktemp -d); smeta="$smetad/state"; rm -f "$out/.synth-tmp.meta"
+    raw=$(CADRE_RUN_META="$smeta" "$CADRE_ROOT/bin/agentcall" "$a" "${mm[@]}" -d /tmp -m ro < "$pf" 2>&1); rc=$?
+    [ -s "$smeta" ] && mv "$smeta" "$out/.synth-tmp.meta"
+    rm -rf "$smetad"
     printf '%s' "$raw" > "$out/.synth-tmp"
     # ★ The THIRD retry loop. The commit that taught the two reviewer loops to
     # stop trusting a keyword scan over the adapter left this one asking the old
@@ -198,6 +210,12 @@ and declined to flag it, which is exactly backwards.
   printf '%s' "$raw" > "$out/.synth-tmp"
   if [ "$(classify_run "$out/.synth-tmp" "$rc" synth)" != ok ]; then
     mv "$out/.synth-tmp" "$out/synthesis.md.failed"
+    # ★ Cleared only HERE and on the success path, never inside the loop. The
+    # loop deletes and re-creates .synth-tmp around the retry check, so a meta
+    # removed there would be gone before classify_run above ever read it. A
+    # stale one is prevented at the other end instead: each attempt clears it
+    # before dispatch.
+    rm -f "$out/.synth-tmp.meta"
     # ★ Third consumer of the same split (#12). The synthesizer is a model and
     # fails like one, so "the provider returned nothing" and "cadre's clock cut
     # a live merge short" are as distinguishable here as on a review -- and the
@@ -208,7 +226,7 @@ and declined to flag it, which is exactly backwards.
     echo "The individual reviews are intact in $out." >&2
     return 0
   fi
-  rm -f "$out/.synth-tmp"
+  rm -f "$out/.synth-tmp" "$out/.synth-tmp.meta"
   { echo "# Synthesis ($synth)"; echo
     echo "_Model-produced and unverified. It merges what the reviewers said; it has"
     echo "not seen the code. Read the individual reviews before acting._"; echo

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -581,7 +581,7 @@ remove that directory and re-run."
     # fallback". A pass with a record gets facts; a pass without gets the best
     # inference from filenames, and the two must not be confused for each other.
     local pass_record="$CADRE_HOME/$label/runs.jsonl" pass_runs=""
-    pass_runs=$(record_rows "$pass_record" complete run state rc secs)
+    pass_runs=$(record_rows "$pass_record" complete slug run state rc secs)
     local n
     for n in $(seq 1 "$runs"); do
       local rf="$CADRE_HOME/$label/$sl-run$n.md"
@@ -625,9 +625,24 @@ remove that directory and re-run."
         # same manufactured verdict pointed the other way. The record carries
         # `rc`, so that gap closes: a pass with a record can name a clock kill
         # at grade time, and a pass without one still declines to guess.
+        # ★ Keyed on SEAT AND RUN, and taking the LAST match. Both halves are
+        # required and each was a way to describe this artifact with somebody
+        # else's exit code:
+        #  - `runs.jsonl` lives at $CADRE_HOME/$label/ and is SHARED BY EVERY
+        #    CANDIDATE on that pass, so `run == 1` alone matches run 1 of every
+        #    seat ever benchmarked there. Grading `waffle` would read `terse`'s
+        #    rc, with no re-run involved at all.
+        #  - the record is append-only and `cadre run` re-dispatches any slot
+        #    whose .md is missing, so one seat's run 1 can hold several
+        #    completions. The artifact on disk is the LAST attempt's.
+        # Either mistake reports "TIMED OUT -- cadre's own clock killed it"
+        # about a run that simply crashed, which is the manufactured verdict #12
+        # exists to kill, arriving through the record instead of through prose.
+        # Same last-wins rail as `.meta`, for the same reason.
         local rec_rc=""
         if [ -n "$pass_runs" ]; then
-          rec_rc=$(printf '%s\n' "$pass_runs" | awk -F '\t' -v r="$n" '$1 == r { print $3; exit }')
+          rec_rc=$(printf '%s\n' "$pass_runs" |
+            awk -F '\t' -v s="$sl" -v r="$n" '$1 == s && $2 == r { v = $4 } END { print v }')
         fi
         # ★ -e, not -s. A hung provider that wrote nothing to stdout OR stderr
         # leaves run-pass.sh a 0-byte `.part` to rename, so the truest form of

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -575,6 +575,13 @@ remove that directory and re-run."
     { echo "## $label${pass_clean:+ (CLEAN - false-positive probe, no planted defects)}"; echo; } >> "$report"
 
     local items; items=$(key_items "$keyfile")
+    # ★ The pass's run record, read ONCE (#2). Empty for a pass graded before
+    # run-pass.sh wrote one, which is the legacy case the suffix-probing below
+    # still exists to serve -- criterion 2's "edge-matching survives only as a
+    # fallback". A pass with a record gets facts; a pass without gets the best
+    # inference from filenames, and the two must not be confused for each other.
+    local pass_record="$CADRE_HOME/$label/runs.jsonl" pass_runs=""
+    pass_runs=$(record_rows "$pass_record" complete run state rc secs)
     local n
     for n in $(seq 1 "$runs"); do
       local rf="$CADRE_HOME/$label/$sl-run$n.md"
@@ -612,10 +619,16 @@ remove that directory and re-run."
         # ★ "the adapter failed" was a claim, not an observation (#12). The same
         # line covered a provider that returned nothing, a live adapter killed
         # by cadre's own clock, and a real adapter crash -- and it sent the
-        # reader to the adapter for all three. The discriminator survives on
-        # disk even though the exit code does not, so failure_kind is asked
-        # WITHOUT an rc here: a no-output artifact is stated as fact, and the
-        # timeout case is left unclaimed rather than guessed at from bytes.
+        # reader to the adapter for all three.
+        # ★ #12 had to leave the TIMEOUT case unclaimed here, because the exit
+        # code was gone by grade time and guessing one from bytes would be the
+        # same manufactured verdict pointed the other way. The record carries
+        # `rc`, so that gap closes: a pass with a record can name a clock kill
+        # at grade time, and a pass without one still declines to guess.
+        local rec_rc=""
+        if [ -n "$pass_runs" ]; then
+          rec_rc=$(printf '%s\n' "$pass_runs" | awk -F '\t' -v r="$n" '$1 == r { print $3; exit }')
+        fi
         # ★ -e, not -s. A hung provider that wrote nothing to stdout OR stderr
         # leaves run-pass.sh a 0-byte `.part` to rename, so the truest form of
         # "the provider returned nothing" is the one a `-s` gate skips entirely:
@@ -624,14 +637,19 @@ remove that directory and re-run."
         # Every other artifact test in this block stays `-s` on purpose -- an
         # empty .partial or .inconclusive really is nothing to report.
         if [ -e "$rf.failed" ]; then
-          if [ "$(failure_kind "$rf.failed")" = misconfigured ]; then
-            why="MISCONFIGURED on this box, the reviewer was never called: $(misconfigured_line "$rf.failed" | cut -c1-120)"
-          elif content_empty "$rf.failed"; then
-            why="the provider returned NOTHING (no content in $sl-run$n.md.failed)"
-            no_output_runs=$((no_output_runs + 1))
-          else
-            why="the run produced output but no usable review, see $sl-run$n.md.failed"
-          fi
+          case "$(failure_kind "$rf.failed" "$rec_rc")" in
+            misconfigured)
+              why="MISCONFIGURED on this box, the reviewer was never called: $(misconfigured_line "$rf.failed" | cut -c1-120)" ;;
+            no-output)
+              why="the provider returned NOTHING (no content in $sl-run$n.md.failed)"
+              no_output_runs=$((no_output_runs + 1)) ;;
+            # Only reachable with a record: `rec_rc` is empty otherwise and
+            # failure_kind declines to claim a timeout without one.
+            timed-out)
+              why="TIMED OUT -- cadre's own clock killed it, not a verdict on the model; raise CADRE_TIMEOUT and re-run (see $sl-run$n.md.failed)" ;;
+            *)
+              why="the run produced output but no usable review, see $sl-run$n.md.failed" ;;
+          esac
           [ -s "$rf.partial" ] && why="$why (an earlier attempt stopped early, see $sl-run$n.md.partial)"
         fi
         echo "- run $n: **UNUSABLE** ($why)" >> "$report"

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -32,6 +32,13 @@ BASE="${CADRE_PASS_BASE:-HEAD~1}"
 export CADRE_PASS_BASE="$BASE"   # adapters that need it (coderabbit) read this
 
 OUT="$CADRE_HOME/$label"
+# ★ Same record shape and the same name as the panel path's (lib/run-review.sh).
+# The benchmark side had NO record at all: grade.sh reconstructed every run's
+# state by probing which suffix existed on disk -- .failed, .partial,
+# .inconclusive -- which is a state machine encoded in filenames and cannot
+# carry a duration, an exit code or a prompt size at all. One record shape for
+# both callers, so a consumer does not need to know which command produced a run.
+RUNLOG="$OUT/runs.jsonl"
 
 # Outputs must not land inside the reviewed tree or reviewer #1's findings
 # become reviewer #2's input. docs/METHOD.md §5.
@@ -118,6 +125,14 @@ for r in "${reviewers[@]}"; do
     [ -s "$f" ] && { echo "  $r run$n: already have it, skipping"; ok_runs=$((ok_runs + 1)); continue; }
     echo "  $r run$n ..."
     start=$(date +%s)
+    # Measured at dispatch, never reconstructed: the prompt is on disk now and
+    # its size cannot be recovered from an artifact later.
+    prompt_bytes=$(wc -c < "$PROMPT" 2>/dev/null | tr -d ' ')
+    # ★ Before the attempt loop, so a sweep killed mid-run still proves this run
+    # was dispatched. Same guarantee, same shape, as the panel path.
+    record_event "$RUNLOG" event=dispatch pass="$label" \
+      seat="$r" family="$(spec_family "$r")" slug="$(slug "$r")" "run#=$n" \
+      "prompt_bytes#=$prompt_bytes" "ts#=$start"
     # ★ .failed and .inconclusive, never .partial. Deleting .partial here threw
     # away real findings the moment a retry produced nothing -- the previous
     # attempt's partial review was the only copy, and this feature exists
@@ -179,7 +194,8 @@ for r in "${reviewers[@]}"; do
     # exists. ★ A degraded run is still NOT SCORED: a benchmark number is a
     # per-model claim, and a run cut short is not a fair sample of the model.
     # It is kept as .partial so the report can say WHICH kind of nothing it was.
-    case "$(classify_run "$f.part" "$rc")" in
+    state=$(classify_run "$f.part" "$rc")
+    case "$state" in
       ok)
         mv "$f.part" "$f"
         # Now, and only now, last attempt's partial is genuinely superseded.
@@ -216,6 +232,20 @@ for r in "${reviewers[@]}"; do
         esac
         echo "    $(failure_phrase "$f.failed" "$rc" "$took"), kept as $(basename "$f.failed"), not counted as a run" ;;
     esac
+
+    # ★ After the `mv`, so `bytes` describes the artifact under its final name --
+    # the same rule the panel path follows. `run` is the field the benchmark
+    # side has and the panel side does not: a pass asks the SAME seat for N
+    # runs, so seat alone does not identify a row here.
+    art="$f"
+    [ -s "$art" ] || art="$f.partial"
+    [ -s "$art" ] || art="$f.inconclusive"
+    [ -s "$art" ] || art="$f.failed"
+    run_bytes=$(wc -c < "$art" 2>/dev/null | tr -d ' ')
+    record_event "$RUNLOG" event=complete pass="$label" \
+      seat="$r" family="$(spec_family "$r")" slug="$(slug "$r")" "run#=$n" \
+      state="$state" "rc#=$rc" "secs#=$took" "bytes#=${run_bytes:-0}" \
+      "prompt_bytes#=$prompt_bytes" "attempts#=$attempt" "ts#=$(date +%s)"
 
     # Out of budget: stop this agent HERE. The remaining runs of this pass, and
     # every later pass in the sweep, would produce the same refusal. Loud, and

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -147,11 +147,16 @@ for r in "${reviewers[@]}"; do
     # exists to catch. Free tiers are the reason this loop exists, see README.
     attempt=1
     while :; do
+      # Same channel as the panel path, same reason for the temp path: $OUT
+      # holds every other run's output and the adapter must not learn it.
+      meta=$(mktemp); rm -f "$f.part.meta"
       "${SCRUB[@]}" CADRE_AGENTS_D="${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}" \
-        CADRE_PASS_BASE="$BASE" \
+        CADRE_PASS_BASE="$BASE" CADRE_RUN_META="$meta" \
         "$CADRE_ROOT/bin/agentcall" "$agent" -d "$CHECKOUT" -m ro "${m[@]}" \
         < "$PROMPT" > "$f.part" 2>&1
       rc=$?
+      [ -s "$meta" ] && mv "$meta" "$f.part.meta"
+      rm -f "$meta"
       # ★ Same order as the review path, same reason: the adapter's own verdict
       # outranks a keyword scan. A short partial that merely DISCUSSES rate
       # limiting used to drive real retries and then get cadre's own note
@@ -246,6 +251,10 @@ for r in "${reviewers[@]}"; do
       seat="$r" family="$(spec_family "$r")" slug="$(slug "$r")" "run#=$n" \
       state="$state" "rc#=$rc" "secs#=$took" "bytes#=${run_bytes:-0}" \
       "prompt_bytes#=$prompt_bytes" "attempts#=$attempt" "ts#=$(date +%s)"
+    # Same rule as the panel path: the declaration is consumed, the state lives
+    # in runs.jsonl, and a stale .meta would classify the NEXT attempt at this
+    # slot by this one's field.
+    rm -f "$f.part.meta"
 
     # Out of budget: stop this agent HERE. The remaining runs of this pass, and
     # every later pass in the sweep, would produce the same refusal. Loud, and

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -149,14 +149,15 @@ for r in "${reviewers[@]}"; do
     while :; do
       # Same channel as the panel path, same reason for the temp path: $OUT
       # holds every other run's output and the adapter must not learn it.
-      meta=$(mktemp); rm -f "$f.part.meta"
+      # Private dir, not a bare temp file: see the note in lib/run-review.sh.
+      metad=$(mktemp -d); meta="$metad/state"; rm -f "$f.part.meta"
       "${SCRUB[@]}" CADRE_AGENTS_D="${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}" \
         CADRE_PASS_BASE="$BASE" CADRE_RUN_META="$meta" \
         "$CADRE_ROOT/bin/agentcall" "$agent" -d "$CHECKOUT" -m ro "${m[@]}" \
         < "$PROMPT" > "$f.part" 2>&1
       rc=$?
       [ -s "$meta" ] && mv "$meta" "$f.part.meta"
-      rm -f "$meta"
+      rm -rf "$metad"
       # ★ Same order as the review path, same reason: the adapter's own verdict
       # outranks a keyword scan. A short partial that merely DISCUSSES rate
       # limiting used to drive real retries and then get cadre's own note

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -76,6 +76,10 @@ case "$sha" in "$have"*) ;; *) die "$CHECKOUT is at $have, not $sha" ;; esac
 secrets_preflight "$CHECKOUT"
 
 PROMPT="$OUT/prompt.txt"
+# ★ Frozen once, before the first seat goes out (#37): the same rule as the
+# panel path. Recomputing per run would describe the tree as it stands after a
+# long pass, which is exactly the difference the field exists to make visible.
+HARNESS_SHA=$(harness_sha)
 if [ -n "${CADRE_PROMPT_FILE:-}" ]; then
   cp "$CADRE_PROMPT_FILE" "$PROMPT"
 else
@@ -128,6 +132,11 @@ for r in "${reviewers[@]}"; do
     # Measured at dispatch, never reconstructed: the prompt is on disk now and
     # its size cannot be recovered from an artifact later.
     prompt_bytes=$(wc -c < "$PROMPT" 2>/dev/null | tr -d ' ')
+    # ★ EMPTY for a promptless adapter, never the hash of a prompt it did not
+    # get -- the panel path's rule, for the panel path's reason: a sha of the
+    # empty string would compare equal across every promptless seat as if they
+    # shared an input. prompt_bytes stays a measured 0 there.
+    prompt_sha=""; is_promptless "$agent" || prompt_sha=$(content_sha "$PROMPT")
     # ★ Before the attempt loop, so a sweep killed mid-run still proves this run
     # was dispatched. Same guarantee, same shape, as the panel path.
     record_event "$RUNLOG" event=dispatch pass="$label" \
@@ -251,7 +260,10 @@ for r in "${reviewers[@]}"; do
     record_event "$RUNLOG" event=complete pass="$label" \
       seat="$r" family="$(spec_family "$r")" slug="$(slug "$r")" "run#=$n" \
       state="$state" "rc#=$rc" "secs#=$took" "bytes#=${run_bytes:-0}" \
-      "prompt_bytes#=$prompt_bytes" "attempts#=$attempt" "ts#=$(date +%s)"
+      "prompt_bytes#=$prompt_bytes" "attempts#=$attempt" \
+      "v#=$SLOTS_SCHEMA_V" prompt_sha="$prompt_sha" \
+      adapter_sha="$(adapter_sha "$agent")" harness_sha="$HARNESS_SHA" \
+      "ts#=$(date +%s)"
     # Same rule as the panel path: the declaration is consumed, the state lives
     # in runs.jsonl, and a stale .meta would classify the NEXT attempt at this
     # slot by this one's field.

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -594,14 +594,23 @@ run_one() {
     # path gives an adapter somewhere to declare its state while telling it
     # nothing about where the panel lives. Moved next to the artifact afterward,
     # by cadre, so classify_run can find it by convention.
-    meta=$(mktemp); rm -f "$f.part.meta"
+    # ★ A private DIRECTORY, not a bare mktemp file. The declaration is trusted
+    # over the artifact's own text, so who can write it matters. A model with a
+    # shell runs as the SAME UID as cadre -- grok's ro mode allows bash -- and
+    # the cheap attack is a blind spray: `for f in /tmp/tmp.*; [ -w "$f" ] &&
+    # echo state=ok >> "$f"`, which upgrades a truncated review to a complete
+    # one. A directory does not match that `[ -f ]`. It is a speed bump, not a
+    # boundary: same-uid means no filesystem barrier, and a child that walks
+    # /proc/<pid>/environ can still find the path. See docs/ADDING-AN-AGENT.md --
+    # a declaration is trusted exactly as much as the adapter is.
+    metad=$(mktemp -d); meta="$metad/state"; rm -f "$f.part.meta"
     "${SCRUB[@]}" CADRE_AGENTS_D="${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}" \
       CADRE_PASS_BASE="$BASE" CADRE_RUN_META="$meta" \
       "$CADRE_ROOT/bin/agentcall" "$agent" -d "$dir" -m ro "${m[@]}" \
       < "$PROMPT" > "$f.part" 2>&1
     rc=$?
     [ -s "$meta" ] && mv "$meta" "$f.part.meta"
-    rm -f "$meta"
+    rm -rf "$metad"
     # ★ The adapter's own verdict outranks the keyword match HERE too, not only
     # inside classify_run. rate_limited() is a keyword scan over small files, so
     # a short partial review that merely DISCUSSES rate limiting drove three

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -588,11 +588,20 @@ run_one() {
     printf '%s\n%s\n' "$PROMPT_SHA" "$asha" > "$shaf"
   fi
   while :; do
+    # ★ A TEMP path, never "$f.part.meta". The meta file is handed to the
+    # adapter, and $OUT is the directory holding every other reviewer's output --
+    # the exact thing CADRE_WORK was added to the scrub list to protect. A temp
+    # path gives an adapter somewhere to declare its state while telling it
+    # nothing about where the panel lives. Moved next to the artifact afterward,
+    # by cadre, so classify_run can find it by convention.
+    meta=$(mktemp); rm -f "$f.part.meta"
     "${SCRUB[@]}" CADRE_AGENTS_D="${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}" \
-      CADRE_PASS_BASE="$BASE" \
+      CADRE_PASS_BASE="$BASE" CADRE_RUN_META="$meta" \
       "$CADRE_ROOT/bin/agentcall" "$agent" -d "$dir" -m ro "${m[@]}" \
       < "$PROMPT" > "$f.part" 2>&1
     rc=$?
+    [ -s "$meta" ] && mv "$meta" "$f.part.meta"
+    rm -f "$meta"
     # ★ The adapter's own verdict outranks the keyword match HERE too, not only
     # inside classify_run. rate_limited() is a keyword scan over small files, so
     # a short partial review that merely DISCUSSES rate limiting drove three
@@ -670,6 +679,12 @@ run_one() {
   esac
   # After the `mv`, so `bytes` describes the artifact under its final name.
   record_complete "$sl" "$spec" "$state" "$rc" "$took"
+  # ★ The declaration has done its job: classify_run read it, and runs.jsonl is
+  # where the state lives durably now. Leaving it behind would strand a `.meta`
+  # naming an artifact that has since been renamed -- and a stale declaration
+  # that outlives the run it describes is worse than none, because the next
+  # attempt at this slot would be classified by the last one's field.
+  rm -f "$f.part.meta"
   rm -rf "$dir"
 }
 

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -22,7 +22,7 @@ REPO="${1:?usage: run-review.sh <repo> <base-rev> <out-dir> <jobs> <spec ...>}"
 BASE_REV="${2-}"
 MODE=diff; [ -n "$BASE_REV" ] || MODE=target
 OUT="${3:?need an out dir}"
-# ★ NOT `.log-*`, `.status-*` or `.len-*`. Those three globs are wiped at the
+# ★ NOT `.log-*`, `.status-*`, `.len-*` or `.sha-*`. Those four globs are wiped at the
 # bottom of this file, and a record that a cleanup line can match is a record
 # that will eventually be deleted by someone extending that line. The name is
 # the enforcement. Per-panel and under $OUT, because `cadre receipts` finds
@@ -411,6 +411,14 @@ else
   render_review_prompt "$CADRE_ROOT/lib/prompts/$BRIEF" "$BASE" "$TPL" "$PRERUN_FILE" > "$PROMPT"
 fi
 
+# ★ Frozen HERE, once, before a single seat is dispatched (#37). Recomputing per
+# seat would let a mid-panel edit land in half the rows and read as two seats
+# legitimately disagreeing about the harness, which is the opposite of what the
+# field is for. Same reasoning as docs/METHOD.md's refusal to edit lib/ mid-sweep,
+# made checkable instead of asked for.
+HARNESS_SHA=$(harness_sha)
+PROMPT_SHA=$(content_sha "$PROMPT")
+
 # ★ Capability preflight BEFORE any paid call. A seat whose adapter (or model)
 # has declared it cannot do this job is skipped loudly, not dispatched. Same
 # skipped-seat path as roster gates: slots.tsv status, report line, out of
@@ -463,6 +471,11 @@ unset _kept _spec _block _decl _reason
   # would split into rows that parse as other fields.
   [ -n "$PRERUN_FILE" ] && echo "prerun:    exit $PRERUN_RC | $(printf '%s' "$CADRE_PRERUN" | tr '\n' ' ')"
   echo "prompt:    $(cksum < "$PROMPT" | cut -d' ' -f1)"
+  # ★ Content, beside the revision, not instead of it. `cadre:` is a git sha and
+  # goes stale the moment lib/ is dirty; this one changes with the bytes. Kept
+  # here as well as on every row so a panel killed before slots.tsv was written
+  # still says which harness produced its artifacts.
+  echo "harness:   ${HARNESS_SHA:-unknown}"
   echo "cadre:     $(git -C "$CADRE_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 } > "$OUT/manifest.txt"
 
@@ -485,23 +498,36 @@ mapfile -t SCRUB < <(scrubbed_env)
 # measured, and record_event turns an empty numeric into `null`. Bytes come from
 # the artifact rather than any log line, so the number always describes the file
 # that is actually on disk.
+#
+# ★ The hashes are read from the DISPATCH scratch file, not recomputed here.
+# Recomputing would describe the tree as it stands after the seat finished,
+# which on a long panel is a different tree than the one that was reviewed --
+# and the whole point of the field is to make that difference visible.
+# They are STRINGS, not `#` numerics: EMPTY means "not determined" and must stay
+# an empty field, where a numeric null would print the same but claim a measure.
 record_complete() {  # <slug> <spec> <state> [rc] [secs]
-  local sl="$1" spec="$2" state="$3" rc="${4:-}" secs="${5:-}" art bytes
+  local sl="$1" spec="$2" state="$3" rc="${4:-}" secs="${5:-}" art bytes shaf
   art="$OUT/$sl.md"
   [ -s "$art" ] || art="$OUT/$sl.md.partial"
   [ -s "$art" ] || art="$OUT/$sl.md.inconclusive"
   [ -s "$art" ] || art="$OUT/$sl.md.failed"
   bytes=$(wc -c < "$art" 2>/dev/null | tr -d ' ')
+  shaf="$OUT/.sha-$sl"
   record_event "$RUNLOG" event=complete panel="$(basename "$OUT")" \
     seat="$spec" family="$(spec_family "$spec")" slug="$sl" \
     state="$state" "rc#=$rc" "secs#=$secs" "bytes#=${bytes:-0}" \
-    "prompt_bytes#=$(cat "$OUT/.len-$sl" 2>/dev/null)" "ts#=$(date +%s)"
+    "prompt_bytes#=$(cat "$OUT/.len-$sl" 2>/dev/null)" \
+    "v#=$SLOTS_SCHEMA_V" \
+    prompt_sha="$(sed -n 1p "$shaf" 2>/dev/null)" \
+    adapter_sha="$(sed -n 2p "$shaf" 2>/dev/null)" \
+    harness_sha="$HARNESS_SHA" "ts#=$(date +%s)"
 }
 
 run_one() {
   local spec="$1" idx="$2"
   local sl; sl=$(slug "$spec")
   local f="$OUT/$sl.md" log="$OUT/.log-$sl" st="$OUT/.status-$sl" len="$OUT/.len-$sl"
+  local shaf="$OUT/.sha-$sl"
   local agent model dir attempt=1 rc w start took
   agent=$(spec_agent "$spec"); model=$(spec_model "$spec")
 
@@ -510,6 +536,14 @@ run_one() {
   # prompt. Overwrite it at the dispatch site so adapter failures still retain
   # the exact prompt size after the scratch files disappear.
   echo 0 > "$len"
+  # ★ Line 1 prompt, line 2 adapter (#37). Written BEFORE the installed check,
+  # so a seat that never runs still records which adapter file was consulted --
+  # "the adapter is missing" and "the adapter is present and broken" are
+  # different facts and the row should not need the console to tell them apart.
+  # Line 1 stays EMPTY until dispatch: the prompt this seat is charged for is
+  # the one agentcall actually receives, and a promptless adapter never receives
+  # one at all.
+  printf '\n%s\n' "$(adapter_sha "$agent")" > "$shaf"
   # ★ Recorded BEFORE anything can go wrong, which is the entire reason the log
   # is append-only rather than assembled at the end: a panel killed here leaves
   # proof this seat was dispatched. Every `return` below has a matching
@@ -543,7 +577,16 @@ run_one() {
   start=$(date +%s)
   # Promptless adapters use their own contract; zero is the exact number of
   # shared-brief bytes they send to their provider.
-  if ! is_promptless "$agent"; then wc -c < "$PROMPT" | tr -d ' ' > "$len"; fi
+  if ! is_promptless "$agent"; then
+    wc -c < "$PROMPT" | tr -d ' ' > "$len"
+    # ★ EMPTY for a promptless adapter, never the hash of a prompt it did not
+    # get. `prompt_bytes` records a measured 0 there because zero shared-brief
+    # bytes really were sent; the identity of a prompt that was never dispatched
+    # is not zero, it is unknown, and a sha of the empty string would compare
+    # equal across every promptless seat as if they shared an input.
+    local asha; asha=$(sed -n 2p "$shaf" 2>/dev/null)
+    printf '%s\n%s\n' "$PROMPT_SHA" "$asha" > "$shaf"
+  fi
   while :; do
     "${SCRUB[@]}" CADRE_AGENTS_D="${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}" \
       CADRE_PASS_BASE="$BASE" \
@@ -639,9 +682,16 @@ run_one() {
 # `secs` stays null, because nothing was timed.
 for row in "${skipped_rows[@]}"; do
   IFS=$'\t' read -r sk_spec _sk_gate _sk_reason <<< "$row"
+  # prompt_sha is EMPTY for the same reason prompt_bytes is a measured 0: the
+  # seat sent nothing, so there is no dispatched prompt to identify. The adapter
+  # and the harness are still recorded -- the gate that skipped it is a harness
+  # decision, and which version made it is exactly what a later reader asks.
   record_event "$RUNLOG" event=complete panel="$(basename "$OUT")" \
     seat="$sk_spec" family="$(spec_family "$sk_spec")" slug="$(slug "$sk_spec")" \
-    state=skipped "rc#=" "secs#=" "bytes#=0" "prompt_bytes#=0" "ts#=$(date +%s)"
+    state=skipped "rc#=" "secs#=" "bytes#=0" "prompt_bytes#=0" \
+    "v#=$SLOTS_SCHEMA_V" prompt_sha= \
+    adapter_sha="$(adapter_sha "$(spec_agent "$sk_spec")")" \
+    harness_sha="$HARNESS_SHA" "ts#=$(date +%s)"
 done
 
 i=0; running=0
@@ -809,14 +859,22 @@ slot_rows=$(
   # reasoning aggregate.sh gives for trusting the roster line over filenames.
   # A seat with no completion event prints `failed` with EMPTY secs: it did not
   # take zero seconds, it was never measured.
-  all_complete=$(record_rows "$RUNLOG" complete seat family state bytes secs prompt_bytes)
+  # ★ `v` is a CONSTANT here, not a field read back from the record (#20). It
+  # describes the ROW -- which columns these are and which rule wrote them --
+  # and this harness wrote every row below, including one for a seat that left
+  # no completion event at all. Reading it from the record would blank exactly
+  # that row and lose the provenance for the only row whose provenance is in
+  # question.
+  all_complete=$(record_rows "$RUNLOG" complete seat family state bytes secs prompt_bytes \
+                   prompt_sha adapter_sha harness_sha)
   for spec in "${reviewers[@]}"; do
     rec_row=$(printf '%s\n' "$all_complete" | awk -F '\t' -v s="$spec" '$1 == s { print; exit }')
     rec_row="${rec_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt <<< "$rec_row"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt r_psha r_asha r_hsha <<< "$rec_row"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
       "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
-      "${r_state:-failed}" "${r_bytes:-0}" "$r_secs" "$r_prompt"
+      "${r_state:-failed}" "${r_bytes:-0}" "$r_secs" "$r_prompt" \
+      "$SLOTS_SCHEMA_V" "$r_psha" "$r_asha" "${r_hsha:-$HARNESS_SHA}"
   done
   # Skipped seats come from the same stream, for the same reason: one source, so
   # a change to how spend is recorded cannot land in one renderer and not the
@@ -826,10 +884,11 @@ slot_rows=$(
     IFS=$'\t' read -r spec _gate _reason <<< "$row"
     rec_row=$(printf '%s\n' "$all_complete" | awk -F '\t' -v s="$spec" '$1 == s { print; exit }')
     rec_row="${rec_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt <<< "$rec_row"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt r_psha r_asha r_hsha <<< "$rec_row"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
       "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
-      "${r_state:-skipped}" "${r_bytes:-0}" "$r_secs" "${r_prompt:-0}"
+      "${r_state:-skipped}" "${r_bytes:-0}" "$r_secs" "${r_prompt:-0}" \
+      "$SLOTS_SCHEMA_V" "$r_psha" "$r_asha" "${r_hsha:-$HARNESS_SHA}"
   done
 )
 printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
@@ -848,7 +907,7 @@ printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
     # Tabs are IFS whitespace, so plain `read` collapses the empty secs field in
     # a skipped row. Translate to a non-whitespace delimiter before splitting.
     slot_row="${slot_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _run spec _fam st bytes secs prompt_bytes <<< "$slot_row"
+    IFS=$'\034' read -r _run spec _fam st bytes secs prompt_bytes _v _psha _asha _hsha <<< "$slot_row"
     prompt_kb=""
     if [ -n "${prompt_bytes:-}" ]; then
       prompt_kb=$(awk -v n="$prompt_bytes" 'BEGIN { printf "%.1f", n / 1024 }')
@@ -872,7 +931,7 @@ printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
   echo "> Estimated as bytes/4 of what the harness sent and received. Hidden reasoning tokens are invisible from outside the CLI and are NOT in this number: a seat that thinks long and answers short costs more than its row shows. This is a relative-spend signal, not a bill."
 } >> "$REPORT"
 
-rm -f "$OUT"/.log-* "$OUT"/.status-* "$OUT"/.len-*
+rm -f "$OUT"/.log-* "$OUT"/.status-* "$OUT"/.len-* "$OUT"/.sha-*
 echo
 skipped_count=${#skipped_rows[@]}
 if [ "$skipped_count" -gt 0 ]; then

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -1951,6 +1951,54 @@ check "sha: order changes the hash"  "[ \"\$(content_sha '$CS/a' '$CS/b')\" != \
 # reason, so it reads as agreement where there is none.
 check "sha: a missing input is EMPTY" "[ -z \"\$(content_sha '$CS/a' '$CS/nope')\" ]"
 check "sha: no input at all is EMPTY" "[ -z \"\$(content_sha)\" ]"
+# ★ The worst shape this function can produce is not a missing value, it is a
+# CONFIDENT one. The first cut piped `cat -- "$@"` into sha256sum: cat printed
+# "Permission denied" to stderr, the pipe exited 0, and the digest of NOTHING
+# came back -- e3b0c44298fc, which is STABLE, so two runs that both failed to
+# read an input compared EQUAL. Every happy-path check above passed while that
+# held; a second-opinion reviewer found it.
+printf 'secret' > "$CS/locked"; chmod 000 "$CS/locked"
+check "sha: an unreadable input is EMPTY" "[ -z \"\$(content_sha '$CS/locked' 2>/dev/null)\" ]"
+check "sha: never the digest of nothing"  "! content_sha '$CS/locked' 2>/dev/null | grep -q e3b0c44298fc"
+check "sha: a directory is EMPTY"         "[ -z \"\$(content_sha '$CS' 2>/dev/null)\" ]"
+chmod 644 "$CS/locked"
+# ★ Concatenating raw bytes has no field boundary, so '#a' + 'x=1' and '#' +
+# 'ax=1' are both '#ax=1' and hash IDENTICALLY -- two adapter sets that source
+# to different code, reported as one input. Hashing the per-file digests gives
+# every file a fixed-width block that cannot run into its neighbour.
+printf '#a' > "$CS/c1"; printf 'x=1' > "$CS/c2"; printf '#' > "$CS/c3"; printf 'ax=1' > "$CS/c4"
+check "sha: file boundaries are kept" \
+  "[ \"\$(content_sha '$CS/c1' '$CS/c2')\" != \"\$(content_sha '$CS/c3' '$CS/c4')\" ]"
+
+# ---- what the harness hash covers (#37) --------------------------------------
+# ★ bin/agentcall is what spawns the CLI and decides whether the brief arrives
+# on stdin or in argv. Left out of the set, an agentcall edit changes what every
+# seat receives while prompt_sha, adapter_sha and harness_sha all hold still.
+check "harness: agentcall is hashed"     "printf '%s\n' \"\${HARNESS_FILES[@]}\" | grep -qx 'bin/agentcall'"
+# ★ ...and bin/cadre is deliberately NOT. It is the driver -- argument parsing,
+# the report, receipts -- and folding it in would invalidate every stored
+# comparison on any CLI edit. A field whose whole job is to be believed when it
+# fires must not fire on that.
+check "harness: bin/cadre is left out"   "! printf '%s\n' \"\${HARNESS_FILES[@]}\" | grep -qx 'bin/cadre'"
+check "harness: every named file exists" "for f in \"\${HARNESS_FILES[@]}\"; do [ -f '$ROOT'/\$f ] || exit 1; done"
+
+# ---- the adapter namespace, not just the adapter file (#37) ------------------
+# ★ agentcall sources EVERY *.sh in both dirs into ONE namespace, so a foreign
+# `zzz.sh` defining run_<agent>() replaces the shipped function while
+# <agent>.sh is byte-identical: a different reviewer behind an unchanged hash.
+# The per-adapter check further up passed the entire time this was live.
+AD=$(mktemp -d -p "$SANDBOX"); mkdir -p "$AD/agents.d"
+printf 'run_probe() { echo shipped; }\n' > "$AD/agents.d/probe.sh"
+ASHA_BASE=$(CADRE_ROOT="$ROOT" CADRE_AGENTS_D="$AD/agents.d" adapter_sha probe)
+printf 'run_probe() { echo hijacked; }\n' > "$AD/agents.d/zzz.sh"
+ASHA_HIJ=$(CADRE_ROOT="$ROOT" CADRE_AGENTS_D="$AD/agents.d" adapter_sha probe)
+check "adapter hash sees a foreign override" "[ -n '$ASHA_BASE' ] && [ '$ASHA_BASE' != '$ASHA_HIJ' ]"
+# ★ ...and stays put for an adapter that cannot touch this seat. Hashing the
+# whole directory would close the hole above and break this, which is why
+# membership is "mentions _<agent>(" rather than "is in agents.d".
+printf 'run_other() { echo unrelated; }\n' > "$AD/agents.d/zzz.sh"
+ASHA_OTHER=$(CADRE_ROOT="$ROOT" CADRE_AGENTS_D="$AD/agents.d" adapter_sha probe)
+check "and ignores an unrelated adapter"     "[ '$ASHA_BASE' = '$ASHA_OTHER' ]"
 
 RJ=$(mktemp -d -p "$SANDBOX"); RL="$RJ/runs.jsonl"
 record_event "$RL" event=complete seat='codex:gpt-5.5' "secs#=12" "rc#=0"
@@ -2116,6 +2164,21 @@ check "harness: both are named"        "grep -q '111111111111, 222222222222' <<<
 printf 'r3\tc\topenai\tok\t10\t1\t10\t2\tpppppppppppp\taaaaaaaaaaaa\t111111111111\n' > "$RF/harness/slots.tsv"
 OUT=$(run_cadre "$D" receipts "$RF/harness")
 check "harness: agreement is stated"   "grep -q 'every row ran against 111111111111' <<<\"\$OUT\""
+
+# ★ receipts takes ANY directory, and a stale `cadre dataset` output dir is a
+# directory. The dataset written by the old lib/aggregate.sh puts `source` in
+# column 8 -- exactly where the schema version now lives -- so `recorded` and
+# `reconstructed` came back as two schema NAMES and split every family in the
+# table. Column 8 is a version only when it reads as one.
+mkdir -p "$RF/olddataset"
+printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tsource\n' > "$RF/olddataset/slots.tsv"
+printf 'p1\tc\topenai\tok\t100\t2\t200\trecorded\n' >> "$RF/olddataset/slots.tsv"
+printf 'p2\tc\topenai\tok\t100\t\t\treconstructed\n' >> "$RF/olddataset/slots.tsv"
+OUT=$(run_cadre "$D" receipts "$RF/olddataset")
+check "olddata: one row, not one per source"  "[ \$(awk '\$1 == \"openai\"' <<<\"\$OUT\" | wc -l) -eq 1 ]"
+check "olddata: the schema reads unknown"     "awk '\$1 == \"openai\" && \$13 == \"?\" { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "olddata: a source word is never a schema" "! awk '\$13 == \"recorded\" || \$13 == \"reconstructed\" { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "olddata: both rows still counted"      "awk '\$1 == \"openai\" && \$3 == 2 { f=1 } END { exit !f }' <<<\"\$OUT\""
 
 echo "== ★ settled-decisions ledger =="
 # ★ The loop-breaker. Cadre reviews once, but anything that WRAPS it re-raises

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -3447,8 +3447,7 @@ R=$(ls "$D/home"/report-*.md | head -1)
 check "cost: partial denominator named" \
   "grep -qE 'est\. tokens per blocking item hit: \*\*[0-9]+\*\* \(partial denominator\)' '$R'"
 
-# ============================================================================
-# coverage-per-changeset (#5): what the reviewer never looked at.
+# =====================================================================# coverage-per-changeset (#5): what the reviewer never looked at.
 # ============================================================================
 
 # ---- unit tests on the helpers (grade.sh is already sourced above, line ~542),
@@ -4200,6 +4199,62 @@ FJ="$D/state/reviews/one/findings.json"
 check "one: findings.json written"      "[ -s '$FJ' ]"
 check "one: status says skipped"        "[ \"\$(jq -r .synthesis.status '$FJ')\" = 'skipped' ]"
 check "one: claims survived"            "[ \$(jq '.claims | length' '$FJ') -eq 4 ]"
+=======
+
+# ============================================================================
+# #2: the benchmark path gets the same record the panel path has.
+# ============================================================================
+# ★ grade.sh used to reconstruct every run's state by probing which suffix
+# existed on disk -- a state machine encoded in filenames, which cannot carry a
+# duration, an exit code or a prompt size at all.
+echo "== ★ #2: the benchmark run record =="
+DB=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DB" terse "$HITBOTH" "$HITBOTH"
+SLB2=$(slug terse)
+rm -f "$DB/home/p1/$SLB2-run1.md"            # make the agent actually run
+run_gaunt "$DB" good,good2 terse >/dev/null 2>&1 || true
+BREC="$DB/home/p1/runs.jsonl"
+check "bench: a record is written"     "[ -s '$BREC' ]"
+check "bench: dispatch before complete" \
+  "[ \$(grep -n dispatch '$BREC' | head -1 | cut -d: -f1) -lt \$(grep -n complete '$BREC' | tail -1 | cut -d: -f1) ]"
+check "bench: state is a field"        "grep -q '\"state\":\"ok\"' '$BREC'"
+# ★ `run` is the field the benchmark side needs and the panel side does not: one
+# pass asks the SAME seat for N runs, so seat alone does not identify a row.
+check "bench: the run index is recorded" "grep -q '\"run\":1' '$BREC'"
+check "bench: rc is recorded"          "grep -qE '\"rc\":[0-9]+' '$BREC'"
+check "bench: attempts are recorded"   "grep -qE '\"attempts\":[0-9]+' '$BREC'"
+check "bench: prompt size is recorded, not reconstructed" \
+  "grep -qE '\"prompt_bytes\":[1-9][0-9]*' '$BREC'"
+check "bench: reader round-trips the state" \
+  "[ \"\$(record_rows '$BREC' complete run state | awk -F'\t' '\$1==1{print \$2}')\" = ok ]"
+
+# ★ THE gap #12 had to leave open. At grade time the exit code was gone, so a
+# clock kill and an ordinary crash read identically and #12 deliberately refused
+# to guess one from bytes. The record carries rc, so a pass WITH a record can
+# name the timeout -- and a pass WITHOUT one must still refuse.
+DT2=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DT2" terse "$HITBOTH" "$HITBOTH"
+rm -f "$DT2/home/p1/$SLB2-run1.md"
+printf 'a reviewer thinking out loud before the clock got it\n' > "$DT2/home/p1/$SLB2-run1.md.failed"
+printf '{"event":"complete","pass":"p1","seat":"terse","run":1,"state":"failed","rc":124,"secs":900}\n' \
+  > "$DT2/home/p1/runs.jsonl"
+OUTT=$(CADRE_HOME="$DT2/home" CADRE_WORK="$DT2/work" CADRE_AGENTS_D="$DT2/agents.d" \
+  CADRE_JUDGE=good,good2 PATH="$DT2/bin:$PATH" "$ROOT/bin/cadre" grade terse 1 p1 2>&1 || true)
+RT2=$(ls "$DT2/home"/report-*.md | head -1)
+check "bench: a recorded rc names the timeout at grade time" \
+  "grep -q 'TIMED OUT' '$RT2'"
+check "bench: and says it is not a verdict on the model" \
+  "grep -q \"cadre's own clock killed it\" '$RT2'"
+
+# ★ The legacy half of the same criterion: a pass with NO record still grades,
+# and still declines to claim a timeout it cannot know about. Identical
+# artifact, no runs.jsonl.
+DL=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DL" terse "$HITBOTH" "$HITBOTH"
+rm -f "$DL/home/p1/$SLB2-run1.md"
+printf 'a reviewer thinking out loud before the clock got it\n' > "$DL/home/p1/$SLB2-run1.md.failed"
+OUTL=$(CADRE_HOME="$DL/home" CADRE_WORK="$DL/work" CADRE_AGENTS_D="$DL/agents.d" \
+  CADRE_JUDGE=good,good2 PATH="$DL/bin:$PATH" "$ROOT/bin/cadre" grade terse 1 p1 2>&1 || true)
+RL=$(ls "$DL/home"/report-*.md | head -1)
+check "bench: no record => no timeout claimed"  "! grep -q 'TIMED OUT' '$RL'"
+check "bench: legacy pass still names the run"  "grep -q 'produced output but no usable review' '$RL'"
 
 echo
 echo "$PASS passed, $FAIL failed"

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -4256,6 +4256,110 @@ RL=$(ls "$DL/home"/report-*.md | head -1)
 check "bench: no record => no timeout claimed"  "! grep -q 'TIMED OUT' '$RL'"
 check "bench: legacy pass still names the run"  "grep -q 'produced output but no usable review' '$RL'"
 
+# ============================================================================
+# #2 criterion 2: the adapter DECLARES its state, out of band.
+# ============================================================================
+# ★ The only channel used to be a marker in the review text, which cadre
+# edge-matched back out -- and text a MODEL controls can collide with text the
+# contract reserves. Both known collisions are that shape.
+echo "== ★ #2: state as a declared field =="
+MD=$(mktemp -d -p "$SANDBOX")
+printf 'a fluent review with findings\nVerdict: ship it\n' > "$MD/art"
+
+check "meta: no declaration => the text still decides" \
+  "[ \$(classify_run '$MD/art' 0) = ok ]"
+printf 'state=degraded\n' > "$MD/art.meta"
+check "meta: a declared state outranks the text" \
+  "[ \$(classify_run '$MD/art' 0) = degraded ]"
+# ★ ...including against the EXIT CODE, which is the case the marker contract
+# already privileged: an adapter that stopped early and also exited nonzero.
+check "meta: it outranks a nonzero exit too" \
+  "[ \$(classify_run '$MD/art' 1) = degraded ]"
+
+# ★ THE collision this criterion exists to kill. A synthesis is ASKED to say
+# which reviewers were truncated, so its own text quoting the marker is the most
+# likely legitimate answer in the system -- and no text test can tell that from
+# a real truncation. Quoting is not declaring.
+printf 'The codex seat stopped early:\n_TRUNCATED, it was killed at the timeout._\nVerdict: ship it\n' \
+  > "$MD/quoted"
+check "meta: quoting a marker is not declaring a state" \
+  "[ \$(classify_run '$MD/quoted' 0 synth) = ok ]"
+printf 'state=degraded\n' > "$MD/quoted.meta"
+check "meta: but the adapter can still declare one" \
+  "[ \$(classify_run '$MD/quoted' 0 synth) = degraded ]"
+
+# ★ EMPTY still wins. An adapter that declared `ok` and returned nothing is
+# describing an intention, not a result -- and a chrome-only artifact scored as
+# a clean review is the worst failure in the system.
+printf '\033[0m\n   \n' > "$MD/empty"; printf 'state=ok\n' > "$MD/empty.meta"
+check "meta: a declaration cannot rescue an empty artifact" \
+  "[ \$(classify_run '$MD/empty' 0) = failed ]"
+
+# ★ A typo must not silently become a state. Falling back is the safe direction:
+# a wrong FIELD outranks the text and would be believed.
+printf 'state=nonsense\n' > "$MD/art.meta"
+check "meta: an unknown state falls back to the text" \
+  "[ \$(classify_run '$MD/art' 0) = ok ]"
+# Last declaration wins, so an adapter that revises itself is not ambiguous.
+printf 'state=failed\nstate=degraded\n' > "$MD/art.meta"
+check "meta: the last declaration wins" \
+  "[ \$(classify_run '$MD/art' 0) = degraded ]"
+
+# ---- the channel, end to end -----------------------------------------------
+# ★ An adapter that calls cadre_state must reach classify_run, and the state it
+# declares must be the one recorded. `terse` returns a valid short review, so
+# without the declaration this run would be `ok` -- the assertion is that the
+# declaration, not the text, decided.
+DD=$(case_dir declared)
+cat > "$DD/agents.d/declarer.sh" <<'A'
+run_declarer() {
+  cadre_state degraded "caught its own stopReason"
+  echo "a partial finding, and no marker anywhere in this text"
+}
+A
+printf '#!/bin/sh\nexit 0\n' > "$DD/bin/declarer"; chmod +x "$DD/bin/declarer"
+git -C "$DD/src" checkout -qb feature
+echo committed >> "$DD/src/app.js"; git -C "$DD/src" commit -qam feat
+OUTD=$(run_cadre "$DD" review --roster declarer --synth none --base main --label dc "$DD/src")
+RD="$DD/state/reviews/dc"
+check "meta: the declared state reaches the record" \
+  "grep -q '\"state\":\"degraded\"' '$RD/runs.jsonl'"
+check "meta: and the artifact is filed as partial" \
+  "ls '$RD'/declarer*.md.partial >/dev/null 2>&1"
+check "meta: text alone would have said ok" \
+  "! grep -q '_TRUNCATED' '$RD'/declarer*.md.partial"
+# ★ Consumed, not left behind. A .meta outliving its run would classify the NEXT
+# attempt at that slot by this one's field.
+check "meta: the declaration does not outlive the run" \
+  "! ls '$RD'/*.meta >/dev/null 2>&1"
+
+# ★ The path handed to the adapter must not be inside the panel directory. $OUT
+# holds every other reviewer's output, which is what CADRE_WORK was added to the
+# scrub list to protect; a writable path into it would route straight around
+# that. The adapter echoes what it was given.
+cat > "$DD/agents.d/peeker.sh" <<'A'
+run_peeker() {
+  echo "META_WAS=${CADRE_RUN_META:-unset}"
+  echo "Verdict: ship it"
+}
+A
+printf '#!/bin/sh\nexit 0\n' > "$DD/bin/peeker"; chmod +x "$DD/bin/peeker"
+OUTP=$(run_cadre "$DD" review --roster peeker --synth none --base main --label pk "$DD/src")
+RP="$DD/state/reviews/pk"
+check "meta: the adapter does get a channel" \
+  "grep -q 'META_WAS=/' '$RP'/peeker*.md"
+check "meta: and it is NOT inside the panel dir" \
+  "! grep -q \"META_WAS=\$RP\" '$RP'/peeker*.md"
+
+# ★ agentcall standing alone must not require cadre to be driving it. With no
+# CADRE_RUN_META in the environment, cadre_state is a no-op that cannot fail.
+STANDALONE=$(CADRE_AGENTS_D="$DD/agents.d" PATH="$DD/bin:$PATH" \
+  "$ROOT/bin/agentcall" declarer -d "$DD/src" hi 2>&1)
+check "meta: cadre_state is a no-op outside cadre" \
+  "grep -q 'a partial finding' <<<\"\$STANDALONE\""
+check "meta: and it says nothing on the way through" \
+  "! grep -qi 'cadre_state\|CADRE_RUN_META' <<<\"\$STANDALONE\""
+
 echo
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -4234,7 +4234,7 @@ check "bench: reader round-trips the state" \
 DT2=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DT2" terse "$HITBOTH" "$HITBOTH"
 rm -f "$DT2/home/p1/$SLB2-run1.md"
 printf 'a reviewer thinking out loud before the clock got it\n' > "$DT2/home/p1/$SLB2-run1.md.failed"
-printf '{"event":"complete","pass":"p1","seat":"terse","run":1,"state":"failed","rc":124,"secs":900}\n' \
+printf '{"event":"complete","pass":"p1","seat":"terse","slug":"%s","run":1,"state":"failed","rc":124,"secs":900}\n' "$SLB2" \
   > "$DT2/home/p1/runs.jsonl"
 OUTT=$(CADRE_HOME="$DT2/home" CADRE_WORK="$DT2/work" CADRE_AGENTS_D="$DT2/agents.d" \
   CADRE_JUDGE=good,good2 PATH="$DT2/bin:$PATH" "$ROOT/bin/cadre" grade terse 1 p1 2>&1 || true)
@@ -4255,6 +4255,42 @@ OUTL=$(CADRE_HOME="$DL/home" CADRE_WORK="$DL/work" CADRE_AGENTS_D="$DL/agents.d"
 RL=$(ls "$DL/home"/report-*.md | head -1)
 check "bench: no record => no timeout claimed"  "! grep -q 'TIMED OUT' '$RL'"
 check "bench: legacy pass still names the run"  "grep -q 'produced output but no usable review' '$RL'"
+
+# ★ The record is APPEND-ONLY and `cadre run` re-dispatches a run whose .md is
+# missing, so two invocations of the same failing run leave TWO completions for
+# it. Taking the first would describe the artifact on disk with an earlier
+# attempt's exit code -- a run that timed out once and crashed the next time
+# would be reported "TIMED OUT, cadre's own clock killed it" about the crash.
+# The manufactured verdict #12 exists to kill, arriving through the record.
+DS=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DS" terse "$HITBOTH" "$HITBOTH"
+rm -f "$DS/home/p1/$SLB2-run1.md"
+printf 'a reviewer that crashed outright\n' > "$DS/home/p1/$SLB2-run1.md.failed"
+{ printf '{"event":"complete","pass":"p1","seat":"terse","slug":"%s","run":1,"state":"failed","rc":124,"secs":900}\n' "$SLB2"
+  printf '{"event":"complete","pass":"p1","seat":"terse","slug":"%s","run":1,"state":"failed","rc":1,"secs":3}\n' "$SLB2"
+} > "$DS/home/p1/runs.jsonl"
+OUTS=$(CADRE_HOME="$DS/home" CADRE_WORK="$DS/work" CADRE_AGENTS_D="$DS/agents.d" \
+  CADRE_JUDGE=good,good2 PATH="$DS/bin:$PATH" "$ROOT/bin/cadre" grade terse 1 p1 2>&1 || true)
+RS2=$(ls "$DS/home"/report-*.md | head -1)
+check "bench: the LAST completion wins, not the first" "! grep -q 'TIMED OUT' '$RS2'"
+check "bench: and the crash is described as one" \
+  "grep -q 'produced output but no usable review' '$RS2'"
+
+# ★ The half that last-match does NOT fix, and the worse one: runs.jsonl lives
+# at $CADRE_HOME/<label>/ and is SHARED BY EVERY CANDIDATE benchmarked on that
+# pass. Keyed on run index alone, `run == 1` matches run 1 of every seat that
+# ever ran there -- so grading one candidate reads another's exit code, with no
+# re-run involved at all. Here the OTHER seat's row is the last one in the file,
+# so a last-match-without-a-seat-filter still gets it wrong.
+DX2=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DX2" terse "$HITBOTH" "$HITBOTH"
+rm -f "$DX2/home/p1/$SLB2-run1.md"
+printf 'this seat crashed outright\n' > "$DX2/home/p1/$SLB2-run1.md.failed"
+{ printf '{"event":"complete","pass":"p1","seat":"terse","slug":"%s","run":1,"state":"failed","rc":1,"secs":3}\n' "$SLB2"
+  printf '{"event":"complete","pass":"p1","seat":"waffle","slug":"%s","run":1,"state":"failed","rc":124,"secs":900}\n' "$(slug waffle)"
+} > "$DX2/home/p1/runs.jsonl"
+OUTX2=$(CADRE_HOME="$DX2/home" CADRE_WORK="$DX2/work" CADRE_AGENTS_D="$DX2/agents.d" \
+  CADRE_JUDGE=good,good2 PATH="$DX2/bin:$PATH" "$ROOT/bin/cadre" grade terse 1 p1 2>&1 || true)
+RX2=$(ls "$DX2/home"/report-*.md | head -1)
+check "bench: another seat's rc is not borrowed" "! grep -q 'TIMED OUT' '$RX2'"
 
 # ============================================================================
 # #2 criterion 2: the adapter DECLARES its state, out of band.
@@ -4326,8 +4362,15 @@ check "meta: the declared state reaches the record" \
   "grep -q '\"state\":\"degraded\"' '$RD/runs.jsonl'"
 check "meta: and the artifact is filed as partial" \
   "ls '$RD'/declarer*.md.partial >/dev/null 2>&1"
-check "meta: text alone would have said ok" \
+# ★ Names the ACTUAL baseline. This asserted "text alone would have said ok",
+# which was wrong: that artifact states no findings and no verdict, so without
+# the declaration classify_run would have called it `inconclusive`. Either way
+# the declaration decided -- but a test that misnames what it is comparing
+# against is a test nobody can check.
+check "meta: no marker in the text at all" \
   "! grep -q '_TRUNCATED' '$RD'/declarer*.md.partial"
+check "meta: and without the .meta that text is inconclusive, not degraded" \
+  "[ \$(classify_run '$RD'/declarer*.md.partial 0) = inconclusive ]"
 # ★ Consumed, not left behind. A .meta outliving its run would classify the NEXT
 # attempt at that slot by this one's field.
 check "meta: the declaration does not outlive the run" \
@@ -4350,6 +4393,52 @@ check "meta: the adapter does get a channel" \
   "grep -q 'META_WAS=/' '$RP'/peeker*.md"
 check "meta: and it is NOT inside the panel dir" \
   "! grep -q \"META_WAS=\$RP\" '$RP'/peeker*.md"
+
+# ★ THE containment claim, which the peeker above cannot make: an adapter is a
+# function inside agentcall, so it is on the ALLOWED side of the boundary. What
+# must not see CADRE_RUN_META is the CLI the adapter spawns. This stub binary
+# prints its own environment, which is the only place that boundary is visible.
+cat > "$DD/bin/envdump" <<'B'
+#!/bin/sh
+env | grep -c '^CADRE_RUN_META=' || true
+B
+chmod +x "$DD/bin/envdump"
+cat > "$DD/agents.d/envdump.sh" <<'A'
+run_envdump() {
+  echo "SPAWNED_SAW=$(envdump)"
+  echo "ADAPTER_SAW=${CADRE_RUN_META:+yes}"
+  echo "Verdict: ship it"
+}
+A
+OUTE=$(run_cadre "$DD" review --roster envdump --synth none --base main --label ev "$DD/src")
+RE2="$DD/state/reviews/ev"
+# Guards the assertion itself: if the adapter never saw it either, the next
+# check would pass while proving nothing about the boundary.
+check "meta: the adapter itself DOES see it"   "grep -q 'ADAPTER_SAW=yes' '$RE2'/envdump*.md"
+check "meta: the spawned CLI does NOT"         "grep -q 'SPAWNED_SAW=0' '$RE2'/envdump*.md"
+
+# ★ The synth slot gets the channel too, and it is the slot the doc uses as its
+# motivating example: a synthesis quoting `_TRUNCATED` cannot be told from a
+# real truncation by any text test, which is why ctx=synth ignores the marker.
+# Without this wiring `cadre_state` would be a no-op in exactly the seat that
+# needs it most.
+cat > "$DD/agents.d/synthdecl.sh" <<'A'
+run_synthdecl() {
+  cadre_state failed "the merge never completed"
+  echo "a merged review that looks perfectly fine"
+}
+A
+printf '#!/bin/sh\nexit 0\n' > "$DD/bin/synthdecl"; chmod +x "$DD/bin/synthdecl"
+# Two seats: a synthesis of one review is skipped as pointless, so a one-seat
+# roster would leave the synth adapter never dispatched.
+OUTSD=$(run_cadre "$DD" review --roster good,good2 --synth synthdecl --base main --label sd "$DD/src" 2>&1)
+RSD="$DD/state/reviews/sd"
+check "meta: a synth adapter can declare failure" \
+  "grep -q 'synthesis' <<<\"\$OUTSD\" && [ ! -s '$RSD/synthesis.md' ]"
+check "meta: the declared failure is kept as .failed" \
+  "[ -s '$RSD/synthesis.md.failed' ]"
+check "meta: and the declaration does not outlive it" \
+  "[ ! -e '$RSD/.synth-tmp.meta' ]"
 
 # ★ agentcall standing alone must not require cadre to be driving it. With no
 # CADRE_RUN_META in the environment, cadre_state is a no-op that cannot fail.

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -423,7 +423,7 @@ OUT=$(run_cadre "$D" review --roster 'good ?min-lines=2' --base main "$S"); RC=$
 R="$D/state/reviews/$(ls "$D/state/reviews" | head -1)"
 check "gate: below threshold exits clean" "[ $RC -eq 0 ]"
 check "gate: skip is loud in report"      "grep -qF -- '- \`good\` — SKIPPED by its roster gate (?min-lines=2: diff is 1 lines).' '$R/report.md'"
-check "gate: skipped slot has zero spend" "grep -qP '\tgood\t.*\tskipped\t0\t\t0\$' '$R/slots.tsv'"
+check "gate: skipped slot has zero spend" "grep -qP '\tgood\t.*\tskipped\t0\t\t0\t2\t' '$R/slots.tsv'"
 check "gate: receipt keeps empty seconds"  "grep -qF '| \`good\` | skipped |  | 0.0 | 0.0 | 0 |' '$R/report.md'"
 check "gate: console counts the skip"      "grep -q '0 ok, 0 degraded, 0 inconclusive, 0 failed, 1 skipped' <<<\"\$OUT\""
 check "gate: no prompt reached the seat"   "[ ! -e '$R/good.md' ]"
@@ -506,7 +506,7 @@ R="$D/state/reviews/$(ls "$D/state/reviews" | head -1)"
 check "cap: blocked seat exits clean"   "[ $RC -eq 0 ]"
 check "cap: skip names declaration"     "grep -qF -- '- \`refuses\` — SKIPPED by capability preflight (role:reviewer:' '$R/report.md'"
 check "cap: reason is in the report"    "grep -q 'declared unable to serve as a reviewer' '$R/report.md'"
-check "cap: skipped slot has zero spend" "grep -qP '\trefuses\t.*\tskipped\t0\t\t0\$' '$R/slots.tsv'"
+check "cap: skipped slot has zero spend" "grep -qP '\trefuses\t.*\tskipped\t0\t\t0\t2\t' '$R/slots.tsv'"
 check "cap: no prompt reached the seat" "[ ! -e '$R'/refuses-*.md ] && [ -z \"\$(ls '$R'/refuses-* 2>/dev/null)\" ]"
 check "cap: sibling seat still ran"     "grep -qP '\tgood\t.*\tok\t' '$R/slots.tsv'"
 check "cap: console counts the skip"    "grep -q '1 ok, 0 degraded, 0 inconclusive, 0 failed, 1 skipped' <<<\"\$OUT\""
@@ -541,7 +541,7 @@ OUT=$(CADRE_STACK='Please run a full security audit of this codebase for vulnera
   run_cadre "$D" review --roster audithate --label audit2 --base main "$S")
 R="$D/state/reviews/audit2"
 check "cap: audit-shaped stack blocks" "grep -qF 'SKIPPED by capability preflight (prompt:security-audit:' '$R/report.md'"
-check "cap: audit skip in slots.tsv"   "grep -qP '\taudithate\t.*\tskipped\t0\t\t0\$' '$R/slots.tsv'"
+check "cap: audit skip in slots.tsv"   "grep -qP '\taudithate\t.*\tskipped\t0\t\t0\t2\t' '$R/slots.tsv'"
 
 # Model-keyed: cerebras/* is role:reviewer-only. Any adapter:cerebras/... is
 # blocked as a reviewer and accepted as a judge.
@@ -1882,7 +1882,7 @@ check "it survives the cleanup"     "[ ! -e '$R/.status-good' ]"
 check "one row per roster seat"     "[ \$(wc -l < '$R/slots.tsv') -eq 2 ]"
 check "a good seat is ok"           "grep -qP '\tgood\t.*\tok\t' '$R/slots.tsv'"
 check "a dead seat is failed"       "grep -qP '\tdead\t.*\tfailed\t' '$R/slots.tsv'"
-check "timing and prompt captured"  "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*\$' '$R/slots.tsv'"
+check "timing and prompt captured"  "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*\t2\t' '$R/slots.tsv'"
 # ★ CHANGED with #2, deliberately. A failed seat used to carry EMPTY secs, and
 # not because anything decided it should: the old reconstruction grepped the
 # console log for "in Ns", the failure line says "after Ns", the pattern missed,
@@ -1891,9 +1891,9 @@ check "timing and prompt captured"  "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*
 # then failed cost exactly that much -- dropping it understated real spend.
 # The empty-is-not-zero rule still holds where it is true; the seat that was
 # never timed at all is asserted below.
-check "failed seat keeps its prompt"  "grep -qP '\tfailed\t[0-9]+\t[0-9]*\t[1-9][0-9]*\$' '$R/slots.tsv'"
+check "failed seat keeps its prompt"  "grep -qP '\tfailed\t[0-9]+\t[0-9]*\t[1-9][0-9]*\t2\t' '$R/slots.tsv'"
 check "failed seat's time is measured, not blank" \
-  "grep -qP '\tfailed\t[0-9]+\t[0-9]+\t[1-9][0-9]*\$' '$R/slots.tsv'"
+  "grep -qP '\tfailed\t[0-9]+\t[0-9]+\t[1-9][0-9]*\t2\t' '$R/slots.tsv'"
 check "report has receipt table"    "grep -qF '| seat | status | secs | prompt KB | review KB | est. tokens |' '$R/report.md'"
 check "receipt caveat is explicit" "grep -qF '> Estimated as bytes/4 of what the harness sent and received. Hidden reasoning tokens are invisible from outside the CLI and are NOT in this number: a seat that thinks long and answers short costs more than its row shows. This is a relative-spend signal, not a bill.' '$R/report.md'"
 # ★ A seat that produced NO artifact must still appear. Deriving rows from
@@ -1909,11 +1909,49 @@ check "no seat vanishes from Receipts too" \
 check "Receipts names the same seats as slots.tsv" \
   "grep -q '^| .good. |' '$R/report.md' && grep -q '^| .dead. |' '$R/report.md'"
 
+# ---- input provenance on every row (#37) -------------------------------------
+# ★ `prompt_bytes` is a SIZE. Two prompts that differ and happen to be the same
+# length are one row in the record, and CADRE_PROMPT_FILE replaces the brief
+# wholesale -- so the single input with the largest effect on a review was the
+# one the record described least. Three content hashes close it: the rendered
+# prompt, the adapter that ran, and the harness that dispatched.
+check "row carries a prompt hash"   "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*\t2\t[0-9a-f]{12}\t' '$R/slots.tsv'"
+check "row carries an adapter hash" "[ \$(cut -f10 '$R/slots.tsv' | grep -cE '^[0-9a-f]{12}\$') -eq 2 ]"
+check "row carries a harness hash"  "[ \$(cut -f11 '$R/slots.tsv' | grep -cE '^[0-9a-f]{12}\$') -eq 2 ]"
+# One panel dispatches one prompt from one harness, so those two columns have to
+# agree across seats. If they ever do not, the panel is not the comparison it
+# says it is, and that is the whole reason the fields exist.
+check "one prompt hash for the panel"  "[ \$(cut -f9  '$R/slots.tsv' | sort -u | wc -l) -eq 1 ]"
+check "one harness hash for the panel" "[ \$(cut -f11 '$R/slots.tsv' | sort -u | wc -l) -eq 1 ]"
+# ★ ...and the adapter column must NOT agree. Two different adapter files
+# produced these two rows; a hash that collapses them is hashing something else,
+# which is the failure a size-based field already had.
+check "adapter hash is per adapter"    "[ \$(cut -f10 '$R/slots.tsv' | sort -u | wc -l) -eq 2 ]"
+check "manifest names the harness too" "grep -qE '^harness:   [0-9a-f]{12}\$' '$R/manifest.txt'"
+check "the record carries the hashes"  "grep -qE '\"harness_sha\":\"[0-9a-f]{12}\"' '$R/runs.jsonl'"
+check "and the schema version"         "grep -q '\"v\":2' '$R/runs.jsonl'"
+
 # ---- record writer/reader units (#2) ----------------------------------------
 # ★ Hand-rolled JSON, so the escaping is the risk. Every one of these is a way a
 # single malformed line silently becomes a wrong FIELD rather than a parse
 # error -- which is worse than the prose-grepping it replaced, because a wrong
 # field looks measured.
+# ---- content_sha unit (#37) --------------------------------------------------
+CS=$(mktemp -d -p "$SANDBOX")
+printf 'alpha' > "$CS/a"; printf 'beta' > "$CS/b"
+check "sha: same bytes, same hash"   "[ \"\$(content_sha '$CS/a')\" = \"\$(content_sha '$CS/a')\" ]"
+check "sha: different bytes differ"  "[ \"\$(content_sha '$CS/a')\" != \"\$(content_sha '$CS/b')\" ]"
+check "sha: it is 12 hex chars"      "printf '%s' \"\$(content_sha '$CS/a')\" | grep -qE '^[0-9a-f]{12}\$'"
+# ★ Order is part of the identity, which is why harness_sha sorts its file list:
+# find's order is filesystem-dependent, so an unsorted input would hash the same
+# tree differently on two machines and manufacture a harness split.
+check "sha: order changes the hash"  "[ \"\$(content_sha '$CS/a' '$CS/b')\" != \"\$(content_sha '$CS/b' '$CS/a')\" ]"
+# ★ EMPTY, never a hash of whichever inputs happened to exist. A partial-set
+# hash compares EQUAL to another run that lost the same file for an unrelated
+# reason, so it reads as agreement where there is none.
+check "sha: a missing input is EMPTY" "[ -z \"\$(content_sha '$CS/a' '$CS/nope')\" ]"
+check "sha: no input at all is EMPTY" "[ -z \"\$(content_sha)\" ]"
+
 RJ=$(mktemp -d -p "$SANDBOX"); RL="$RJ/runs.jsonl"
 record_event "$RL" event=complete seat='codex:gpt-5.5' "secs#=12" "rc#=0"
 check "rec: seat with a colon survives" \
@@ -2018,7 +2056,7 @@ rm -f "$R/slots.tsv"
 OUT=$(run_cadre "$D" dataset "$D/dataset" 2>&1)
 check "aggregate walks the reviews" "[ -s '$D/dataset/slots.tsv' ]"
 check "it reconstructs the panel"   "grep -q reconstructed '$D/dataset/slots.tsv'"
-check "unknown measures stay empty" "grep -qP '\t[0-9]+\t\t\treconstructed\$' '$D/dataset/slots.tsv'"
+check "unknown measures stay empty" "grep -qP '\t[0-9]+\t\t\t\t\t\t\treconstructed\$' '$D/dataset/slots.tsv'"
 # ★ Explicitly: NOT zeroes. A reconstructed row has neither measurement, and
 # writing 0 would average like a real value and drag every mean toward the floor.
 check "never a fabricated sec zero" "! grep -qP '\t0\t\treconstructed\$' '$D/dataset/slots.tsv'"
@@ -2031,7 +2069,7 @@ mkdir -p "$D/state/reviews/ds-skip"
 printf 'ds-skip\tgood\tstub-good\tok\t100\t1\t100\nds-skip\tgood2\tstub-good2\tskipped\t0\t\t0\n' > "$D/state/reviews/ds-skip/slots.tsv"
 printf 'base-tree: aaaaaaaa11111111\nreviewed-tree: bbbbbbbb22222222\n' > "$D/state/reviews/ds-skip/manifest.txt"
 OUT=$(run_cadre "$D" dataset "$D/dataset" 2>&1)
-check "aggregate keeps skipped slot row" "grep -qP 'ds-skip\tgood2\t.*\tskipped\t0\t\t0\trecorded\$' '$D/dataset/slots.tsv'"
+check "aggregate keeps skipped slot row" "grep -qP 'ds-skip\tgood2\t.*\tskipped\t0\t\t0\t\t\t\t\trecorded\$' '$D/dataset/slots.tsv'"
 check "aggregate excludes skip from seats" "grep -qP 'ds-skip\t\S+\t1\t1\t0\t0\t0\t' '$D/dataset/panels.tsv'"
 
 RF="$D/receipt-fixtures"
@@ -2046,6 +2084,38 @@ printf 'oldrun\tlegacy\tlegacy\tok\t400\t5\n' > "$RF/old/slots.tsv"
 OUT=$(run_cadre "$D" receipts "$RF/old" 2>&1); RC=$?
 check "old receipts do not crash"    "[ '$RC' -eq 0 ]"
 check "old prompt spend is named"    "grep -q '1 rows predate prompt-byte capture; their prompt spend is not counted.' <<<\"\$OUT\""
+
+# ★ #20: ONE family, TWO slots.tsv schemas. `secs` changed meaning for a failed
+# seat -- it used to be blank, it is now the measured seconds -- and neither
+# value is wrong, so the per-schema totals are not wrong either. A single total
+# over both is the thing nobody can interpret. Nothing is dropped: the rows are
+# listed separately, which is both the refusal to average and the notice.
+mkdir -p "$RF/mixed"
+printf 'r1\tcodex:a\topenai\tok\t1024\t7\t2048\n' > "$RF/mixed/slots.tsv"
+printf 'r2\tcodex:a\topenai\tok\t1024\t9\t2048\t2\tdeadbeefcafe\taaaaaaaaaaaa\tbbbbbbbbbbbb\n' >> "$RF/mixed/slots.tsv"
+OUT=$(run_cadre "$D" receipts "$RF/mixed")
+check "mixed: one row per schema"    "[ \$(awk '\$1 == \"openai\"' <<<\"\$OUT\" | wc -l) -eq 2 ]"
+check "mixed: nothing is dropped"    "[ \$(awk '\$1 == \"openai\" { n += \$3 } END { print n+0 }' <<<\"\$OUT\") -eq 2 ]"
+# The number this whole issue exists to prevent: 7 + 9 printed as one SECS cell.
+check "mixed: the two secs never merge" "! awk '\$1 == \"openai\" && \$9 == 16 { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "mixed: an old row says unknown"  "awk '\$1 == \"openai\" && \$13 == \"?\" { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "mixed: a new row names its schema" "awk '\$1 == \"openai\" && \$13 == 2 { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "mixed: the boundary is said out loud" "grep -q 'Those rows are NOT comparable' <<<\"\$OUT\""
+check "mixed: pre-#19 panels still read"     "awk '\$1 == \"openai\" && \$13 == \"?\" && \$9 == 7 { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "mixed: an unhashed row is counted"    "grep -q 'Harness: 1 row(s) name none' <<<\"\$OUT\""
+
+# ★ #37: a comparison spanning two harnesses is not like-for-like, and the
+# AGREEMENT case prints too. An absent warning is indistinguishable from a check
+# that never ran, and this line is the only place harness identity surfaces.
+mkdir -p "$RF/harness"
+printf 'r1\tc\topenai\tok\t10\t1\t10\t2\tpppppppppppp\taaaaaaaaaaaa\t111111111111\n' > "$RF/harness/slots.tsv"
+printf 'r2\tc\topenai\tok\t10\t1\t10\t2\tpppppppppppp\taaaaaaaaaaaa\t222222222222\n' >> "$RF/harness/slots.tsv"
+OUT=$(run_cadre "$D" receipts "$RF/harness")
+check "harness: a split is called out" "grep -q 'span 2 versions' <<<\"\$OUT\""
+check "harness: both are named"        "grep -q '111111111111, 222222222222' <<<\"\$OUT\""
+printf 'r3\tc\topenai\tok\t10\t1\t10\t2\tpppppppppppp\taaaaaaaaaaaa\t111111111111\n' > "$RF/harness/slots.tsv"
+OUT=$(run_cadre "$D" receipts "$RF/harness")
+check "harness: agreement is stated"   "grep -q 'every row ran against 111111111111' <<<\"\$OUT\""
 
 echo "== ★ settled-decisions ledger =="
 # ★ The loop-breaker. Cadre reviews once, but anything that WRAPS it re-raises


### PR DESCRIPTION
Closes #2.

Finishes the issue: the benchmark path gets the record the panel path got in #19, and criterion 2 lands — state read as a **field** rather than grepped back out of prose.

> ⚠️ Carries one commit that is not mine and not part of #2: `61fafc1` *docs: security and reliability check list, adapted from goshipit*. It was committed onto this branch while the work was in progress. Review it on its own merits or split it out.

## The benchmark path

`grade.sh` reconstructed every run's state by probing which suffix existed on disk — `.failed`, `.partial`, `.inconclusive`. That is a state machine encoded in filenames, and filenames cannot carry a duration, an exit code, a prompt size or an attempt count at all.

`run-pass.sh` now writes the same record shape under the same name the panel path uses, so a consumer does not have to know which command produced a run. One field differs and has to: `run`, because a pass asks the *same* seat for N runs, so seat alone does not identify a row.

**This closes a gap #12 documented and could not fix.** At grade time the exit code was gone, so a clock kill and an ordinary crash read identically, and #12 deliberately refused to guess one from bytes — a fabricated *"your clock killed it"* is the same manufactured verdict pointed the other way. The record carries `rc`, so a pass **with** a record now names the timeout at grade time, and a pass **without** one still declines.

## Criterion 2: declaring, instead of spelling it into prose

The only channel an adapter had was a marker in the review text, which cadre then edge-matched back out — and text a *model* controls can collide with text the contract reserves. Both known collisions are that shape: a synthesis asked to discuss which reviewers were truncated quotes `_TRUNCATED` and classifies **itself** as truncated; a short review that merely mentions rate limiting trips the keyword scan. The `ctx=synth` narrowing relocated the first onto the exact spot the prompt drives the model toward and could not remove it, because no text test can.

`agentcall` now offers `cadre_state ok|degraded|inconclusive|failed`, and `classify_run` reads that field ahead of every inference it would otherwise make. Found by **convention** at `$f.meta` rather than passed as a parameter: three call sites string-compare `classify_run` and a new argument would have to be threaded through all of them.

Three rails, each pointing the safe way:

- an **unknown** state is ignored, not believed — a wrong field would outrank the text, a missing one just falls back
- **empty still wins** — an adapter that declared `ok` and returned nothing is describing an intention, not a result
- the marker contract is **not deprecated**. Every shipped adapter still uses it and needed no edit; declaring is for an adapter that *knows* — it read a `stopReason`, it caught its own timeout.

## ⚠️ How far the declaration can be trusted

A declaration is trusted exactly as much as the **adapter** is, and no further. Cadre hands the adapter a path and believes what it finds there; it cannot tell a `cadre_state` call from anything else that wrote to that file. The agent CLI runs as the **same uid** as cadre and several will run a shell on request, so a model that goes looking can reach it — and a declared `ok` outranks a `_TRUNCATED` marker and a nonzero exit.

The path is a private temp **directory** rather than a bare temp file, which defeats the cheap blind spray (`for f in /tmp/tmp.*; [ -w "$f" ] && echo state=ok >> "$f"`). That is a speed bump, not a boundary: same uid means no filesystem barrier, and `/proc/<pid>/environ` still leaks the path to a determined child. `docs/ADDING-AN-AGENT.md` says this plainly rather than implying containment — same "mitigation, not a sandbox" posture as the environment scrub, `docs/METHOD.md` §5.

**The marker contract remains the more conservative channel**, because the adapter appends it after the CLI has already exited. If the forgery surface is judged unacceptable, dropping `cadre_state` and keeping the record work is a clean subtraction — say so and I'll cut it.

What the containment *does* hold: the spawned CLI cannot read `CADRE_RUN_META` from its environment (`export -n` in agentcall, plus the name on the scrub list so an outer environment cannot supply one and pre-declare a run it does not own), and the handed path is never inside `$OUT`, the directory holding every other reviewer's output.

## Three defects found in review, all in the first cut

1. **A seat could be graded with another seat's exit code.** `runs.jsonl` lives at `$CADRE_HOME/<label>/` and is shared by *every candidate* benchmarked on that pass, so a lookup keyed on run index alone matched run 1 of every seat that ever ran there. Grading `waffle` read `terse`'s rc, with no re-run involved. Separately the lookup took the **first** match, while the record is append-only and `cadre run` re-dispatches any slot whose `.md` is missing — so the artifact on disk is the *last* attempt's. Either way: *"TIMED OUT — cadre's own clock killed it"* about a run that crashed.
2. **`cadre_state` was a no-op in the synth slot** — the slot the documentation uses as its motivating example. `cmd_synthesize` never set the variable.
3. **The forgery surface above**, which was a bare `mktemp` file.

## Tests

816 pass, 0 fail.

Correctness of the new field: a declaration outranking text and a nonzero exit; a synthesis quoting `_TRUNCATED` still not self-classifying, then declaring successfully; an empty artifact surviving a declared `ok`; an unknown state falling back; last declaration winning; the channel end to end through a real panel and through a real synth slot.

Containment: a stub binary that dumps its own environment proves the spawned CLI is blind to `CADRE_RUN_META` — guarded by a paired assertion that the adapter itself *does* see it, so the two cannot pass by both being empty. The handed path is asserted to be outside the panel directory.

Record correctness: another seat's rc not borrowed, the last completion winning over an earlier one, and the legacy no-record path still declining to claim a timeout from an identical artifact.

One existing assertion was corrected rather than left green: it claimed the declarer's text "would have said ok" when that artifact states no findings and no verdict, so it would have been `inconclusive`. The declaration decided either way, but a test that misnames its comparison is one nobody can check.
