### PR TITLE
pi adapter: append the output contract the classifier reads

### DIFF
--- a/agents.d/pi.sh
+++ b/agents.d/pi.sh
@@ -49,6 +49,20 @@ CADRE DOES NOT WRITE THAT FILE, the user does.
 NOTES
 }
 
+# ★ issue #33, measured: pi-routed qwen3.8 reviews that DID state real findings
+# were still binned inconclusive, because review_findings and has_verdict saw
+# no severity labels and no closing Verdict: -- the model narrated both in
+# prose, and the classifier reads only the shape. The adapter's one lever on
+# the shape that arrives is the prompt, so the prompt is told the shape.
+pi_output_contract() {
+  cat <<'CONTRACT'
+Format contract: state each finding under a bold severity label on its own
+line -- **blocking**, **should-fix**, or **nit** -- and end the whole review
+with a final line starting with `Verdict:` followed by one of: blocking,
+should-fix, no defects found.
+CONTRACT
+}
+
 run_pi() {
   local m=() out rc
   [ -n "$model" ] && m=(--model "$model")
@@ -59,7 +73,7 @@ run_pi() {
   # No working-directory flag, so cd. The pipe is not optional: it is what keeps
   # pi from waiting on a terminal that is never going to type anything.
   out=$(mktemp)
-  ( cd "$dir" && printf '%s' "$prompt" \
+  ( cd "$dir" && printf '%s\n\n%s' "$prompt" "$(pi_output_contract)" \
       | timeout -k 30 "$TIMEOUT" pi -p "${m[@]}" 2>&1 ) > "$out"
   rc=$?
 

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -1595,6 +1595,13 @@ OUT=$(CADRE_AGENTS_D="$PD/agents.d" PATH="$PD/bin:$PATH" \
       "$ROOT/bin/agentcall" pi -d /tmp -m ro 'review' 2>&1); RC=$?
 check "a real error stays nonzero"    "[ $RC -ne 0 ]"
 check "and keeps the provider text"   "grep -q '400: model not found' <<<\"\$OUT\""
+# ★ issue #33: run_pi's stdin pipe carries the prompt PLUS the format contract,
+# and the contract must carry the two hooks the classifier actually reads -- a
+# bold severity label and a closing Verdict: line. pi_output_contract alone, in
+# a subshell: no run_pi, no pi binary, no network.
+contract=$( . "$ROOT/agents.d/pi.sh" >/dev/null 2>&1; pi_output_contract )
+check "pi adapter appends output contract (issue #33)" \
+  "grep -q 'Verdict:' <<<\"\$contract\" && grep -qF -- '**blocking**' <<<\"\$contract\""
 
 echo "== ★ the run dataset =="
 # ★ The record has to be written BEFORE the scratch files it is built from are


### PR DESCRIPTION
Closes #33.

pi-routed reviews that stated real findings were binned `inconclusive`: the model wrote severities in prose, so `review_findings` counted zero and `has_verdict` found no closing line. The pi adapter now appends a short format-contract reminder to the prompt it pipes — bold severity labels on their own lines, a final `Verdict:` line — the two hooks `classify_run` actually reads.

- `agents.d/pi.sh`: new `pi_output_contract()` + the pipe carries `prompt + contract`; DRY branch, exit codes, and failure-shape handling untouched.
- `tests/review-smoke.sh`: hermetic check that the contract text carries both hooks (no `run_pi`, no pi binary, no network).

Verified: smoke suite 817/817; a contract-conforming review passes the real classifier (`findings=2`, `has_verdict` ok, `classify_run` → `ok`). The originating artifact is preserved at `ref-execa-pipe/pi-ollama-box-qwen38-cadre-64k-707074377-run1.md.inconclusive`.

Provenance: patch written by a local qwen3.8:27b through the pi harness (the same seat the issue is about), from a spec pre-reviewed by a second model; tests and classifier verification re-run independently before push.