### PR TITLE
Engine/benchmark seam: extract synthesize + settle, write an unverified findings.json (#25)

### DIFF
--- a/bin/cadre
+++ b/bin/cadre
@@ -34,6 +34,10 @@ export CADRE_ROOT="${CADRE_ROOT:-$(dirname "$SELF_DIR")}"
 . "$CADRE_ROOT/lib/grade.sh"
 # shellcheck source=lib/adjudicate.sh
 . "$CADRE_ROOT/lib/adjudicate.sh"
+# The engine. It produces findings.json; the benchmark half of cadre only ever
+# consumes it. lib/engine/README.md draws the line, tests/engine-seam.sh holds it.
+# shellcheck source=lib/engine/synthesize.sh
+. "$CADRE_ROOT/lib/engine/synthesize.sh"
 
 PASSES="$CADRE_HOME/passes.conf"
 
@@ -924,199 +928,13 @@ cmd_review() {
   fi
 
   [ -n "$synth" ] && [ "$synth" != none ] && cmd_synthesize "$out" "$synth" "${specs[@]}"
+  # ★ UNCONDITIONAL, and deliberately outside the `&&` chain above. findings.json
+  # is the engine's output for this panel, and a panel that produced reviews
+  # produced claims whether or not a merge ran, succeeded, or was even asked for.
+  # Hanging it off the synthesize call would erase every degraded run from the
+  # benchmark's view -- see the comment on engine_write_findings.
+  engine_write_findings "$out" "${synth:-none}" "${specs[@]}"
   return 0
-}
-
-# Merge the reviews. A model too, so the same rate-limit rule applies, and a
-# failure here must not cost the individual reviews: they are already on disk.
-cmd_synthesize() {
-  local out="$1" synth="$2"; shift 2
-  local specs=("$@") sl body="" cap="${CADRE_SYNTH_MAX:-200000}"
-  local dead=() srcspec=() srcfile=() srcstate=() total=0
-  for sp in "${specs[@]}"; do
-    sl=$(slug "$sp")
-    if [ -s "$out/$sl.md" ];           then srcspec+=("$sp"); srcfile+=("$out/$sl.md");         srcstate+=(ok)
-    elif [ -s "$out/$sl.md.partial" ]; then srcspec+=("$sp"); srcfile+=("$out/$sl.md.partial"); srcstate+=(degraded)
-    else dead+=("$sp"); fi
-  done
-  local usable=${#srcspec[@]} i
-  # Partials count toward having something to merge. One full review plus one
-  # partial is still two independent looks at the diff.
-  [ "$usable" -ge 2 ] || { echo "only $usable usable review(s); nothing to synthesize."; return 0; }
-  for i in "${!srcfile[@]}"; do total=$((total + $(wc -c < "${srcfile[$i]}"))); done
-
-  # Over budget, every review gets the same byte share. ★ head -c MAKES a review
-  # partial: a full review cut at 40KB is silent about everything after 40KB for
-  # exactly the reason a truncated one is. Re-label it degraded here or the
-  # silence rule below skips the reviews this function itself just truncated.
-  local per=0
-  if [ "$total" -gt "$cap" ]; then
-    per=$(( cap / usable ))
-    # A share of 0 would announce a truncation and then perform none, quietly
-    # sending the whole oversized body anyway.
-    [ "$per" -lt 1 ] && per=1
-    echo "⚠ reviews total $total bytes, over CADRE_SYNTH_MAX ($cap). Truncating each to $per."
-  fi
-
-  # ★ TWO different facts, kept apart. "The reviewer stopped early" is a fact
-  # about the reviewer's health. "Cadre sent only the first N bytes" is a fact
-  # about what this function did to a reviewer that finished perfectly well.
-  # Both mean the silence that follows proves nothing, so both get the silence
-  # rule -- but telling the synthesizer a healthy reviewer "stopped early" is
-  # simply false, and it is the kind of false that ends up quoted in a report.
-  local partial=() capped=() n=0 text cut
-  for i in "${!srcspec[@]}"; do
-    cut=0
-    if [ "$per" -gt 0 ] && [ "$(wc -c < "${srcfile[$i]}")" -gt "$per" ]; then
-      text=$(head -c "$per" "${srcfile[$i]}"); cut=1
-    else
-      text=$(cat "${srcfile[$i]}")
-    fi
-    # A DIFFERENT delimiter, not just different prose. Under the same delimiter
-    # as a full review the synthesizer has no handle to apply a different rule
-    # to, however carefully the instructions are worded.
-    if [ "${srcstate[$i]}" = degraded ]; then
-      body="$body===== REVIEWER (PARTIAL, THIS REVIEWER STOPPED EARLY): ${srcspec[$i]} ====="$'\n'"$text"$'\n\n'
-      partial+=("${srcspec[$i]}")
-    elif [ "$cut" = 1 ]; then
-      body="$body===== REVIEWER (COMPLETE, BUT CADRE SENT ONLY ITS FIRST $per BYTES): ${srcspec[$i]} ====="$'\n'"$text"$'\n\n'
-      capped+=("${srcspec[$i]}")
-    else
-      body="$body===== REVIEWER: ${srcspec[$i]} ====="$'\n'"$text"$'\n\n'
-      n=$((n + 1))
-    fi
-  done
-  local short=("${partial[@]}" "${capped[@]}")
-  # ★ Two different counts, and conflating them made cadre lie in prose while
-  # the arithmetic stayed right. $n is "full text in front of the synthesizer",
-  # which is the correct denominator floor for a finding only the full reviews
-  # could have named. It is NOT the number of reviewers who finished: a capped
-  # reviewer reviewed the whole diff and returned a complete review, cadre just
-  # sent part of it. Reporting $n as "returned a complete review" understates a
-  # healthy panel, and when every survivor was capped the console announced
-  # "synthesizing 0 review(s)" for a run that was about to synthesize several.
-  local completed=$((n + ${#capped[@]}))
-
-  # ★ Tell the synthesizer who DIED. Without this it sees two reviews, reports
-  # "2/2 agree", and the reader concludes the panel was unanimous when a third
-  # of it never returned. The header line the prompt asks for is what carries
-  # that; these members are NOT in the tags, because a reviewer that never ran
-  # has no opinion to count either way.
-  #
-  # ★ dead[] is anything that is neither .md nor .md.partial, which is what
-  # makes an INCONCLUSIVE run safe by construction: it lands here, and this
-  # block already keeps it out of every denominator. That is the whole fix for
-  # the false green -- no third delimiter, no new counting rule. The delimiter
-  # says NO REVIEW rather than FAILED because a run that exited 0 and wrote 40KB
-  # did not fail, and the prompt asks the synthesizer to describe these members
-  # in the verdict spread.
-  if [ ${#dead[@]} -gt 0 ]; then
-    body="$body===== NO USABLE REVIEW: ${dead[*]} =====
-These roster members produced no usable review. Say so in the verdict spread and
-in the header line. Keep them out of every agreement tag: they neither agree nor
-disagree with anything. This panel was ${#specs[@]} reviewers, of whom $completed
-returned a complete review.
-
-"
-  fi
-  # ★ Incomplete coverage breaks the agreement MATH, not just the prose, and in
-  # the direction nobody checks. Tagging a finding [1/4] when two of the four
-  # never reached that file reads as three dissents; it is one reviewer and two
-  # absences. One rule for both causes, since the consequence is identical, but
-  # each reviewer is listed under the cause that is actually true of it.
-  if [ ${#short[@]} -gt 0 ]; then
-    body="$body===== REVIEWERS WITH INCOMPLETE COVERAGE: ${short[*]} ====="$'\n'
-    [ ${#partial[@]} -gt 0 ] && body="$body\
-  ${partial[*]} -- stopped partway through, out of tokens or time.
-"
-    [ ${#capped[@]} -gt 0 ] && body="$body\
-  ${capped[*]} -- reviewed the whole diff, but their review was too long for
-  this synthesis and CADRE cut it. The reviewer is healthy; the copy you were
-  given is not the whole of what it wrote. Do not say it stopped early.
-"
-    body="$body
-Their text is a real review of the part you can see. Rules for them, unlike a
-review you have in full:
-  - On a finding one of them RAISED, it counts in both the numerator and the
-    denominator, exactly like a complete review.
-  - On a finding it never mentioned, it counts in NEITHER. That code is outside
-    what you were given, so its silence is not agreement, disagreement, or
-    clearance, and the denominator for that finding is smaller. Never list one
-    under Disagreements for something it simply does not mention.
-  - Give no overall verdict on behalf of a reviewer that stopped early.
-
-Do the arithmetic for THIS panel. You have $n review(s) in full and ${#short[@]} with
-incomplete coverage (${short[*]}). For each finding: denominator = $n, plus one
-for EACH of those ${#short[@]} that raised that finding. So it is $n when none of them
-raised it, and at most $((n + ${#short[@]})) when all of them did.
-
-The low end is the case that gets written wrong. A defect only the full reviews
-named is tagged [x/$n]. A bigger number there claims someone looked at that code
-and declined to flag it, which is exactly backwards.
-
-"
-  fi
-
-  local pf="$out/.synth-prompt" raw attempt=1 w
-  { cat "$CADRE_ROOT/lib/prompts/synthesize.md"; echo; printf '%s' "$body"; } > "$pf"
-  local pcount=""
-  [ ${#capped[@]} -gt 0 ] && pcount="$pcount, ${#capped[@]} sent short"
-  [ ${#partial[@]} -gt 0 ] && pcount="$pcount, ${#partial[@]} partial"
-  echo "synthesizing $usable review(s)${pcount:+ ($n full$pcount)} with $synth ..."
-  local a m mm=(); a=$(spec_agent "$synth"); m=$(spec_model "$synth")
-  [ -n "$m" ] && mm=(-M "$m")
-  # Capability preflight: a doomed synthesizer must not burn the merge call.
-  local sblock sdecl sreason
-  if sblock=$(capability_block "$synth" synth); then
-    IFS=$'\t' read -r sdecl sreason <<< "$sblock"
-    echo "synthesis SKIPPED by capability preflight ($sdecl: $sreason). Individual reviews are intact in $out." >&2
-    rm -f "$pf"
-    return 0
-  fi
-  local rc=0
-  while :; do
-    raw=$("$CADRE_ROOT/bin/agentcall" "$a" "${mm[@]}" -d /tmp -m ro < "$pf" 2>&1); rc=$?
-    printf '%s' "$raw" > "$out/.synth-tmp"
-    # ★ The THIRD retry loop. The commit that taught the two reviewer loops to
-    # stop trusting a keyword scan over the adapter left this one asking the old
-    # question, so a healthy short merge that discussed rate limiting burned
-    # three retries and then got filed failed. Same principle, different test,
-    # because a synthesis has no marker to be rescued by. See provider_refused.
-    provider_refused "$out/.synth-tmp" "$rc" || { rm -f "$out/.synth-tmp"; break; }
-    rm -f "$out/.synth-tmp"
-    [ "$attempt" -ge "${CADRE_RETRIES:-3}" ] && break
-    w=$(retry_wait "$attempt")
-    echo "  synthesis rate limited, waiting ${w}s ($((attempt + 1))/${CADRE_RETRIES:-3})"
-    sleep "$w"; attempt=$((attempt + 1))
-  done
-  rm -f "$pf"
-  # ★ Same classifier the reviewers get. An auth error or an exhausted retry is
-  # NON-EMPTY text, so testing only for emptiness filed the error itself as
-  # synthesis.md and the reader saw a merged review that was really a 429. The
-  # synthesizer is a model; it fails like one.
-  # ★ Deliberately NOT three-state: only `ok` survives here. A partial merge is
-  # worthless in a way a partial review is not, because the reviews it was
-  # merging are already on disk and complete. Fail closed and keep them.
-  printf '%s' "$raw" > "$out/.synth-tmp"
-  if [ "$(classify_run "$out/.synth-tmp" "$rc" synth)" != ok ]; then
-    mv "$out/.synth-tmp" "$out/synthesis.md.failed"
-    # ★ Third consumer of the same split (#12). The synthesizer is a model and
-    # fails like one, so "the provider returned nothing" and "cadre's clock cut
-    # a live merge short" are as distinguishable here as on a review -- and the
-    # second one is fixable by re-running with a bigger CADRE_TIMEOUT, which the
-    # old flat message never suggested. No elapsed time is tracked on this path,
-    # so the phrase is asked for without one rather than handed a made-up number.
-    echo "synthesis $(failure_phrase "$out/synthesis.md.failed" "$rc"), kept as synthesis.md.failed." >&2
-    echo "The individual reviews are intact in $out." >&2
-    return 0
-  fi
-  rm -f "$out/.synth-tmp"
-  { echo "# Synthesis ($synth)"; echo
-    echo "_Model-produced and unverified. It merges what the reviewers said; it has"
-    echo "not seen the code. Read the individual reviews before acting._"; echo
-    printf '%s\n' "$raw"
-  } > "$out/synthesis.md"
-  echo "saved: $out/synthesis.md"
 }
 
 # ---- the settled-decisions ledger --------------------------------------------

--- a/bin/cadre
+++ b/bin/cadre
@@ -38,6 +38,8 @@ export CADRE_ROOT="${CADRE_ROOT:-$(dirname "$SELF_DIR")}"
 # consumes it. lib/engine/README.md draws the line, tests/engine-seam.sh holds it.
 # shellcheck source=lib/engine/synthesize.sh
 . "$CADRE_ROOT/lib/engine/synthesize.sh"
+# shellcheck source=lib/engine/settle.sh
+. "$CADRE_ROOT/lib/engine/settle.sh"
 
 PASSES="$CADRE_HOME/passes.conf"
 
@@ -937,43 +939,6 @@ cmd_review() {
   return 0
 }
 
-# ---- the settled-decisions ledger --------------------------------------------
-#
-# ★ Cadre reviews once and stops, so on its own it cannot treadmill. The moment
-# something WRAPS it in a loop, which is the normal way people use a review tool
-# on a branch, every re-run re-raises findings the human already dismissed. The
-# reviewers have no memory; the human is the only thing that remembers, and
-# making them remember is how a review loop becomes unbearable.
-#
-# The ledger is a human-written file. Nothing writes to it automatically: a tool
-# that files its own dismissals will eventually dismiss something real, and the
-# whole value here is that a person decided. `cadre settle` only READS it.
-LEDGER_HELP='One finding per line:
-
-    <id> | <disposition> | <description>
-
-  L1 | wontfix  | timestamps are strings from neon-http, callers wrap them
-  L2 | accepted | missing test for the retry path, tracked in #412
-
-disposition is yours; cadre does not interpret it.'
-
-ledger_path() { echo "${CADRE_LEDGER:-$CADRE_HOME/ledger}"; }
-
-cmd_ledger() {
-  local lp; lp=$(ledger_path)
-  case "${1:-show}" in
-    show)
-      if [ ! -s "$lp" ]; then
-        echo "no ledger at $lp"; echo; echo "$LEDGER_HELP"; return 0
-      fi
-      echo "$lp"; echo
-      # Comments and blanks are the user's; print the file as they wrote it.
-      cat "$lp" ;;
-    path) echo "$lp" ;;
-    *) die "ledger: expected 'show' or 'path'" ;;
-  esac
-}
-
 # Sum only what slots.tsv measured. Old and reconstructed rows have no prompt
 # length, and a receipt command that guesses one would turn missing history into
 # a confident spend number.
@@ -1039,106 +1004,6 @@ cmd_receipts() {
     echo
     echo "$missing rows predate prompt-byte capture; their prompt spend is not counted."
   fi
-}
-
-# Split one review into SETTLED / NEW against the ledger. Read-only, and it
-# never edits the review: the finding stays on disk exactly as written.
-cmd_settle() {
-  local review="" judge="${CADRE_JUDGE:-}"
-  while [ $# -gt 0 ]; do
-    case "$1" in
-      --judge) judge="${2:?--judge needs an agent spec}"; shift 2 ;;
-      -*) die "settle: unknown option '$1'" ;;
-      *)  review="$1"; shift ;;
-    esac
-  done
-  [ -n "$review" ] || die "usage: cadre settle <review-file-or-dir> [--judge spec]"
-
-  # A review directory is the normal thing to have: point at the report.
-  [ -d "$review" ] && review="$review/report.md"
-  [ -s "$review" ] || die "no review to read at $review"
-
-  local lp; lp=$(ledger_path)
-  [ -s "$lp" ] || die "no ledger at $lp, so there is nothing settled yet.
-
-     $LEDGER_HELP"
-
-  [ -n "$judge" ] || { pick_judge || true; judge="${CADRE_JUDGE:-}"; }
-  [ -n "$judge" ] || die "settle needs a judge. Set \$CADRE_JUDGE or pass --judge."
-
-  # ★ Strip comments and blanks before the model sees it. A '#' line is a note
-  # to the human, and feeding it as an entry invites a match against a comment.
-  local entries; entries=$(grep -vE '^[[:space:]]*(#|$)' "$lp")
-  [ -n "$entries" ] || die "$lp has no entries, only comments."
-
-  local pf; pf=$(mktemp)
-  { cat "$CADRE_ROOT/lib/prompts/settle.md"; echo
-    echo "===== LEDGER ====="; printf '%s\n' "$entries"; echo
-    echo "===== REVIEW ====="; cat "$review"
-  } > "$pf"
-
-  local a m mm=() raw rc
-  a=$(spec_agent "$judge"); m=$(spec_model "$judge")
-  [ -n "$m" ] && mm=(-M "$m")
-  echo "matching against $(printf '%s\n' "$entries" | wc -l) ledger entries with $judge …"
-  raw=$("$CADRE_ROOT/bin/agentcall" "$a" "${mm[@]}" -d /tmp -m ro < "$pf" 2>&1); rc=$?
-  rm -f "$pf"
-
-  # ★ Fail loudly. A settle pass that silently returns nothing looks exactly
-  # like "everything here is already settled", which would hide a live finding
-  # behind a judge that never ran.
-  # ★ Models fence their JSON. `sed -n '/{/,$p'` took the first { to EOF, which
-  # carries the CLOSING ``` along with it, and jq rejects the trailing fence --
-  # so a judge that answered perfectly was reported as one that "failed or
-  # stopped early". Measured with qwen as judge on a real panel: the correct
-  # findings were printed in the error's own diagnostic lines, which is as close
-  # to self-refuting as a message gets.
-  # Take the first { to the LAST }, after dropping fence lines. That survives
-  # prose on either side of the block and braces inside strings, which a
-  # brace-counting scan does not. Anything that still is not JSON -- no object
-  # at all, or a truncated one -- fails jq and is refused below, which is the
-  # direction that has to stay safe.
-  local js
-  js=$(printf '%s' "$raw" \
-       | sed -e '/^[[:space:]]*```/d' \
-       | awk 'BEGIN{RS="\0"} {
-             i=index($0,"{"); if(!i) exit; s=substr($0,i);
-             for(k=length(s);k>0;k--) if(substr(s,k,1)=="}") { printf "%s", substr(s,1,k); exit }
-           }' \
-       | jq -c . 2>/dev/null) || js=""
-  # ★ Two causes, one message, so say both. An adapter that truncates now exits
-  # nonzero even when the JSON it printed parses fine, and reporting that as
-  # "did not return usable JSON" describes the wrong problem to whoever has to
-  # fix it. A partial match is still refused either way: settle's exit code is a
-  # stopping rule, and half a match reads as "nothing new is left".
-  if [ "$rc" -ne 0 ] || [ -z "$js" ]; then
-    echo "cadre: the judge failed or stopped early, so nothing was matched." >&2
-    printf '%s\n' "$raw" | head -5 | sed 's/^/     /' >&2
-    return 1
-  fi
-
-  local total new
-  total=$(printf '%s' "$js" | jq '.findings | length')
-  new=$(printf '%s' "$js" | jq '[.findings[] | select(.status != "SETTLED")] | length')
-  echo
-  if [ "$total" -eq 0 ]; then echo "no findings in that review."; return 0; fi
-
-  if [ "$new" -gt 0 ]; then
-    echo "NEW ($new of $total):"
-    printf '%s' "$js" | jq -r '.findings[] | select(.status != "SETTLED") | "  - \(.summary)"'
-  fi
-  if [ "$new" -lt "$total" ]; then
-    echo
-    echo "already settled ($((total - new)) of $total), shown so you can check the match:"
-    printf '%s' "$js" | jq -r '.findings[] | select(.status == "SETTLED")
-                               | "  - [\(.ledger_id // "?")] \(.summary)"'
-  fi
-  echo
-  echo "The review itself is unchanged at $review."
-  # ★ The exit status is the useful part for a wrapper: 0 means nothing new to
-  # look at, so a loop can stop. Non-zero means a human still has something to
-  # read. That is the stopping rule, and it is deliberately not automatic.
-  [ "$new" -eq 0 ]
 }
 
 # Exits non-zero when a pass is broken. README and docs both say doctor FAILS a

--- a/bin/cadre
+++ b/bin/cadre
@@ -136,16 +136,6 @@ init_home() {
   [ -f "$PASSES" ] || cp "$CADRE_ROOT/templates/passes.conf" "$PASSES"
 }
 
-# The judge is a model too. Default to the first installed candidate and SAY
-# which one, because a silently-chosen judge is a silently-chosen bias.
-pick_judge() {
-  [ -n "$CADRE_JUDGE" ] && return 0
-  local a
-  for a in claude codex grok opencode; do
-    agent_installed "$a" && { CADRE_JUDGE="$a"; return 0; }
-  done
-  return 1
-}
 need_judge() {
   pick_judge || die "no judge available, set CADRE_JUDGE to an agent agentcall can run"
   # Catch a typo or a missing CLI here. Otherwise every call fails and the whole
@@ -935,7 +925,10 @@ cmd_review() {
   # produced claims whether or not a merge ran, succeeded, or was even asked for.
   # Hanging it off the synthesize call would erase every degraded run from the
   # benchmark's view -- see the comment on engine_write_findings.
-  engine_write_findings "$out" "${synth:-none}" "${specs[@]}"
+  # $skipped_env carries the gate-skipped seats, which are NOT in $specs: they
+  # were filtered out before dispatch, and a panel built from $specs alone would
+  # report a smaller roster than the user asked for.
+  engine_write_findings "$out" "${synth:-none}" "$skipped_env" "${specs[@]}"
   return 0
 }
 

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -2,7 +2,7 @@
 
 Claims about what the harness protects, each backed by a test that fails if
 the claim stops being true. To verify one, grep the quoted name in
-`tests/review-smoke.sh` and run the suite. Anything backed only by a design
+`tests/review-smoke.sh` or `tests/engine-seam.sh` and run that suite. Anything backed only by a design
 description belongs under non-goals instead — naming what this does NOT
 protect against is half the point of the file.
 
@@ -58,6 +58,29 @@ that mattered are pinned by tests.
 Tests: "docs say the adapter wins", "preflight claim corrected", "but still
 says what it misses".
 
+**7. A reviewer is scored on what it wrote, not on what survived the merge.**
+`claims[]` in `findings.json` is extracted from each reviewer's own file by
+grep, with no model in the path. The merge is lossy on purpose — it truncates
+an over-long review to fit the synthesizer's budget and leaves a dead reviewer
+out entirely — so a projection built from the synthesis would mark a reviewer
+as having missed a bug it actually reported.
+Tests: "cap: the finding is NOT in the merge", "cap: but it IS claimed".
+
+**8. Nothing downstream of the reviewers can write to the graded layer.**
+Verification, synthesis and `settle` all produce opinions about findings, and
+all three write `findings[]` only. A `status`, `ledger_id` or verify verdict on
+a claim would make a reviewer's score a function of a later model's quality
+while still looking like a score.
+Tests: "fj: claims carry no settle/verify fields", "engine_claims writes no
+status field", "engine_claims writes no ledger_id".
+
+**9. A panel that degraded still leaves a record.** `findings.json` is written
+whether the merge succeeded, failed, was skipped by the capability preflight,
+or was never asked for — a run with one usable review still made claims, and
+the degraded runs are the ones a benchmark most needs to see.
+Tests: "ns: findings.json still written", "one: findings.json written",
+"one: claims survived".
+
 ## Non-goals, named
 
 - **The preflight reads filenames, plus content for exactly four config
@@ -88,3 +111,11 @@ says what it misses".
   exhaustive.** An undeclared quirk costs one wasted paid call, not a lost
   review — loose is safe, and a declaration earns its place from an observed
   refusal, never a guess. docs/ADDING-AN-AGENT.md has the contract.
+- **The engine/benchmark seam is checked in the source, not enforced at
+  runtime.** `bin/cadre` is one binary that sources both halves, so every
+  function is in scope regardless of which side owns it;
+  `tests/engine-seam.sh` reads the code for a crossing rather than observing a
+  refusal, and it cannot see one made through a variable or an `eval`. Real
+  isolation arrives with the two-binary split. Claim 8 is the part that IS
+  enforced in the output: the assertions there run against a findings.json
+  produced by a real panel.

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -81,6 +81,23 @@ the degraded runs are the ones a benchmark most needs to see.
 Tests: "ns: findings.json still written", "one: findings.json written",
 "one: claims survived".
 
+**10. The recorded panel is the panel that was asked for.** Every roster member
+appears in `panel[]`, and the four states are kept apart: `ok`, `degraded`,
+`absent` (asked, never answered — silence proves nothing) and `skipped` (never
+asked, on purpose, with the gate and reason recorded). A seat filtered out by a
+`?min-lines` gate is not in the dispatch list, so a panel derived from that list
+alone reports a smaller roster than the user configured.
+Tests: "gt: the gated seat is in the panel", "gt: it is skipped, NOT absent",
+"gt: the roster size is honest".
+
+**11. One stray byte cannot empty a reviewer's claims.** A NUL byte anywhere in
+a review makes grep treat the file as binary and collapse its whole output to a
+diagnostic on stderr. Without `-a` on the extraction grep, every finding in that
+review vanishes and the reviewer scores as having found nothing — silently, with
+no diagnostic in the pipeline.
+Tests: "by: without -a the whole review is suppressed", "by: the pre-existing
+claims survive", "by: the finding after the bad byte is claimed".
+
 ## Non-goals, named
 
 - **The preflight reads filenames, plus content for exactly four config

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -540,8 +540,23 @@ review_findings() {
   # number, or one short label, and the severity has to arrive immediately after
   # it. Probed against `**Overall:** no critical problems` and `*not a nit* but
   # worth noting` -- both stay zero, as does the whole corpus.
-  grep -cEi '^ *(#{1,6} *)?[*_`]*([0-9]+[.)]|[-*+])? *(\*\*[A-Za-z][A-Za-z ]{0,18}:?\*\*:? *)?[*_[(`]*(blocking|should[ -]fix|must[ -]fix|nit|critical|major)\**' "$1"
+  grep -cEi "$SEVERITY_RE" "$1"
 }
+
+# ★ ONE definition, two callers, and that is a correctness rail rather than
+# tidiness. This function COUNTS severity lines; lib/engine/ EXTRACTS them for
+# claims[]. A second copy of the pattern over there would drift the moment either
+# side is tuned -- and drift silently, because nothing in cadre compares the two
+# numbers: a review counted at 13 findings and projected as 4 both look fine
+# alone. Same pattern, `-c` here and `-n` there.
+#
+# SEVERITY_WORDS is split out for the same reason. The extractor needs the
+# vocabulary alternation on its own to pull the severity back off a matched line,
+# and spelling that list twice is how the two ends stop agreeing about what a
+# severity is. Every documented near-miss above is a change to the PREFIX; the
+# vocabulary itself has been stable, which is exactly why it is safe to share.
+SEVERITY_WORDS='blocking|should[ -]fix|must[ -]fix|nit|critical|major'
+SEVERITY_RE='^ *(#{1,6} *)?[*_`]*([0-9]+[.)]|[-*+])? *(\*\*[A-Za-z][A-Za-z ]{0,18}:?\*\*:? *)?[*_[(`]*('"$SEVERITY_WORDS"')\**'
 
 # Did this review state a BOTTOM LINE? Not "is it any good" -- only whether the
 # reviewer answered the question it was asked. Two legal forms, both already in

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1180,6 +1180,23 @@ CADRE_SCRUB_ENV=(CADRE_HOME CADRE_ROOT CADRE_JUDGE CADRE_PROMPT_FILE
                  CADRE_ADJUDICATOR CADRE_LEDGER CADRE_ROSTER
                  CADRE_SYNTH CADRE_SYNTH_MAX
                  CADRE_TARGET_MAX_FILES CADRE_TARGET_MAX_KB)
+# The judge is a model too. Default to the first installed candidate and SAY
+# which one, because a silently-chosen judge is a silently-chosen bias.
+#
+# ★ SHARED, not bin/cadre-local, because lib/engine/settle.sh calls it: settle
+# picks a judge when none was passed. It worked from bin/cadre only because
+# everything is sourced into one binary, so the engine was quietly depending on
+# a symbol the benchmark's entrypoint owned -- which is exactly the coupling the
+# two-binary split will trip over. Living here it belongs to neither half.
+pick_judge() {
+  [ -n "${CADRE_JUDGE:-}" ] && return 0
+  local a
+  for a in claude codex grok opencode; do
+    agent_installed "$a" && { CADRE_JUDGE="$a"; return 0; }
+  done
+  return 1
+}
+
 scrubbed_env() {
   local a=(env) v
   for v in "${CADRE_SCRUB_ENV[@]}"; do a+=(-u "$v"); done

--- a/lib/engine/README.md
+++ b/lib/engine/README.md
@@ -1,0 +1,64 @@
+# lib/engine — the review engine
+
+Everything here answers one question: **what did this panel say about this tree?**
+
+It ends at `findings.json`. The other half of cadre — `grade`, the judges,
+`aggregate`, the pass runner — answers a different question, *how good was each
+reviewer*, and it is a **consumer of `findings.json`** and nothing else. That is
+the seam, and `tests/engine-seam.sh` is what holds it.
+
+## The two layers, and which one gets graded
+
+```
+claims[]     verbatim. What each reviewer actually asserted, pulled out of that
+             reviewer's own file by grep. No model in the path.
+             >>> this is the layer the benchmark grades <<<
+
+findings[]   the merged, human-facing view: what the synthesizer said after
+             reading the whole panel. Model-produced, so never graded.
+```
+
+Everything downstream of the reviewers — the synthesizer, an optional `verify`
+overlay, `settle` matching against your ledger — writes `findings[]`. None of
+them may touch `claims[]`.
+
+The reason is worth stating once. A synthesizer paraphrases. A verify pass can be
+wrong about the code. A settle pass encodes one human's dismissals. If any of the
+three could reach `claims[]`, a reviewer's score would become a function of a
+downstream model's quality instead of a function of what the reviewer wrote — and
+it would do that silently, because the score would still look like a score.
+
+## Why claims are extracted from disk, never from the merge
+
+The merge is lossy on purpose:
+
+- an over-long review is cut to fit the synthesizer's budget (`CADRE_SYNTH_MAX`),
+  so its later findings are not in the merge at all;
+- a reviewer that returned nothing is kept out of every denominator, which is
+  correct for a merge and would be a false clearance in a score.
+
+So `engine_claims` re-reads each reviewer's file in full. A projection built by
+parsing `synthesis.md` would mark a reviewer as having missed a bug it reported.
+
+## Contract notes
+
+- `target.base_tree` / `target.reviewed_tree` are **content addresses** and are
+  required. Commit shas are not durable here: the snapshot is an unreferenced
+  stash commit that the next `git gc` reclaims, and on a `--full` or dirty tree
+  there is no revision at all.
+- `severity_stated` on a claim is **verbatim**, never mapped onto
+  `blocking|should-fix|nit`. Mapping is an interpretation and belongs on
+  `findings[]`. A consumer can normalize; it cannot un-normalize.
+- Agreement is **copied from the synthesizer's `[n/d]` tag, never recomputed**.
+  Recomputing a denominator from a count of files restores the bug the merge
+  already fixed: an absent reviewer read as a dissent. No tag means `null`.
+- `findings.json` is a **lossy view**. `runs.jsonl` and `slots.tsv` remain the
+  durable per-seat record, and `synthesis.md` remains the thing a human reads.
+- It is written on **every** path, including the ones where no merge happened.
+  A missing `findings.json` must never be read as a clean panel.
+
+## Files
+
+| file | what it owns |
+| --- | --- |
+| `synthesize.sh` | the merge (`cmd_synthesize`), the claims projection, `findings.json` |

--- a/lib/engine/README.md
+++ b/lib/engine/README.md
@@ -62,3 +62,4 @@ parsing `synthesis.md` would mark a reviewer as having missed a bug it reported.
 | file | what it owns |
 | --- | --- |
 | `synthesize.sh` | the merge (`cmd_synthesize`), the claims projection, `findings.json` |
+| `settle.sh` | the human-written ledger, and splitting a review into NEW vs settled |

--- a/lib/engine/README.md
+++ b/lib/engine/README.md
@@ -71,8 +71,12 @@ parsing `synthesis.md` would mark a reviewer as having missed a bug it reported.
   grep call the file binary and suppress every line **on stderr**, which silently
   empties that reviewer's claims — a reviewer that reported a blocking bug
   reading as one that found nothing.
-- It is written on **every** path, including the ones where no merge happened.
-  A missing `findings.json` must never be read as a clean panel.
+- It is written **whenever a review directory survives** — including every path
+  where no merge happened: preflight skip, a rate-limited merge, one usable
+  review, `--synth none`, and a panel down to a single truncated review. The one
+  case with no file is a run where *every* reviewer failed, which leaves an empty
+  review dir that `cmd_review` removes. So a missing `findings.json` means "no
+  panel output exists", and must never be read as a clean panel.
 
 ## Files
 

--- a/lib/engine/README.md
+++ b/lib/engine/README.md
@@ -54,6 +54,23 @@ parsing `synthesis.md` would mark a reviewer as having missed a bug it reported.
   already fixed: an absent reviewer read as a dissent. No tag means `null`.
 - `findings.json` is a **lossy view**. `runs.jsonl` and `slots.tsv` remain the
   durable per-seat record, and `synthesis.md` remains the thing a human reads.
+- `panel[]` carries **every roster member**, in one of four states, and the
+  distinctions matter more than they look:
+
+  | state | meaning |
+  | --- | --- |
+  | `ok` | returned a complete review |
+  | `degraded` | stopped partway; kept, and excluded from denominators it did not raise |
+  | `absent` | asked, never answered — its silence proves **nothing** |
+  | `skipped` | never asked, on purpose; `skipped_gate`/`skipped_reason` say why |
+
+  `absent` and `skipped` are deliberately not merged. Collapsing them turns a
+  config decision into a reviewer failure, and dropping either makes the panel
+  read cleaner than it was.
+- The extraction grep runs with `-a`. One NUL byte in a review otherwise makes
+  grep call the file binary and suppress every line **on stderr**, which silently
+  empties that reviewer's claims — a reviewer that reported a blocking bug
+  reading as one that found nothing.
 - It is written on **every** path, including the ones where no merge happened.
   A missing `findings.json` must never be read as a clean panel.
 

--- a/lib/engine/settle.sh
+++ b/lib/engine/settle.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# lib/engine/settle.sh -- the settled-decisions ledger, and splitting a review
+# into NEW vs already-settled.
+#
+# ENGINE, not benchmark, and that placement is the answer to the open question on
+# #25. Settle is a LIVE-LOOP concern: it exists so that re-running a review on a
+# branch stops re-raising what a human already dismissed. Nothing about it has an
+# opinion on how good a reviewer is, and the benchmark never calls it.
+#
+# ★★ IT WRITES findings[], NEVER claims[]. A settle disposition is one human's
+# judgement about one repo, so a `status` or `ledger_id` stamped onto the graded
+# layer would make a reviewer's benchmark score a function of Cody's dismissals
+# -- and it would keep looking like a score. engine_findings() puts both fields
+# on findings[] as nulls for exactly this reason: settle has a place to write
+# that is not the place we grade. tests/engine-seam.sh asserts both halves.
+#
+# ★ And the ledger stays HUMAN-WRITTEN. Nothing here appends to it. A tool that
+# files its own dismissals will eventually dismiss something real, and the whole
+# value of the file is that a person decided. Folding settle into the engine does
+# not change that; if a later change gives the engine a way to write the ledger,
+# the treadmill it was built to stop comes back with cadre's signature on it.
+
+# ---- the settled-decisions ledger --------------------------------------------
+#
+# ★ Cadre reviews once and stops, so on its own it cannot treadmill. The moment
+# something WRAPS it in a loop, which is the normal way people use a review tool
+# on a branch, every re-run re-raises findings the human already dismissed. The
+# reviewers have no memory; the human is the only thing that remembers, and
+# making them remember is how a review loop becomes unbearable.
+#
+# The ledger is a human-written file. Nothing writes to it automatically: a tool
+# that files its own dismissals will eventually dismiss something real, and the
+# whole value here is that a person decided. `cadre settle` only READS it.
+LEDGER_HELP='One finding per line:
+
+    <id> | <disposition> | <description>
+
+  L1 | wontfix  | timestamps are strings from neon-http, callers wrap them
+  L2 | accepted | missing test for the retry path, tracked in #412
+
+disposition is yours; cadre does not interpret it.'
+
+ledger_path() { echo "${CADRE_LEDGER:-$CADRE_HOME/ledger}"; }
+
+cmd_ledger() {
+  local lp; lp=$(ledger_path)
+  case "${1:-show}" in
+    show)
+      if [ ! -s "$lp" ]; then
+        echo "no ledger at $lp"; echo; echo "$LEDGER_HELP"; return 0
+      fi
+      echo "$lp"; echo
+      # Comments and blanks are the user's; print the file as they wrote it.
+      cat "$lp" ;;
+    path) echo "$lp" ;;
+    *) die "ledger: expected 'show' or 'path'" ;;
+  esac
+}
+
+# Split one review into SETTLED / NEW against the ledger. Read-only, and it
+# never edits the review: the finding stays on disk exactly as written.
+cmd_settle() {
+  local review="" judge="${CADRE_JUDGE:-}"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --judge) judge="${2:?--judge needs an agent spec}"; shift 2 ;;
+      -*) die "settle: unknown option '$1'" ;;
+      *)  review="$1"; shift ;;
+    esac
+  done
+  [ -n "$review" ] || die "usage: cadre settle <review-file-or-dir> [--judge spec]"
+
+  # A review directory is the normal thing to have: point at the report.
+  [ -d "$review" ] && review="$review/report.md"
+  [ -s "$review" ] || die "no review to read at $review"
+
+  local lp; lp=$(ledger_path)
+  [ -s "$lp" ] || die "no ledger at $lp, so there is nothing settled yet.
+
+     $LEDGER_HELP"
+
+  [ -n "$judge" ] || { pick_judge || true; judge="${CADRE_JUDGE:-}"; }
+  [ -n "$judge" ] || die "settle needs a judge. Set \$CADRE_JUDGE or pass --judge."
+
+  # ★ Strip comments and blanks before the model sees it. A '#' line is a note
+  # to the human, and feeding it as an entry invites a match against a comment.
+  local entries; entries=$(grep -vE '^[[:space:]]*(#|$)' "$lp")
+  [ -n "$entries" ] || die "$lp has no entries, only comments."
+
+  local pf; pf=$(mktemp)
+  { cat "$CADRE_ROOT/lib/prompts/settle.md"; echo
+    echo "===== LEDGER ====="; printf '%s\n' "$entries"; echo
+    echo "===== REVIEW ====="; cat "$review"
+  } > "$pf"
+
+  local a m mm=() raw rc
+  a=$(spec_agent "$judge"); m=$(spec_model "$judge")
+  [ -n "$m" ] && mm=(-M "$m")
+  echo "matching against $(printf '%s\n' "$entries" | wc -l) ledger entries with $judge …"
+  raw=$("$CADRE_ROOT/bin/agentcall" "$a" "${mm[@]}" -d /tmp -m ro < "$pf" 2>&1); rc=$?
+  rm -f "$pf"
+
+  # ★ Fail loudly. A settle pass that silently returns nothing looks exactly
+  # like "everything here is already settled", which would hide a live finding
+  # behind a judge that never ran.
+  # ★ Models fence their JSON. `sed -n '/{/,$p'` took the first { to EOF, which
+  # carries the CLOSING ``` along with it, and jq rejects the trailing fence --
+  # so a judge that answered perfectly was reported as one that "failed or
+  # stopped early". Measured with qwen as judge on a real panel: the correct
+  # findings were printed in the error's own diagnostic lines, which is as close
+  # to self-refuting as a message gets.
+  # Take the first { to the LAST }, after dropping fence lines. That survives
+  # prose on either side of the block and braces inside strings, which a
+  # brace-counting scan does not. Anything that still is not JSON -- no object
+  # at all, or a truncated one -- fails jq and is refused below, which is the
+  # direction that has to stay safe.
+  local js
+  js=$(printf '%s' "$raw" \
+       | sed -e '/^[[:space:]]*```/d' \
+       | awk 'BEGIN{RS="\0"} {
+             i=index($0,"{"); if(!i) exit; s=substr($0,i);
+             for(k=length(s);k>0;k--) if(substr(s,k,1)=="}") { printf "%s", substr(s,1,k); exit }
+           }' \
+       | jq -c . 2>/dev/null) || js=""
+  # ★ Two causes, one message, so say both. An adapter that truncates now exits
+  # nonzero even when the JSON it printed parses fine, and reporting that as
+  # "did not return usable JSON" describes the wrong problem to whoever has to
+  # fix it. A partial match is still refused either way: settle's exit code is a
+  # stopping rule, and half a match reads as "nothing new is left".
+  if [ "$rc" -ne 0 ] || [ -z "$js" ]; then
+    echo "cadre: the judge failed or stopped early, so nothing was matched." >&2
+    printf '%s\n' "$raw" | head -5 | sed 's/^/     /' >&2
+    return 1
+  fi
+
+  local total new
+  total=$(printf '%s' "$js" | jq '.findings | length')
+  new=$(printf '%s' "$js" | jq '[.findings[] | select(.status != "SETTLED")] | length')
+  echo
+  if [ "$total" -eq 0 ]; then echo "no findings in that review."; return 0; fi
+
+  if [ "$new" -gt 0 ]; then
+    echo "NEW ($new of $total):"
+    printf '%s' "$js" | jq -r '.findings[] | select(.status != "SETTLED") | "  - \(.summary)"'
+  fi
+  if [ "$new" -lt "$total" ]; then
+    echo
+    echo "already settled ($((total - new)) of $total), shown so you can check the match:"
+    printf '%s' "$js" | jq -r '.findings[] | select(.status == "SETTLED")
+                               | "  - [\(.ledger_id // "?")] \(.summary)"'
+  fi
+  echo
+  echo "The review itself is unchanged at $review."
+  # ★ The exit status is the useful part for a wrapper: 0 means nothing new to
+  # look at, so a loop can stop. Non-zero means a human still has something to
+  # read. That is the stopping rule, and it is deliberately not automatic.
+  [ "$new" -eq 0 ]
+}

--- a/lib/engine/synthesize.sh
+++ b/lib/engine/synthesize.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+# lib/engine/synthesize.sh -- the review ENGINE: merge the panel, then project
+# what it saw into findings.json.
+#
+# Everything in lib/engine/ answers "what did this panel say about this tree".
+# The BENCHMARK -- grade, judges, scoring -- answers "how good was each reviewer",
+# and it is a CONSUMER of findings.json only. It does not source this directory,
+# which tests/engine-seam.sh asserts, so a foreign findings.json (CodeRabbit, a
+# raw Codex export, anything shaped right) grades with zero engine code run.
+#
+# ★ THE TWO LAYERS, and which one the benchmark is allowed to grade:
+#
+#   claims[]    verbatim. What each reviewer actually asserted, pulled out of
+#               that reviewer's own file by grep. NO MODEL TOUCHES IT.
+#               >>> This is the layer the benchmark grades. <<<
+#   findings[]  the merged, human-facing view: what the synthesizer said after
+#               reading the whole panel. Model-produced, so NOT graded.
+#
+# The direction of that rule is the part worth keeping, because every downstream
+# step is a plausible place to lose it. A synthesizer paraphrases. A verify pass
+# can be wrong about the code. A settle pass encodes one human's dismissals. If
+# any of the three could reach claims[], a reviewer's score would become a
+# function of a downstream model's quality instead of a function of what the
+# reviewer wrote -- and it would do so invisibly, because the score would still
+# look like a score. So: grade reads claims[]; everything downstream may write
+# findings[] and nothing else.
+
+# Merge the reviews. A model too, so the same rate-limit rule applies, and a
+# failure here must not cost the individual reviews: they are already on disk.
+cmd_synthesize() {
+  local out="$1" synth="$2"; shift 2
+  local specs=("$@") sl body="" cap="${CADRE_SYNTH_MAX:-200000}"
+  local dead=() srcspec=() srcfile=() srcstate=() total=0
+  for sp in "${specs[@]}"; do
+    sl=$(slug "$sp")
+    if [ -s "$out/$sl.md" ];           then srcspec+=("$sp"); srcfile+=("$out/$sl.md");         srcstate+=(ok)
+    elif [ -s "$out/$sl.md.partial" ]; then srcspec+=("$sp"); srcfile+=("$out/$sl.md.partial"); srcstate+=(degraded)
+    else dead+=("$sp"); fi
+  done
+  local usable=${#srcspec[@]} i
+  # Partials count toward having something to merge. One full review plus one
+  # partial is still two independent looks at the diff.
+  [ "$usable" -ge 2 ] || { echo "only $usable usable review(s); nothing to synthesize."; return 0; }
+  for i in "${!srcfile[@]}"; do total=$((total + $(wc -c < "${srcfile[$i]}"))); done
+
+  # Over budget, every review gets the same byte share. ★ head -c MAKES a review
+  # partial: a full review cut at 40KB is silent about everything after 40KB for
+  # exactly the reason a truncated one is. Re-label it degraded here or the
+  # silence rule below skips the reviews this function itself just truncated.
+  local per=0
+  if [ "$total" -gt "$cap" ]; then
+    per=$(( cap / usable ))
+    # A share of 0 would announce a truncation and then perform none, quietly
+    # sending the whole oversized body anyway.
+    [ "$per" -lt 1 ] && per=1
+    echo "⚠ reviews total $total bytes, over CADRE_SYNTH_MAX ($cap). Truncating each to $per."
+  fi
+
+  # ★ TWO different facts, kept apart. "The reviewer stopped early" is a fact
+  # about the reviewer's health. "Cadre sent only the first N bytes" is a fact
+  # about what this function did to a reviewer that finished perfectly well.
+  # Both mean the silence that follows proves nothing, so both get the silence
+  # rule -- but telling the synthesizer a healthy reviewer "stopped early" is
+  # simply false, and it is the kind of false that ends up quoted in a report.
+  local partial=() capped=() n=0 text cut
+  for i in "${!srcspec[@]}"; do
+    cut=0
+    if [ "$per" -gt 0 ] && [ "$(wc -c < "${srcfile[$i]}")" -gt "$per" ]; then
+      text=$(head -c "$per" "${srcfile[$i]}"); cut=1
+    else
+      text=$(cat "${srcfile[$i]}")
+    fi
+    # A DIFFERENT delimiter, not just different prose. Under the same delimiter
+    # as a full review the synthesizer has no handle to apply a different rule
+    # to, however carefully the instructions are worded.
+    if [ "${srcstate[$i]}" = degraded ]; then
+      body="$body===== REVIEWER (PARTIAL, THIS REVIEWER STOPPED EARLY): ${srcspec[$i]} ====="$'\n'"$text"$'\n\n'
+      partial+=("${srcspec[$i]}")
+    elif [ "$cut" = 1 ]; then
+      body="$body===== REVIEWER (COMPLETE, BUT CADRE SENT ONLY ITS FIRST $per BYTES): ${srcspec[$i]} ====="$'\n'"$text"$'\n\n'
+      capped+=("${srcspec[$i]}")
+    else
+      body="$body===== REVIEWER: ${srcspec[$i]} ====="$'\n'"$text"$'\n\n'
+      n=$((n + 1))
+    fi
+  done
+  local short=("${partial[@]}" "${capped[@]}")
+  # ★ Two different counts, and conflating them made cadre lie in prose while
+  # the arithmetic stayed right. $n is "full text in front of the synthesizer",
+  # which is the correct denominator floor for a finding only the full reviews
+  # could have named. It is NOT the number of reviewers who finished: a capped
+  # reviewer reviewed the whole diff and returned a complete review, cadre just
+  # sent part of it. Reporting $n as "returned a complete review" understates a
+  # healthy panel, and when every survivor was capped the console announced
+  # "synthesizing 0 review(s)" for a run that was about to synthesize several.
+  local completed=$((n + ${#capped[@]}))
+
+  # ★ Tell the synthesizer who DIED. Without this it sees two reviews, reports
+  # "2/2 agree", and the reader concludes the panel was unanimous when a third
+  # of it never returned. The header line the prompt asks for is what carries
+  # that; these members are NOT in the tags, because a reviewer that never ran
+  # has no opinion to count either way.
+  #
+  # ★ dead[] is anything that is neither .md nor .md.partial, which is what
+  # makes an INCONCLUSIVE run safe by construction: it lands here, and this
+  # block already keeps it out of every denominator. That is the whole fix for
+  # the false green -- no third delimiter, no new counting rule. The delimiter
+  # says NO REVIEW rather than FAILED because a run that exited 0 and wrote 40KB
+  # did not fail, and the prompt asks the synthesizer to describe these members
+  # in the verdict spread.
+  if [ ${#dead[@]} -gt 0 ]; then
+    body="$body===== NO USABLE REVIEW: ${dead[*]} =====
+These roster members produced no usable review. Say so in the verdict spread and
+in the header line. Keep them out of every agreement tag: they neither agree nor
+disagree with anything. This panel was ${#specs[@]} reviewers, of whom $completed
+returned a complete review.
+
+"
+  fi
+  # ★ Incomplete coverage breaks the agreement MATH, not just the prose, and in
+  # the direction nobody checks. Tagging a finding [1/4] when two of the four
+  # never reached that file reads as three dissents; it is one reviewer and two
+  # absences. One rule for both causes, since the consequence is identical, but
+  # each reviewer is listed under the cause that is actually true of it.
+  if [ ${#short[@]} -gt 0 ]; then
+    body="$body===== REVIEWERS WITH INCOMPLETE COVERAGE: ${short[*]} ====="$'\n'
+    [ ${#partial[@]} -gt 0 ] && body="$body\
+  ${partial[*]} -- stopped partway through, out of tokens or time.
+"
+    [ ${#capped[@]} -gt 0 ] && body="$body\
+  ${capped[*]} -- reviewed the whole diff, but their review was too long for
+  this synthesis and CADRE cut it. The reviewer is healthy; the copy you were
+  given is not the whole of what it wrote. Do not say it stopped early.
+"
+    body="$body
+Their text is a real review of the part you can see. Rules for them, unlike a
+review you have in full:
+  - On a finding one of them RAISED, it counts in both the numerator and the
+    denominator, exactly like a complete review.
+  - On a finding it never mentioned, it counts in NEITHER. That code is outside
+    what you were given, so its silence is not agreement, disagreement, or
+    clearance, and the denominator for that finding is smaller. Never list one
+    under Disagreements for something it simply does not mention.
+  - Give no overall verdict on behalf of a reviewer that stopped early.
+
+Do the arithmetic for THIS panel. You have $n review(s) in full and ${#short[@]} with
+incomplete coverage (${short[*]}). For each finding: denominator = $n, plus one
+for EACH of those ${#short[@]} that raised that finding. So it is $n when none of them
+raised it, and at most $((n + ${#short[@]})) when all of them did.
+
+The low end is the case that gets written wrong. A defect only the full reviews
+named is tagged [x/$n]. A bigger number there claims someone looked at that code
+and declined to flag it, which is exactly backwards.
+
+"
+  fi
+
+  local pf="$out/.synth-prompt" raw attempt=1 w
+  { cat "$CADRE_ROOT/lib/prompts/synthesize.md"; echo; printf '%s' "$body"; } > "$pf"
+  local pcount=""
+  [ ${#capped[@]} -gt 0 ] && pcount="$pcount, ${#capped[@]} sent short"
+  [ ${#partial[@]} -gt 0 ] && pcount="$pcount, ${#partial[@]} partial"
+  echo "synthesizing $usable review(s)${pcount:+ ($n full$pcount)} with $synth ..."
+  local a m mm=(); a=$(spec_agent "$synth"); m=$(spec_model "$synth")
+  [ -n "$m" ] && mm=(-M "$m")
+  # Capability preflight: a doomed synthesizer must not burn the merge call.
+  local sblock sdecl sreason
+  if sblock=$(capability_block "$synth" synth); then
+    IFS=$'\t' read -r sdecl sreason <<< "$sblock"
+    echo "synthesis SKIPPED by capability preflight ($sdecl: $sreason). Individual reviews are intact in $out." >&2
+    rm -f "$pf"
+    return 0
+  fi
+  local rc=0
+  while :; do
+    raw=$("$CADRE_ROOT/bin/agentcall" "$a" "${mm[@]}" -d /tmp -m ro < "$pf" 2>&1); rc=$?
+    printf '%s' "$raw" > "$out/.synth-tmp"
+    # ★ The THIRD retry loop. The commit that taught the two reviewer loops to
+    # stop trusting a keyword scan over the adapter left this one asking the old
+    # question, so a healthy short merge that discussed rate limiting burned
+    # three retries and then got filed failed. Same principle, different test,
+    # because a synthesis has no marker to be rescued by. See provider_refused.
+    provider_refused "$out/.synth-tmp" "$rc" || { rm -f "$out/.synth-tmp"; break; }
+    rm -f "$out/.synth-tmp"
+    [ "$attempt" -ge "${CADRE_RETRIES:-3}" ] && break
+    w=$(retry_wait "$attempt")
+    echo "  synthesis rate limited, waiting ${w}s ($((attempt + 1))/${CADRE_RETRIES:-3})"
+    sleep "$w"; attempt=$((attempt + 1))
+  done
+  rm -f "$pf"
+  # ★ Same classifier the reviewers get. An auth error or an exhausted retry is
+  # NON-EMPTY text, so testing only for emptiness filed the error itself as
+  # synthesis.md and the reader saw a merged review that was really a 429. The
+  # synthesizer is a model; it fails like one.
+  # ★ Deliberately NOT three-state: only `ok` survives here. A partial merge is
+  # worthless in a way a partial review is not, because the reviews it was
+  # merging are already on disk and complete. Fail closed and keep them.
+  printf '%s' "$raw" > "$out/.synth-tmp"
+  if [ "$(classify_run "$out/.synth-tmp" "$rc" synth)" != ok ]; then
+    mv "$out/.synth-tmp" "$out/synthesis.md.failed"
+    # ★ Third consumer of the same split (#12). The synthesizer is a model and
+    # fails like one, so "the provider returned nothing" and "cadre's clock cut
+    # a live merge short" are as distinguishable here as on a review -- and the
+    # second one is fixable by re-running with a bigger CADRE_TIMEOUT, which the
+    # old flat message never suggested. No elapsed time is tracked on this path,
+    # so the phrase is asked for without one rather than handed a made-up number.
+    echo "synthesis $(failure_phrase "$out/synthesis.md.failed" "$rc"), kept as synthesis.md.failed." >&2
+    echo "The individual reviews are intact in $out." >&2
+    return 0
+  fi
+  rm -f "$out/.synth-tmp"
+  { echo "# Synthesis ($synth)"; echo
+    echo "_Model-produced and unverified. It merges what the reviewers said; it has"
+    echo "not seen the code. Read the individual reviews before acting._"; echo
+    printf '%s\n' "$raw"
+  } > "$out/synthesis.md"
+  echo "saved: $out/synthesis.md"
+}
+
+# ---- claims[]: the graded layer ----------------------------------------------
+#
+# ★ Deterministic, and it re-reads the reviewer files rather than taking anything
+# out of the synthesis. cmd_synthesize above may hand the synthesizer only the
+# first $per bytes of a review, and it keeps a dead reviewer out of the merge
+# entirely. Both are right for a MERGE and both are lossy, so a claims layer
+# built from the merge would be missing precisely the claims cadre itself
+# declined to forward -- and a reviewer would be scored on the part of its review
+# that happened to fit. Extraction starts at the file on disk, always in full.
+#
+# ★ Same regex as review_findings(), out of ONE variable rather than a second
+# copy of it. That pattern is corpus-measured through four documented near-misses
+# (see the comment above it in common.sh); a divergent copy here would drift in
+# silence, because nothing in cadre compares the two numbers. A count of 13 and a
+# projection of 4 would both look fine on their own. One pattern, two callers --
+# `-c` there, `-n` here.
+#
+# location is deliberately null. The severity line carries a severity and the
+# reviewer's own words; the file:line it is POINTING AT lives in the prose around
+# it, and a guess would put invented coordinates in the layer we grade against.
+engine_claims() {
+  local out="$1"; shift
+  local sp sl f state
+  for sp in "$@"; do
+    sl=$(slug "$sp")
+    if   [ -s "$out/$sl.md" ];         then f="$sl.md";         state=ok
+    elif [ -s "$out/$sl.md.partial" ]; then f="$sl.md.partial"; state=degraded
+    # ★ No file means NO CLAIMS, which is not the same as a clean review, and
+    # the difference is the whole false-green failure. This reviewer still shows
+    # up in panel[] with state=absent, so a consumer counting denominators can
+    # see that it was asked and never answered. Silence is not clearance.
+    else continue
+    fi
+    engine_severity_lines "$out/$f" \
+      | while IFS=$'\t' read -r ln sev text; do
+          jq -cn --arg r "$sp" --arg st "$state" --arg fl "$f" \
+                 --argjson ln "$ln" --arg sev "$sev" --arg tx "$text" \
+            '{reviewer: $r, reviewer_state: $st,
+              severity_stated: (if $sev == "" then null else $sev end),
+              source: {file: $fl, line: $ln}, source_text: $tx,
+              location: null}'
+        done
+  done
+  return 0
+}
+
+# One severity line per output row: LINE <tab> SEVERITY <tab> TEXT.
+#
+# ★ The severity is re-matched with the SAME anchored pattern and the vocabulary
+# word is taken from the END of that match, which is where the pattern puts it.
+# Scanning the bare line for a vocabulary word instead would misread the one
+# labelled shape the anchor deliberately admits: in `**Critical:** should-fix`
+# the leftmost vocabulary word is in the LABEL, and the severity is the one after
+# it. Taking the tail of the anchored match cannot make that mistake.
+#
+# ★ `-m1` rather than `| head -1`: this repo has already paid for a `grep`
+# feeding a consumer that leaves early (agent_installed, 43 failing tests), and
+# under `pipefail` the SIGPIPE would surface here as an empty severity on a line
+# that matched perfectly well. `tail` is safe in the same pipeline for the
+# opposite reason -- it reads to EOF, so nothing upstream is cut short.
+#
+# severity_stated is VERBATIM, never mapped onto blocking|should-fix|nit. The
+# mapping is an interpretation ("major" -> which of the three?), and an
+# interpretation belongs on findings[], not on the layer a reviewer is scored
+# from. A consumer that wants the three-value vocabulary can normalize; it cannot
+# recover the original once cadre has overwritten it.
+#
+# ★★ THE `return 0` IS LOAD-BEARING AND IT COST FOUR REAL CLAIMS. A review with
+# no severity lines is a CLEAN REVIEW, not an error -- but `grep` says 1 for it,
+# `pipefail` promotes that to the pipeline, and the 1 becomes this function's
+# exit status. Every caller then reads "the extractor failed". Measured: a panel
+# of finder,good ended its loop on `good`, which finds nothing, so engine_claims
+# returned 1 and engine_write_findings' `|| claims='[]'` threw away four
+# correctly extracted claims and wrote an empty array -- silently, over a review
+# that had named a blocking bug. The projection LOOKED like an honest "this
+# reviewer found nothing", which is the worst available failure for this file:
+# the layer we grade from, wrong in the direction that clears a reviewer.
+#
+# Same shape as agent_installed's SIGPIPE bug and the same lesson: under
+# `pipefail`, a `grep` whose no-match is a legitimate answer must have its status
+# discarded on purpose, at the point where the meaning is known.
+engine_severity_lines() {
+  local f="$1" ln text sev
+  grep -nEi "$SEVERITY_RE" "$f" 2>/dev/null | while IFS=: read -r ln text; do
+    sev=$(printf '%s' "$text" | grep -m1 -oEi "$SEVERITY_RE" \
+          | grep -oEi "$SEVERITY_WORDS" | tail -1)
+    printf '%s\t%s\t%s\n' "$ln" "$sev" "$text"
+  done
+  return 0
+}
+
+# ---- findings[]: the merged view ---------------------------------------------
+#
+# The synthesis is prose, so this is a LOSSY projection of it and says so in the
+# contract: runs.jsonl and slots.tsv stay the durable per-seat record, and
+# synthesis.md stays the thing a human reads. What survives into JSON is the one
+# structured thing the synthesizer is asked to produce -- a severity and its
+# [n/d] quorum -- so that a consumer can filter and count without a model.
+#
+# ★ agreement is copied, never computed. The denominator is the synthesizer's own
+# arithmetic over a panel where absent reviewers are excluded by construction
+# (the NO USABLE REVIEW block above), and recomputing it here from a count of
+# files would quietly restore the bug that block exists to prevent: an absence
+# read as a dissent. No tag means null, not [n/1].
+#
+# status/ledger_id start null and are the slots `cadre settle` fills in. They sit
+# on findings[] and there is no equivalent on claims[] -- see the header.
+engine_findings() {
+  local out="$1" f="$out/synthesis.md" q num den
+  [ -s "$f" ] || return 0
+  engine_severity_lines "$f" | while IFS=$'\t' read -r ln sev text; do
+    q=$(printf '%s' "$text" | grep -m1 -oE '\[[0-9]+/[0-9]+\]')
+    num=""; den=""
+    if [ -n "$q" ]; then q=${q#[}; q=${q%]}; num=${q%/*}; den=${q#*/}; fi
+    jq -cn --argjson ln "$ln" --arg sev "$sev" --arg tx "$text" \
+           --arg num "$num" --arg den "$den" \
+      '{severity: (if $sev == "" then null else $sev end),
+        agreement: (if $den == "" then null
+                    else {numerator: ($num | tonumber),
+                          denominator: ($den | tonumber)} end),
+        source: {file: "synthesis.md", line: $ln}, source_text: $tx,
+        status: null, ledger_id: null}'
+  done
+  return 0
+}
+
+# Every roster member with the state its artifacts prove, absent ones included.
+engine_panel() {
+  local out="$1"; shift
+  local sp sl state
+  for sp in "$@"; do
+    sl=$(slug "$sp")
+    if   [ -s "$out/$sl.md" ];         then state=ok
+    elif [ -s "$out/$sl.md.partial" ]; then state=degraded
+    else state=absent
+    fi
+    jq -cn --arg r "$sp" --arg st "$state" '{reviewer: $r, state: $st}'
+  done
+  return 0
+}
+
+# ---- findings.json -----------------------------------------------------------
+#
+# ★ Written on EVERY path, including the ones where no merge happened: a panel
+# whose synthesizer was skipped by the capability preflight, whose merge came
+# back a 429, or that had only one usable review, still produced claims. Hanging
+# this off cmd_synthesize's success path would make a degraded run vanish from
+# the benchmark's view entirely -- the same absence-read-as-nothing shape the NO
+# USABLE REVIEW block above exists to stop, one layer up. So the caller invokes
+# it unconditionally, `--synth none` included, and the synthesis status is
+# derived from which artifact is on disk rather than from a flag some earlier
+# `return 0` never got to set.
+#
+# ★ base_tree/reviewed_tree are content addresses and they are the identity of
+# what was reviewed. Commit shas are not: run-review.sh builds the snapshot as an
+# unreferenced stash commit that the next `git gc` reclaims, and on a dirty or
+# `--full` tree there is no durable revision at all. They come out of
+# manifest.txt, which cmd_review has already written. A manifest that cannot be
+# read yields null and says so on stderr -- writing an invented tree id into the
+# graded layer is the one outcome worse than admitting the gap.
+engine_write_findings() {
+  local out="$1" synth="$2"; shift 2
+  local specs=("$@") mf="$out/manifest.txt" base="" rev="" sstatus
+  [ -d "$out" ] || return 0
+
+  if [ -s "$mf" ]; then
+    base=$(sed -n 's/^base-tree:[[:space:]]*//p'     "$mf" | head -1)
+    rev=$( sed -n 's/^reviewed-tree:[[:space:]]*//p' "$mf" | head -1)
+  fi
+  [ "$base" = unknown ] && base=""
+  [ "$rev"  = unknown ] && rev=""
+  { [ -n "$base" ] && [ -n "$rev" ]; } \
+    || echo "cadre: ⚠ no tree ids in $mf; findings.json is not content-addressed." >&2
+
+  # ★ Derived from the artifacts, not from a variable. `skipped` merges two
+  # causes -- the capability preflight refused the synth slot, or fewer than two
+  # reviews were usable to merge -- because on disk they are the same fact: no
+  # merge was attempted. Neither is a failure, and neither costs the claims.
+  if   [ -s "$out/synthesis.md" ];        then sstatus=ok
+  elif [ -s "$out/synthesis.md.failed" ]; then sstatus=failed
+  elif [ "$synth" = none ] || [ -z "$synth" ]; then sstatus=not_run
+  else sstatus=skipped
+  fi
+
+  # ★ NO `|| x='[]'` HERE, and that is the fix for a bug this function shipped
+  # with. Defaulting a failed projection to the empty array turns "the extractor
+  # broke" into "the reviewer found nothing" -- identical on disk, opposite in
+  # meaning, and the wrong one clears a reviewer that named a blocking bug. It
+  # really happened: see the note on engine_severity_lines. `jq -s .` over no
+  # input is already `[]` with status 0, so the empty case needs no help; the
+  # nonzero case must reach the operator instead of being papered over.
+  local claims findings panel
+  claims=$(engine_claims     "$out" "${specs[@]}" | jq -s .)
+  findings=$(engine_findings "$out"               | jq -s .)
+  panel=$(engine_panel       "$out" "${specs[@]}" | jq -s .)
+  if [ -z "$claims" ] || [ -z "$findings" ] || [ -z "$panel" ]; then
+    echo "cadre: ⚠ the findings projection failed; no findings.json written for $out." >&2
+    echo "     The reviews themselves are intact. Do not read a missing file as a clean panel." >&2
+    return 0
+  fi
+
+  jq -n --arg base "$base" --arg rev "$rev" --arg synth "$synth" \
+        --arg sstatus "$sstatus" \
+        --argjson claims "$claims" --argjson findings "$findings" \
+        --argjson panel "$panel" \
+    '{schema: "cadre/findings@1",
+      target: {base_tree:     (if $base == "" then null else $base end),
+               reviewed_tree: (if $rev  == "" then null else $rev  end)},
+      panel: $panel,
+      synthesis: {status: $sstatus,
+                  agent: (if $synth == "" or $synth == "none" then null
+                          else $synth end)},
+      verify: {ran: false},
+      claims: $claims,
+      findings: $findings}' > "$out/findings.json" \
+    || { echo "cadre: ⚠ could not write $out/findings.json" >&2; return 0; }
+  echo "saved: $out/findings.json"
+}

--- a/lib/engine/synthesize.sh
+++ b/lib/engine/synthesize.sh
@@ -298,9 +298,28 @@ engine_claims() {
 # Same shape as agent_installed's SIGPIPE bug and the same lesson: under
 # `pipefail`, a `grep` whose no-match is a legitimate answer must have its status
 # discarded on purpose, at the point where the meaning is known.
+#
+# ★ `-a` IS NOT OPTIONAL. One invalid byte anywhere in a review makes grep call
+# the whole file binary: it prints "Binary file ... matches" and NOT ONE line
+# number, so every finding in that review silently disappears from claims[] and
+# the reviewer reads as having found nothing. Reviewers emit stray bytes for dull
+# reasons -- a CLI's cursor escapes, a latin-1 quote, a truncated multi-byte
+# character at a token boundary -- and this is the graded layer, so the loss lands
+# in the direction that clears a reviewer that did its job. `-a` is in both GNU
+# and BSD grep. Found by a cross-model review of this commit.
+#
+# ★ The digit guard is the belt to that braces, and it WARNS rather than dropping
+# quietly. Anything that is not `<digits>:<text>` is not a grep -n line, so the
+# claim cannot be trusted -- but a claim silently missing from the graded layer is
+# exactly the failure being defended against, so it has to be said out loud.
 engine_severity_lines() {
   local f="$1" ln text sev
-  grep -nEi "$SEVERITY_RE" "$f" 2>/dev/null | while IFS=: read -r ln text; do
+  grep -anEi "$SEVERITY_RE" "$f" 2>/dev/null | while IFS=: read -r ln text; do
+    case "$ln" in
+      ''|*[!0-9]*)
+        echo "cadre: ⚠ unparsable match in $f (\"$ln\"); that line is NOT in findings.json." >&2
+        continue ;;
+    esac
     sev=$(printf '%s' "$text" | grep -m1 -oEi "$SEVERITY_RE" \
           | grep -oEi "$SEVERITY_WORDS" | tail -1)
     printf '%s\t%s\t%s\n' "$ln" "$sev" "$text"
@@ -325,7 +344,18 @@ engine_severity_lines() {
 # status/ledger_id start null and are the slots `cadre settle` fills in. They sit
 # on findings[] and there is no equivalent on claims[] -- see the header.
 engine_findings() {
-  local out="$1" f="$out/synthesis.md" q num den
+  # ★ SEPARATE STATEMENTS, the same rule case_dir() in the smoke suite carries.
+  # bash expands every word of a `local` line before any of its assignments take
+  # effect, so `local out="$1" f="$out/synthesis.md"` sets f to "/synthesis.md".
+  # This function shipped that way for one commit and WORKED, which is the part
+  # worth remembering: dynamic scoping meant `$out` resolved to the caller's
+  # variable of the same name, and engine_write_findings' `out` happens to hold
+  # the identical value. Correct output, by coincidence, from a line that is
+  # wrong -- and it fails the moment the caller renames its local or anything
+  # calls this directly.
+  local out="$1"
+  local f="$out/synthesis.md"
+  local q num den
   [ -s "$f" ] || return 0
   engine_severity_lines "$f" | while IFS=$'\t' read -r ln sev text; do
     q=$(printf '%s' "$text" | grep -m1 -oE '\[[0-9]+/[0-9]+\]')
@@ -344,17 +374,39 @@ engine_findings() {
 }
 
 # Every roster member with the state its artifacts prove, absent ones included.
+#
+# ★ GATE-SKIPPED SEATS ARE IN HERE TOO, and they arrive by a separate channel
+# because cmd_review never puts them in `specs` -- a seat whose `?min-lines` gate
+# failed is filtered out before dispatch, so a panel built from `specs` alone
+# reports a roster of two where the user asked for three. That is the same
+# false-clearance shape as dropping a dead reviewer, just sourced from config
+# instead of from a failure: the panel reads cleaner than it was. Found by a
+# cross-model review of this commit.
+#
+# `skipped` is DISTINCT from `absent` and the difference is the whole point.
+# absent = it was asked and did not answer, so its silence proves nothing.
+# skipped = it was never asked, on purpose, and the reason is recorded.
+# Collapsing them would turn a deliberate config choice into a reviewer failure.
 engine_panel() {
-  local out="$1"; shift
-  local sp sl state
+  local out="$1" skipped_env="$2"; shift 2
+  local sp sl state gate reason
   for sp in "$@"; do
     sl=$(slug "$sp")
     if   [ -s "$out/$sl.md" ];         then state=ok
     elif [ -s "$out/$sl.md.partial" ]; then state=degraded
     else state=absent
     fi
-    jq -cn --arg r "$sp" --arg st "$state" '{reviewer: $r, state: $st}'
+    jq -cn --arg r "$sp" --arg st "$state" \
+      '{reviewer: $r, state: $st, skipped_gate: null, skipped_reason: null}'
   done
+  # Same tab-separated `spec<TAB>gate<TAB>reason` rows cmd_review already builds
+  # for CADRE_SKIPPED, so there is one format for a skip rather than two.
+  [ -n "$skipped_env" ] || return 0
+  while IFS=$'\t' read -r sp gate reason; do
+    [ -n "$sp" ] || continue
+    jq -cn --arg r "$sp" --arg g "$gate" --arg rs "$reason" \
+      '{reviewer: $r, state: "skipped", skipped_gate: $g, skipped_reason: $rs}'
+  done <<< "$skipped_env"
   return 0
 }
 
@@ -378,8 +430,9 @@ engine_panel() {
 # read yields null and says so on stderr -- writing an invented tree id into the
 # graded layer is the one outcome worse than admitting the gap.
 engine_write_findings() {
-  local out="$1" synth="$2"; shift 2
-  local specs=("$@") mf="$out/manifest.txt" base="" rev="" sstatus
+  local out="$1" synth="$2" skipped_env="$3"; shift 3
+  local specs=("$@")
+  local mf="$out/manifest.txt" base="" rev="" sstatus
   [ -d "$out" ] || return 0
 
   if [ -s "$mf" ]; then
@@ -411,7 +464,7 @@ engine_write_findings() {
   local claims findings panel
   claims=$(engine_claims     "$out" "${specs[@]}" | jq -s .)
   findings=$(engine_findings "$out"               | jq -s .)
-  panel=$(engine_panel       "$out" "${specs[@]}" | jq -s .)
+  panel=$(engine_panel       "$out" "$skipped_env" "${specs[@]}" | jq -s .)
   if [ -z "$claims" ] || [ -z "$findings" ] || [ -z "$panel" ]; then
     echo "cadre: ⚠ the findings projection failed; no findings.json written for $out." >&2
     echo "     The reviews themselves are intact. Do not read a missing file as a clean panel." >&2

--- a/tests/engine-seam.sh
+++ b/tests/engine-seam.sh
@@ -34,8 +34,15 @@ echo "== the benchmark must not call into the engine =="
 # stops being possible and nobody finds out until they try.
 BENCH="$ROOT/lib/grade.sh $ROOT/lib/adjudicate.sh $ROOT/lib/run-pass.sh $ROOT/lib/aggregate.sh"
 for f in $BENCH; do
+  # ★ NO `\b`. It is a GNU grep extension and BSD grep -- what macOS ships --
+  # reads it as a literal `b`, so `\bengine_` searches for `bengine_` and matches
+  # nothing. This check would then pass on an entire platform no matter how many
+  # engine calls the benchmark had grown, which is the worst failure a test can
+  # have. common.sh's has_verdict carries the same ban for the same reason.
+  # Dropping it only makes the pattern looser, and loose is the safe direction
+  # here: a false alarm is read once, a silent pass is trusted forever.
   check "$(basename "$f") calls no engine_* function" \
-    "! code_only < '$f' | grep -qE '\bengine_[a-z_]+'"
+    "! code_only < '$f' | grep -qE 'engine_[a-z_]+'"
   check "$(basename "$f") does not call cmd_synthesize" \
     "! code_only < '$f' | grep -q 'cmd_synthesize'"
   # ★ settle and the ledger are engine too, and this is the direction that would

--- a/tests/engine-seam.sh
+++ b/tests/engine-seam.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Holds the engine/benchmark seam (#25). Static and fast: no models, no reviews.
+#
+#   tests/engine-seam.sh
+#
+# The seam is the claim that lib/engine/ PRODUCES findings.json and the benchmark
+# half of cadre only CONSUMES it. That claim is worth nothing as prose -- the
+# whole reason it is written down is that every future change is a chance to
+# reach across it for one convenient symbol, and nothing about that would fail.
+#
+# ⚠ STRUCTURAL, and honestly weaker than it will be. `bin/cadre` is still one
+# binary that sources both halves, so at runtime every function is in scope no
+# matter who owns it: these checks read the source rather than observing a
+# refusal. The two-binary split (#25 PR3) is what turns them into real isolation.
+# Until then this catches the ordinary way the seam gets crossed -- somebody
+# calls an engine function from the grading path because it was right there.
+set -uo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS + 1)); echo "  ok   $*"; }
+bad()  { FAIL=$((FAIL + 1)); echo "  FAIL $*"; }
+check(){ if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+# Comment lines are exempt throughout. The comments that EXPLAIN this seam name
+# the symbols on both sides of it, and a rule that cannot tell a call from an
+# explanation punishes documentation. Same exemption the \x1b ban in
+# review-smoke.sh needs, for the same reason.
+code_only() { grep -vE '^[[:space:]]*#'; }
+
+echo "== the benchmark must not call into the engine =="
+# grade, the judges and the pass runner are the benchmark. If any of them calls
+# an engine_* function or cmd_synthesize, then grading a FOREIGN findings.json
+# stops being possible and nobody finds out until they try.
+BENCH="$ROOT/lib/grade.sh $ROOT/lib/adjudicate.sh $ROOT/lib/run-pass.sh $ROOT/lib/aggregate.sh"
+for f in $BENCH; do
+  check "$(basename "$f") calls no engine_* function" \
+    "! code_only < '$f' | grep -qE '\bengine_[a-z_]+'"
+  check "$(basename "$f") does not call cmd_synthesize" \
+    "! code_only < '$f' | grep -q 'cmd_synthesize'"
+  check "$(basename "$f") sources nothing from lib/engine" \
+    "! code_only < '$f' | grep -q 'lib/engine'"
+done
+
+echo "== and the engine must not reach back into the benchmark =="
+# The other direction, which is the one that looks harmless. An engine that
+# knows about grades, judges or answer keys cannot be handed to somebody who
+# only wants a review, and the packaging goal (#7) dies quietly.
+for f in "$ROOT"/lib/engine/*.sh; do
+  check "$(basename "$f") does not call the grader" \
+    "! code_only < '$f' | grep -qE 'cmd_grade|judge_[a-z_]+|answer_key|score_'"
+  check "$(basename "$f") does not read slots.tsv or the pass config" \
+    "! code_only < '$f' | grep -qE 'slots\.tsv|passes\.conf'"
+done
+
+echo "== the graded layer is verbatim: nothing downstream may write to it =="
+# ★ THE RAIL, asserted in the source as well as in the output. review-smoke.sh
+# checks that a real findings.json has no settle or verify keys on its claims;
+# this checks that no code was written with the intent of putting them there. A
+# `status` or `ledger_id` assigned inside the claims projection is the whole
+# failure -- a reviewer's score becoming a function of a later model's opinion --
+# and it would still produce a valid-looking file.
+CLAIMS=$(sed -n '/^engine_claims()/,/^}/p' "$ROOT/lib/engine/synthesize.sh")
+check "engine_claims writes no status field" "! grep -q 'status:' <<<\"\$CLAIMS\""
+check "engine_claims writes no ledger_id"    "! grep -q 'ledger_id' <<<\"\$CLAIMS\""
+check "engine_claims writes no verdict"      "! grep -q 'verdict' <<<\"\$CLAIMS\""
+# ...and the merged layer is where they DO belong, so settle has somewhere to go.
+FINDS=$(sed -n '/^engine_findings()/,/^}/p' "$ROOT/lib/engine/synthesize.sh")
+check "engine_findings keeps the settle slots" \
+  "grep -q 'status:' <<<\"\$FINDS\" && grep -q 'ledger_id' <<<\"\$FINDS\""
+check "verify defaults to off"  "grep -q 'ran: false' '$ROOT/lib/engine/synthesize.sh'"
+
+echo "== one severity pattern, not two =="
+# ★ The extraction pattern is shared with review_findings() out of a single
+# variable in common.sh. A literal copy in lib/engine/ would drift the moment
+# either side is tuned, and drift where nothing compares the two numbers: the
+# count says 13 findings, the projection emits 4, and both look fine alone.
+check "the pattern is defined once" \
+  "[ \$(grep -c '^SEVERITY_RE=' '$ROOT/lib/common.sh') -eq 1 ]"
+check "the engine holds no copy of it" \
+  "! code_only < '$ROOT/lib/engine/synthesize.sh' | grep -q 'should\[ -\]fix'"
+check "the engine uses the shared one" \
+  "grep -q 'SEVERITY_RE' '$ROOT/lib/engine/synthesize.sh'"
+
+echo "== a FOREIGN findings.json is readable with no cadre code at all =="
+# The acceptance test for the contract itself: this fixture was not produced by
+# cadre, and everything below is plain jq. If the format needed an engine helper
+# to interpret, the seam would be a seam in name only.
+#
+# ⚠ What this does NOT yet prove: that `cadre grade` scores it. Grading still
+# reads review.md by design in PR1, so the consumer half lands with the grade
+# migration (#25 PR3) and this fixture is what it will be pointed at.
+FX="$ROOT/tests/fixtures/foreign-findings.json"
+check "the fixture is valid json"    "jq -e . '$FX' >/dev/null"
+check "it declares the schema"       "[ \"\$(jq -r .schema '$FX')\" = 'cadre/findings@1' ]"
+check "it is content-addressed"      "jq -e '.target.base_tree and .target.reviewed_tree' '$FX' >/dev/null"
+check "every claim names a reviewer"  \
+  "[ \$(jq '[.claims[] | select(.reviewer == null)] | length' '$FX') -eq 0 ]"
+check "every claim carries its own words" \
+  "[ \$(jq '[.claims[] | select(.source_text == null or .source_text == \"\")] | length' '$FX') -eq 0 ]"
+# ★ Verbatim means a severity cadre's own vocabulary does not contain must
+# survive the round trip. This fixture says `major`, and a contract that quietly
+# rewrote it to should-fix would be grading its own paraphrase.
+check "a foreign severity is not rewritten" \
+  "[ \"\$(jq -r '.claims[0].severity_stated' '$FX')\" = 'major' ]"
+check "an unknown key does not invalidate it" "jq -e '._note' '$FX' >/dev/null"
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/engine-seam.sh
+++ b/tests/engine-seam.sh
@@ -38,6 +38,13 @@ for f in $BENCH; do
     "! code_only < '$f' | grep -qE '\bengine_[a-z_]+'"
   check "$(basename "$f") does not call cmd_synthesize" \
     "! code_only < '$f' | grep -q 'cmd_synthesize'"
+  # ★ settle and the ledger are engine too, and this is the direction that would
+  # actually be tempting: a grading run that filtered out findings the human had
+  # already dismissed would score reviewers against one person's ledger, and the
+  # scores would still look like scores. grade.sh mentions cmd_settle in a
+  # comment, which is why code_only exists.
+  check "$(basename "$f") does not call settle or the ledger" \
+    "! code_only < '$f' | grep -qE 'cmd_settle|cmd_ledger|ledger_path'"
   check "$(basename "$f") sources nothing from lib/engine" \
     "! code_only < '$f' | grep -q 'lib/engine'"
 done
@@ -69,6 +76,17 @@ FINDS=$(sed -n '/^engine_findings()/,/^}/p' "$ROOT/lib/engine/synthesize.sh")
 check "engine_findings keeps the settle slots" \
   "grep -q 'status:' <<<\"\$FINDS\" && grep -q 'ledger_id' <<<\"\$FINDS\""
 check "verify defaults to off"  "grep -q 'ran: false' '$ROOT/lib/engine/synthesize.sh'"
+# ★ settle is the concrete case, and the one folding it into the engine created:
+# it now sits beside the projection, so reaching claims[] is a two-line change
+# nobody would notice. It reads the ledger and the review; it writes neither
+# layer today, and when it starts writing it is findings[] it may write.
+check "settle never mentions claims" \
+  "! code_only < '$ROOT/lib/engine/settle.sh' | grep -q 'claims'"
+# ★ And it still does not write the ledger. The file is human-authored on
+# purpose: a tool that files its own dismissals eventually dismisses something
+# real. `cadre settle` only READS it, and that has to survive the move.
+check "settle does not write the ledger" \
+  "! code_only < '$ROOT/lib/engine/settle.sh' | grep -qE '>+[[:space:]]*\"?\\\$lp|tee.*\\\$lp'"
 
 echo "== one severity pattern, not two =="
 # ★ The extraction pattern is shared with review_findings() out of a single

--- a/tests/fixtures/foreign-findings.json
+++ b/tests/fixtures/foreign-findings.json
@@ -1,0 +1,32 @@
+{
+  "schema": "cadre/findings@1",
+  "_note": "NOT produced by cadre. A CodeRabbit run, mapped by hand into the contract, so tests/engine-seam.sh can prove the format is consumable without any cadre engine code. Deliberately carries an extra key and omits every optional one.",
+  "target": {
+    "base_tree": "9f637265ab1c0d3e4f5a6b7c8d9e0f1a2b3c4d5e",
+    "reviewed_tree": "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d"
+  },
+  "panel": [
+    { "reviewer": "coderabbit", "state": "ok" }
+  ],
+  "synthesis": { "status": "not_run", "agent": null },
+  "verify": { "ran": false },
+  "claims": [
+    {
+      "reviewer": "coderabbit",
+      "reviewer_state": "ok",
+      "severity_stated": "major",
+      "source": { "file": "coderabbit.md", "line": 12 },
+      "source_text": "major: the session token is written to the request log",
+      "location": null
+    },
+    {
+      "reviewer": "coderabbit",
+      "reviewer_state": "ok",
+      "severity_stated": "nit",
+      "source": { "file": "coderabbit.md", "line": 41 },
+      "source_text": "nit: prefer a named constant for the retry ceiling",
+      "location": null
+    }
+  ],
+  "findings": []
+}

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -22,7 +22,8 @@ setup_agents() {
   mkdir -p "$1/bin" "$1/agents.d"
   local n
   for n in good good2 trunc dead echoer chrome terse ratepart ratelim \
-           synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2; do
+           synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2 \
+           finder bigfinder; do
     printf '#!/bin/sh\nexit 0\n' > "$1/bin/$n"; chmod +x "$1/bin/$n"
   done
   # ★ The trailing verdict is not decoration. review-live.md asks every reviewer
@@ -69,6 +70,36 @@ A
   # synthesizer was actually TOLD rather than on a stub's invented answer.
   cat > "$1/agents.d/echoer.sh" <<'A'
 run_echoer() { printf '%s\n' "$prompt"; }
+A
+  # ★ Actually states severities, which every stub above this line does not. A
+  # claims projection cannot be demonstrated by a panel that found nothing: the
+  # empty array is also what a broken extractor returns. Each line here is one of
+  # the shapes review_findings() is anchored to and paid for -- a bare list item,
+  # a labelled field, a bolded numbered heading -- plus the two that must stay
+  # OUT, which is the half of the assertion that a looser pattern breaks.
+  cat > "$1/agents.d/finder.sh" <<'A'
+run_finder() {
+  echo "- blocking: the retry loop deletes the partial it is retrying"
+  echo "* **Severity**: should-fix"
+  echo "#### **1. \`nit\`** name the variable"
+  echo "* **Critical:** should-fix"
+  echo "This is not blocking, and no major issues remain in the helper."
+  echo "Verdict: blocking"
+}
+A
+  # ★ A review whose LAST line is its only severity, padded past any sane
+  # CADRE_SYNTH_MAX. cmd_synthesize hands the synthesizer `head -c $per` of this,
+  # so that finding is not in the merge -- and it must still be in claims[],
+  # because claims are extracted from the file. This stub is the whole argument
+  # for why the projection re-reads disk instead of parsing the synthesis.
+  cat > "$1/agents.d/bigfinder.sh" <<'A'
+run_bigfinder() {
+  local i
+  echo "REVIEW by bigfinder"
+  for i in $(seq 1 400); do echo "Padding line $i, ordinary prose, no severity."; done
+  echo "- blocking: PAST_THE_CAP the token is logged in cleartext"
+  echo "Verdict: blocking"
+}
 A
   # ★ Returns NO review, only the CLI's own chrome. Measured with opencode,
   # which prints colour escapes and a banner around the model's text: the file
@@ -1401,11 +1432,19 @@ echo "== ★ the prompt must name the delimiters the harness actually emits =="
 # longer bound to anything in the body. The suite asserted the emitted string
 # and the prompt's text separately, and neither noticed they had stopped
 # matching. Assert the SAME literal against both, so a rename must touch both.
+#
+# ★ Searched across bin/ and lib/ rather than at bin/cadre, because the thing
+# being asserted is the PAIRING and the emitting file is allowed to move. It
+# already has: cmd_synthesize now lives in lib/engine/synthesize.sh, and pinning
+# the path failed these two checks on a pure relocation while the prompt and the
+# harness still agreed perfectly -- a false alarm that teaches the next person to
+# edit the test instead of reading it. Recursive is also what the \x1b ban above
+# does, for the same reason.
 P_PARTIAL='===== REVIEWER (PARTIAL, THIS REVIEWER STOPPED EARLY):'
 P_CAPPED='===== REVIEWER (COMPLETE, BUT CADRE SENT ONLY ITS FIRST'
-check "harness emits the partial delimiter" "grep -qF '$P_PARTIAL' $ROOT/bin/cadre"
+check "harness emits the partial delimiter" "grep -rqF '$P_PARTIAL' $ROOT/bin $ROOT/lib"
 check "prompt teaches the partial delimiter" "grep -qF '$P_PARTIAL' $ROOT/lib/prompts/synthesize.md"
-check "harness emits the capped delimiter"  "grep -qF '$P_CAPPED' $ROOT/bin/cadre"
+check "harness emits the capped delimiter"  "grep -rqF '$P_CAPPED' $ROOT/bin $ROOT/lib"
 check "prompt teaches the capped delimiter" "grep -qF '$P_CAPPED' $ROOT/lib/prompts/synthesize.md"
 
 echo "== ★ a retry must not destroy the partial it is retrying =="
@@ -3286,6 +3325,104 @@ check "e2e: the silent pass is still named"  "grep -q 'every run came back EMPTY
 check "e2e: the silent pass exited 7"        "grep -q 'run-pass.sh exited 7' <<<\"\$OUTQ\""
 check "e2e: and the real score survives"     "grep -q 'blocking items hit' '$RQ'"
 check "e2e: half-dead sweep does not exit 7" "[ '$RCQ' -ne 7 ]"
+
+echo "== ★ findings.json: the engine's output, and what it must never lose =="
+# The engine/benchmark seam (#25). findings.json is what a consumer grades, so
+# every assertion here is about a way the file could look right and be wrong.
+D=$(case_dir engine_out); S="$D/src"
+git -C "$S" checkout -qb feature; echo change >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster finder,good,dead --base main --synth echoer --label fj "$S")
+FJ="$D/state/reviews/fj/findings.json"
+check "fj: findings.json is written"   "[ -s '$FJ' ]"
+check "fj: it is valid json"           "jq -e . '$FJ' >/dev/null"
+check "fj: schema is declared"         "[ \"\$(jq -r .schema '$FJ')\" = 'cadre/findings@1' ]"
+
+# ★ Content-addressed, per run-review.sh: the snapshot COMMIT is an unreferenced
+# stash that `git gc` reclaims, so a consumer holding a commit sha cannot prove
+# later what was reviewed. The tree ids can.
+check "fj: base_tree recorded"     "jq -e '.target.base_tree | test(\"^[0-9a-f]{7,}\$\")' '$FJ' >/dev/null"
+check "fj: reviewed_tree recorded" "jq -e '.target.reviewed_tree | test(\"^[0-9a-f]{7,}\$\")' '$FJ' >/dev/null"
+
+# The four shapes the anchor is built for, and the two that must stay out.
+check "fj: every stated severity is claimed" \
+  "[ \$(jq '[.claims[] | select(.reviewer | startswith(\"finder\"))] | length' '$FJ') -eq 4 ]"
+check "fj: prose about blocking is NOT a claim" \
+  "! jq -e '.claims[] | select(.source_text | test(\"This is not blocking\"))' '$FJ' >/dev/null"
+check "fj: the verdict line is NOT a claim" \
+  "! jq -e '.claims[] | select(.source_text | test(\"^Verdict\"))' '$FJ' >/dev/null"
+# ★ The severity is the tail of the anchored match, not the leftmost vocabulary
+# word on the line. `**Critical:** should-fix` is a real shape and the leftmost
+# word is in the LABEL, so a bare word scan records the wrong severity -- and
+# records it confidently, in the layer a reviewer is scored from.
+check "fj: a label does not steal the severity" \
+  "[ \"\$(jq -r '.claims[] | select(.source_text | test(\"Critical:\")) | .severity_stated' '$FJ')\" = 'should-fix' ]"
+check "fj: severity_stated is verbatim, not mapped" \
+  "jq -e '[.claims[].severity_stated] | index(\"nit\")' '$FJ' >/dev/null"
+check "fj: a claim cites its own file and line" \
+  "jq -e '.claims[] | select(.source.file | startswith(\"finder\")) | .source.line > 0' '$FJ' >/dev/null"
+check "fj: location is null, never guessed" \
+  "[ \$(jq '[.claims[] | select(.location != null)] | length' '$FJ') -eq 0 ]"
+
+# ★ THE RAIL. Nothing downstream may reach the graded layer: no verify verdict,
+# no settle disposition, no ledger id. If one of those keys ever appears on a
+# claim, a reviewer's score has quietly become a function of a later model's
+# quality -- and it will still look like a score, which is why this is asserted
+# rather than commented.
+check "fj: claims carry no settle/verify fields" \
+  "[ \$(jq '[.claims[] | keys[] | select(. == \"status\" or . == \"ledger_id\" or . == \"verdict\")] | length' '$FJ') -eq 0 ]"
+check "fj: verify is off by default"   "[ \"\$(jq -r .verify.ran '$FJ')\" = 'false' ]"
+check "fj: findings carry the settle slots" \
+  "jq -e '.findings | length == 0 or (.[0] | has(\"status\") and has(\"ledger_id\"))' '$FJ' >/dev/null"
+
+# ★ A reviewer that produced nothing is IN the panel as absent. Dropping it would
+# leave a consumer computing denominators over survivors only, which is the
+# false-clearance shape the NO USABLE REVIEW block in the merge exists to stop --
+# there is no point fixing it in the prose and losing it in the JSON.
+check "fj: the dead reviewer is in the panel" \
+  "[ \"\$(jq -r '.panel[] | select(.reviewer | startswith(\"dead\")) | .state' '$FJ')\" = 'absent' ]"
+check "fj: and it contributes no claims" \
+  "[ \$(jq '[.claims[] | select(.reviewer | startswith(\"dead\"))] | length' '$FJ') -eq 0 ]"
+check "fj: synthesis status is recorded" "[ \"\$(jq -r .synthesis.status '$FJ')\" = 'ok' ]"
+
+# ★ CLAIMS COME FROM DISK, NOT FROM THE MERGE, and this is the test that proves
+# it rather than the comment that claims it. bigfinder's only severity is its
+# LAST line and the cap cuts the review well before it, so the synthesizer never
+# saw that finding. A projection built by parsing synthesis.md would score this
+# reviewer as having missed a cleartext-token bug it actually reported.
+export CADRE_SYNTH_MAX=300
+D=$(case_dir engine_cap); S="$D/src"
+git -C "$S" checkout -qb feature; echo change >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster bigfinder,good --base main --synth echoer --label cap "$S")
+unset CADRE_SYNTH_MAX
+FJ="$D/state/reviews/cap/findings.json"
+check "cap: the merge was truncated"   "grep -q 'CADRE SENT ONLY ITS FIRST' '$D/state/reviews/cap/synthesis.md'"
+check "cap: the finding is NOT in the merge" \
+  "! grep -q 'PAST_THE_CAP' '$D/state/reviews/cap/synthesis.md'"
+check "cap: but it IS claimed"          \
+  "[ \$(jq '[.claims[] | select(.source_text | test(\"PAST_THE_CAP\"))] | length' '$FJ') -eq 1 ]"
+
+# ★ Written when no merge happened at all. A degraded panel is exactly the one a
+# benchmark most needs to see, and hanging the write off cmd_synthesize's success
+# path would delete it from the record instead -- absence read as nothing, one
+# layer above the block that already fixed this inside the merge.
+D=$(case_dir engine_nosynth); S="$D/src"
+git -C "$S" checkout -qb feature; echo change >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster finder,good --base main --synth none --label ns "$S")
+FJ="$D/state/reviews/ns/findings.json"
+check "ns: no synthesis ran"            "[ ! -e '$D/state/reviews/ns/synthesis.md' ]"
+check "ns: findings.json still written" "[ -s '$FJ' ]"
+check "ns: status says not_run"         "[ \"\$(jq -r .synthesis.status '$FJ')\" = 'not_run' ]"
+check "ns: the claims survived anyway"  "[ \$(jq '.claims | length' '$FJ') -eq 4 ]"
+check "ns: and findings[] is empty"     "[ \$(jq '.findings | length' '$FJ') -eq 0 ]"
+
+# A single-reviewer panel has nothing to merge, and still made claims.
+D=$(case_dir engine_one); S="$D/src"
+git -C "$S" checkout -qb feature; echo change >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster finder --base main --synth echoer --label one "$S")
+FJ="$D/state/reviews/one/findings.json"
+check "one: findings.json written"      "[ -s '$FJ' ]"
+check "one: status says skipped"        "[ \"\$(jq -r .synthesis.status '$FJ')\" = 'skipped' ]"
+check "one: claims survived"            "[ \$(jq '.claims | length' '$FJ') -eq 4 ]"
 
 echo
 echo "$PASS passed, $FAIL failed"

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -3483,6 +3483,30 @@ check "by: the finding after the bad byte is claimed" \
 check "by: and so is the one below it" \
   "jq -e '.claims[] | select(.source_text | test(\"trailing finding\"))' '$BJ' >/dev/null"
 
+# ★ The most degraded panel that still leaves a record: ONE truncated review and
+# one reviewer that never returned. This is the shape the "written on every path"
+# claim is really about, and cmd_review has an early return above the projection
+# (`rmdir "$out"; return "$rrc"`) that could plausibly have skipped it. Measured:
+# a surviving .partial keeps the run at rc 0, so the projection does run.
+D=$(case_dir engine_degraded); S="$D/src"
+git -C "$S" checkout -qb feature; echo one >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster trunc,dead --base main --synth none --label dg "$S")
+DJ="$D/state/reviews/dg/findings.json"
+check "dg: a partial-only panel is recorded" "[ -s '$DJ' ]"
+check "dg: the truncated seat is degraded" \
+  "[ \"\$(jq -r '.panel[] | select(.reviewer | startswith(\"trunc\")) | .state' '$DJ')\" = 'degraded' ]"
+check "dg: the failed seat is absent"       \
+  "[ \"\$(jq -r '.panel[] | select(.reviewer | startswith(\"dead\")) | .state' '$DJ')\" = 'absent' ]"
+# ★ And the case that legitimately has NO findings.json: every reviewer failed, so
+# cmd_review rmdirs an empty review dir and there is nothing to project. The file
+# being absent is correct here -- which is exactly why a missing findings.json must
+# never be read as a clean panel.
+D=$(case_dir engine_allfail); S="$D/src"
+git -C "$S" checkout -qb feature; echo one >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster dead,dead --base main --synth none --label af "$S"); RC=$?
+check "af: an all-failed panel exits nonzero" "[ '$RC' -ne 0 ]"
+check "af: and leaves no review dir at all"   "[ ! -d '$D/state/reviews/af' ]"
+
 # ★ CLAIMS COME FROM DISK, NOT FROM THE MERGE, and this is the test that proves
 # it rather than the comment that claims it. bigfinder's only severity is its
 # LAST line and the cap cuts the review well before it, so the synthesizer never

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -23,7 +23,7 @@ setup_agents() {
   local n
   for n in good good2 trunc dead echoer chrome terse ratepart ratelim \
            synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2 \
-           finder bigfinder; do
+           finder bigfinder synthmerge; do
     printf '#!/bin/sh\nexit 0\n' > "$1/bin/$n"; chmod +x "$1/bin/$n"
   done
   # ★ The trailing verdict is not decoration. review-live.md asks every reviewer
@@ -98,6 +98,18 @@ run_bigfinder() {
   echo "REVIEW by bigfinder"
   for i in $(seq 1 400); do echo "Padding line $i, ordinary prose, no severity."; done
   echo "- blocking: PAST_THE_CAP the token is logged in cleartext"
+  echo "Verdict: blocking"
+}
+A
+  # A synthesizer that returns a real MERGED shape: severities carrying the
+  # [n/d] quorum the prompt asks for, and one deliberately without a tag.
+  # echoer cannot stand in for this -- it returns the prompt, so a test using it
+  # asserts against cadre's own instructions rather than against a merge.
+  cat > "$1/agents.d/synthmerge.sh" <<'A'
+run_synthmerge() {
+  echo "- blocking [2/3]: the session token is logged in cleartext"
+  echo "* **Severity**: nit [1/3]"
+  echo "- should-fix: no quorum tag on this one"
   echo "Verdict: blocking"
 }
 A
@@ -3371,8 +3383,7 @@ check "fj: location is null, never guessed" \
 check "fj: claims carry no settle/verify fields" \
   "[ \$(jq '[.claims[] | keys[] | select(. == \"status\" or . == \"ledger_id\" or . == \"verdict\")] | length' '$FJ') -eq 0 ]"
 check "fj: verify is off by default"   "[ \"\$(jq -r .verify.ran '$FJ')\" = 'false' ]"
-check "fj: findings carry the settle slots" \
-  "jq -e '.findings | length == 0 or (.[0] | has(\"status\") and has(\"ledger_id\"))' '$FJ' >/dev/null"
+
 
 # ★ A reviewer that produced nothing is IN the panel as absent. Dropping it would
 # leave a consumer computing denominators over survivors only, which is the
@@ -3383,6 +3394,94 @@ check "fj: the dead reviewer is in the panel" \
 check "fj: and it contributes no claims" \
   "[ \$(jq '[.claims[] | select(.reviewer | startswith(\"dead\"))] | length' '$FJ') -eq 0 ]"
 check "fj: synthesis status is recorded" "[ \"\$(jq -r .synthesis.status '$FJ')\" = 'ok' ]"
+
+# ★ findings[] asserted NON-EMPTY, and the count named. The first version of
+# this check was `length == 0 or (has the slots)`, which is true of an empty
+# array -- so it passed while engine_findings was reading the wrong path and
+# emitting nothing at all, for an entire commit. A test with an `or length == 0`
+# escape hatch on the thing it is measuring measures nothing.
+D=$(case_dir engine_merge); S="$D/src"
+git -C "$S" checkout -qb feature; echo change >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster finder,good --base main --synth synthmerge --label mg "$S")
+MJ="$D/state/reviews/mg/findings.json"
+check "mg: the merge produced findings"  "[ \$(jq '.findings | length' '$MJ') -eq 3 ]"
+check "mg: findings carry the settle slots" \
+  "jq -e '[.findings[] | select(has(\"status\") and has(\"ledger_id\"))] | length == 3' '$MJ' >/dev/null"
+check "mg: the settle slots start null" \
+  "[ \$(jq '[.findings[] | select(.status != null or .ledger_id != null)] | length' '$MJ') -eq 0 ]"
+# ★ agreement is COPIED from the synthesizer's own [n/d], never recomputed. A
+# denominator derived here from a count of files would restore the bug the merge
+# already fixed: an absent reviewer read as a dissent.
+check "mg: the quorum is copied verbatim" \
+  "[ \"\$(jq -c '.findings[] | select(.source_text | test(\"session token\")) | .agreement' '$MJ')\" = '{\"numerator\":2,\"denominator\":3}' ]"
+check "mg: a second tag is read too" \
+  "[ \"\$(jq -c '.findings[] | select(.severity == \"nit\") | .agreement' '$MJ')\" = '{\"numerator\":1,\"denominator\":3}' ]"
+# ★ No tag means null, NOT [n/1]. Inventing a denominator is how a lone finding
+# starts looking like a finding the panel considered and declined to back.
+check "mg: an untagged finding gets null, not a guess" \
+  "[ \"\$(jq -r '.findings[] | select(.source_text | test(\"no quorum tag\")) | .agreement' '$MJ')\" = 'null' ]"
+# The claims layer is untouched by any of it.
+check "mg: claims are unaffected by the merge" \
+  "[ \$(jq '.claims | length' '$MJ') -eq 4 ]"
+
+# ★ A GATE-SKIPPED seat is still in the panel, and `skipped` is not `absent`.
+# cmd_review filters a failed-gate seat out of $specs before dispatch, so a panel
+# built from $specs alone reports a roster of one where the user asked for two --
+# the same panel-reads-cleaner-than-it-was shape as losing a dead reviewer, just
+# sourced from config rather than from a failure. Found by a cross-model review.
+D=$(case_dir engine_gate); S="$D/src"
+git -C "$S" checkout -qb feature; echo one >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster 'finder,good2 ?min-lines=999' --base main --synth none --label gt "$S")
+GJ="$D/state/reviews/gt/findings.json"
+check "gt: the gated seat is in the panel" \
+  "[ \$(jq '[.panel[] | select(.state == \"skipped\")] | length' '$GJ') -eq 1 ]"
+check "gt: it is skipped, NOT absent" \
+  "! jq -e '.panel[] | select(.reviewer | startswith(\"good2\")) | select(.state == \"absent\")' '$GJ' >/dev/null"
+check "gt: the gate that stopped it is named" \
+  "jq -e '.panel[] | select(.state == \"skipped\") | .skipped_gate | test(\"min-lines\")' '$GJ' >/dev/null"
+check "gt: and the reason is kept"  \
+  "jq -e '.panel[] | select(.state == \"skipped\") | .skipped_reason | test(\"lines\")' '$GJ' >/dev/null"
+check "gt: the roster size is honest" "[ \$(jq '.panel | length' '$GJ') -eq 2 ]"
+check "gt: a skipped seat contributes no claims" \
+  "[ \$(jq '[.claims[] | select(.reviewer | startswith(\"good2\"))] | length' '$GJ') -eq 0 ]"
+
+# ★ ONE BAD BYTE MUST NOT ERASE A REVIEW, and `-a` on the extraction grep is the
+# whole defence. Measured here, GNU grep 3.12: a NUL byte anywhere in the file
+# makes it binary, and the entire output collapses to one "binary file matches"
+# line -- ON STDERR, so it never even enters the pipeline. Every finding in that
+# review disappears from claims[] and the reviewer reads as having found nothing.
+# There is no diagnostic to notice and the digit guard never fires; without -a it
+# is completely silent, in the direction that clears a reviewer that did its job.
+#
+# A NUL is not exotic in this corpus: an adapter that dumps a provider's raw
+# bytes on a failure is a shape cadre already models (see the `dead` stub, which
+# prints a wall of raw output). Other greps draw the binary line elsewhere --
+# ugrep treats invalid UTF-8 as binary too -- which is the argument for forcing
+# text mode rather than reasoning about any one implementation's heuristic.
+D=$(case_dir engine_bytes); S="$D/src"
+git -C "$S" checkout -qb feature; echo one >> "$S/app.js"; git -C "$S" commit -qam feat
+OUT=$(run_cadre "$D" review --roster finder,good --base main --synth none --label by "$S")
+BJ="$D/state/reviews/by/findings.json"
+FR=$(ls "$D/state/reviews/by"/finder-*.md | head -1)
+# A NUL mid-review, on a line that is NOT itself a finding.
+printf -- '- blocking: a genuine defect after the bad byte\n' >> "$FR"
+printf -- 'chatter carrying a NUL: \000 here\n' >> "$FR"
+printf -- '* **Severity**: nit trailing finding\n' >> "$FR"
+# Both halves, or the test proves nothing about which flag does the work.
+check "by: without -a the whole review is suppressed" \
+  "[ \$(grep -nEi 'blocking|nit' '$FR' 2>/dev/null | wc -l) -eq 0 ]"
+check "by: with -a every line comes back" \
+  "[ \$(grep -anEi 'blocking|nit' '$FR' 2>/dev/null | wc -l) -ge 2 ]"
+# Re-project over the mutated file: same code path cmd_review uses.
+( set -uo pipefail; export CADRE_ROOT="$ROOT"
+  . "$ROOT/lib/common.sh"; . "$ROOT/lib/engine/synthesize.sh"
+  engine_write_findings "$D/state/reviews/by" none "" finder good >/dev/null 2>&1 )
+check "by: the pre-existing claims survive" \
+  "[ \$(jq '[.claims[] | select(.reviewer | startswith(\"finder\"))] | length' '$BJ') -eq 6 ]"
+check "by: the finding after the bad byte is claimed" \
+  "jq -e '.claims[] | select(.source_text | test(\"genuine defect\"))' '$BJ' >/dev/null"
+check "by: and so is the one below it" \
+  "jq -e '.claims[] | select(.source_text | test(\"trailing finding\"))' '$BJ' >/dev/null"
 
 # ★ CLAIMS COME FROM DISK, NOT FROM THE MERGE, and this is the test that proves
 # it rather than the comment that claims it. bigfinder's only severity is its


### PR DESCRIPTION
Carves a harness-agnostic review **engine** out of cadre so the benchmark
consumes its output instead of reaching into its internals. Closes the first cut
of #25 and answers its open scope question: settle/ledger go in the engine.

## The seam

The engine ends at `findings.json`, in two layers:

| layer | what it is | graded? |
| --- | --- | --- |
| `claims[]` | verbatim, per reviewer, extracted from that reviewer's own file by grep. No model in the path. | **yes** |
| `findings[]` | the merged human-facing view — what the synthesizer said after reading the panel. | no |

Everything downstream of the reviewers — synthesis, an eventual `verify` overlay,
`settle` — writes `findings[]` and may not touch `claims[]`. `status`/`ledger_id`
exist on findings only, asserted in both the output and the source. The reason is
the whole point: a synthesizer paraphrases, a verify pass can be wrong about the
code, and a settle pass encodes one human's dismissals — if any of them could
reach `claims[]`, a reviewer's score becomes a function of a downstream model's
quality while still looking like a score.

## Three decisions worth reviewing

**Claims come from disk, never from the merge.** The merge is lossy on purpose:
it cuts an over-long review to fit `CADRE_SYNTH_MAX` and keeps a dead reviewer
out of every denominator. Both are right for a merge, and both mean a projection
built from `synthesis.md` would score a reviewer as having missed a bug it
reported. Pinned by a test whose finding sits deliberately past the cap.

**`findings.json` is written whenever a review directory survives** — preflight
skip, a rate-limited merge, one usable review, `--synth none`, and a panel down to
a single truncated review. Hanging it off the synth success path would have
deleted every degraded run from the benchmark's view. The only case with no file
is a run where every reviewer failed, which leaves an empty dir that `cmd_review`
removes — so a missing file means "no panel output", never "a clean panel".

**`severity_stated` is verbatim, never mapped onto `blocking|should-fix|nit`.**
Mapping is an interpretation and belongs on `findings[]`. A consumer can
normalize; it cannot un-normalize. The foreign fixture says `major` and stays
`major`.

## What is deliberately NOT here

- **Grading still reads `review.md`.** So #25's acceptance test ("grade a foreign
  `findings.json` with zero engine code executed") is delivered by halves: the
  *contract* half is real — `tests/engine-seam.sh` validates a hand-written
  CodeRabbit-shaped fixture with nothing but `jq`. The *grade* half lands with the
  grade migration, and that fixture is what it gets pointed at.
- **The seam is checked in the source, not enforced at runtime.** `bin/cadre` is
  still one binary sourcing both halves, so every function is in scope regardless
  of owner. Named as a non-goal in `docs/ASSURANCE_CASE.md`; real isolation
  arrives with the two-binary split.
- **`awk 'BEGIN{RS="\0"}'` portability** → filed as #26. Pre-existing code this
  branch only relocated, and the same construct is in `grade.sh`, so it wants its
  own change.

## The shared boundary PR2 has to draw

Everything `lib/engine/` consumes from `lib/common.sh`, i.e. the shared set:

`slug` · `spec_agent` · `spec_model` · `capability_block` · `classify_run` ·
`provider_refused` · `retry_wait` · `failure_phrase` · `die` · `pick_judge` ·
`SEVERITY_RE`/`SEVERITY_WORDS`

Plus two paths: `lib/prompts/` and `bin/agentcall`. Nothing in the engine
references the grader, judges, `slots.tsv` or `passes.conf` — there is a test for
both directions.

`pick_judge` moved into `common.sh` in this PR: `settle` calls it and it was
defined in `bin/cadre`, so the engine was depending on a symbol the benchmark's
entrypoint owned. Invisible today, and exactly what the two-binary split trips on.

## Review found four real bugs

A cross-model review (codex/gpt-5.5) plus a re-read caught four, every one wrong
in the same direction — a reviewer that did its job reading as one that found
nothing. All fixed and **negative-tested**: each new check fails when its fix is
reverted.

1. **The extraction grep needed `-a`.** A NUL byte anywhere in a review makes grep
   call the file binary and collapse its whole output to a diagnostic *on stderr*,
   so nothing reaches the pipeline and every claim from that review vanishes.
   Measured on GNU grep 3.12: six claims lost, no diagnostic to notice. (The
   review blamed invalid UTF-8; on GNU grep that is not the trigger, a NUL is.
   `ugrep` differs again, which is the argument for forcing text mode rather than
   reasoning about one implementation's heuristic.)
2. **Gate-skipped seats were missing from `panel[]`.** A `?min-lines` seat is
   filtered out of `$specs` before dispatch, so the panel reported a smaller
   roster than was configured. They now arrive by their own channel as `skipped`,
   kept distinct from `absent` — absent means asked and unanswered, so its silence
   proves nothing; skipped means never asked, with the gate and reason recorded.
3. **`local out="$1" f="$out/synthesis.md"`** set `f` to `/synthesis.md`. It
   shipped *working*, by accident: dynamic scoping made `$out` resolve to the
   caller's identically-named variable. The smoke suite's own `case_dir()`
   documents this trap.
4. **`\b` in the seam test** — a GNU grep extension. On BSD grep `\bengine_`
   searches for `bengine_`, matches nothing, and the check would pass on macOS
   however many engine calls the benchmark grew.

And one of mine: `engine_findings` was emitting nothing, while the test that
should have caught it read `length == 0 or (has the slots)` — true of an empty
array. An `or length == 0` escape hatch on the thing under measurement measures
nothing. Replaced with a real merge stub and seven assertions that name the count.

## Tests

```
tests/review-smoke.sh   830 passed, 0 failed   (was 779 on main)
tests/engine-seam.sh     37 passed, 0 failed   (new)
```

`docs/ASSURANCE_CASE.md` gains claims 7–11 and one non-goal, each citing a test
by the name you can grep.

---

## Rebased onto `main` — 2026-08-31

`main` gained 15 commits while this sat open, so `main` was **merged in** rather
than the branch rebased: the collision is move-vs-edit — this branch takes 344
lines out of `bin/cadre` while `main` edited inside them — and four replays of
that is four chances to resolve it differently.

git cannot port an edit across a move, so **three resolutions are by hand**, and
each is a place where a fix that is on `main` could have vanished silently:

1. **`lib/engine/settle.sh` still held the awk slicer that #26 deleted.** Taking
   either side whole was wrong in both directions: ours reintroduces the
   `BEGIN{RS` gawk dependency into the file the code now lives in, theirs keeps a
   `cmd_settle` this branch removed. The call site is ported to
   `extract_json_slice()`.
2. **`cmd_review`'s tail** carried #29's panel floor on one side and
   `engine_write_findings` on the other, and both belong. `findings.json` is
   written **first**, before the floor check, for the same reason it sits outside
   the `&&` on the synth call: a thin panel's artifacts are all real and all on
   disk, so the engine still owes its consumer a `findings.json`. Exit 10 is a
   statement about the roster, not about the reviews that came back. `main`'s
   claim release and exit code are kept.
3. **`tests/review-smoke.sh` conflicted twice**, both pure appends — `main`'s
   #31/#32/#29 blocks and this branch's `findings.json` block. Both kept, plus a
   merged stub-agent list. A dropped test here would have hidden a dropped fix,
   so the check is the **count**, not a read.

And the #26 source pin was itself wrong after the move: it named `bin/cadre`, so
it went green against a file that no longer holds the code. It greps `lib/` and
`bin/` as directories now. A pin that names a path stops pinning the moment the
path changes — which is the failure this merge exists to catch.

```
tests/review-smoke.sh   985 passed, 0 failed   (934 on main + 51 from this branch)
tests/engine-seam.sh     37 passed, 0 failed
```

20 engine-side checks and 113 from `main`'s recent work both execute, verified by
count rather than by reading the resolution.
