### PR TITLE
A seat stopped by its sandbox is not a review (#28)

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -658,6 +658,39 @@ rate_limited() {
   grep -qiE '(\b(429|529)\b|too many requests|rate[ _-]?limit[a-z]*([ _-](exceeded|reached|hit|error))?|quota (exceeded|exhausted)|exceeded your [a-z ]{0,20}quota|resource[ _-]exhausted|retry[- ]after|slow down|overloaded|capacity constraints|AI_RetryError)' "$f"
 }
 
+# Did the reviewer's ENVIRONMENT stop it before it reviewed? #28. Measured
+# 2026-08-24 on a live panel: codex's shell tool died under bwrap
+# (`loopback: Failed RTM_NEWADDR: Operation not permitted`), the model wrote
+# 334 bytes saying it could not inspect the diff, added "Overall verdict:
+# should-fix" of its own accord, and exited 0. No adapter marker, no rate-limit
+# keyword, and has_verdict rescued it from `inconclusive` -- so a seat that
+# reviewed nothing was counted `ok` and its silence cleared the whole diff.
+#
+# ★ Same guards as rate_limited and for the same reason: a small file, and the
+# caller also demands findings=0. A real review that quotes "permission denied"
+# from the diff states findings, and a real review is not this short. The
+# model's own verdict line does NOT rescue it: a verdict on a review that never
+# happened is the exact fabrication this exists to catch.
+# ★ Two halves, both required: a tool/sandbox error signature AND the model
+# saying it could not look. Either alone is too loose -- a reviewer of sandbox
+# code quotes bwrap, and "unable to access" alone is the request-for-
+# clarification shape that already lands in `inconclusive`.
+env_blocked() {
+  local f="$1"
+  [ -s "$f" ] || return 1
+  [ "$(wc -c < "$f")" -le 2000 ] || return 1
+  grep -qiE '(bwrap:|sandbox|operation not permitted|permission denied|EPERM|EACCES|execution environment|tool call(s)? (failed|error)|command(s)? failed)' "$f" || return 1
+  # ★ The second half names the DIFF as the thing it could not reach, never a
+  # test run. Measured on the bot box's 758 artifacts: "could not execute the
+  # tests in the sandbox" is a routine caveat in five genuine clean reviews, and
+  # a looser "could not (run|execute)" binned every one of them.
+  # ★ And FIRST PERSON. "the diagnostic reports permission denied when the
+  # sandbox cannot access the repository" is a clean review OF such code, not a
+  # reviewer that was stopped; "I could not inspect the diff" is. Found by the
+  # codex review of this change.
+  grep -qiE "\bI (could ?n[o']t|was unable to|am unable to|cannot|can ?not) (review|inspect|read|access|open|examine|see) (the |this |any )?(change|changes|diff|code|files?|source|repo|repository)|(^|\bI am |\bI was )unable to (complete|perform|do) (the |a |this )?review|\b(my |this |the )review (was |is )?blocked|failed before execution" "$f"
+}
+
 # ★ A BUDGET refusal, which is a different animal from a rate limit, and telling
 # them apart is worth a function. Both look like "the provider said no". The
 # difference is whether waiting inside this sweep can clear it:
@@ -1092,6 +1125,14 @@ classify_run() {
     # open with "critical:" slips through here and lands on the judge instead,
     # which is the cheaper direction: a destroyed real review is unrecoverable.
     if rate_limited "$f" && [ "$(review_findings "$f")" -eq 0 ]; then echo failed; return 0; fi
+    # ★ #28. A seat whose sandbox broke before the model could look wrote a
+    # short apology, no findings, and a verdict of its own -- and that verdict
+    # carried it past the inconclusive test below into `ok`. Checked here with
+    # the same findings=0 gate as the rate-limit scan, and ahead of has_verdict
+    # on purpose: a bottom line on a review that never happened is not a
+    # bottom line. `failed`, not `inconclusive`: the report must send the
+    # operator to the box, not to the roster.
+    if env_blocked "$f" && [ "$(review_findings "$f")" -eq 0 ]; then echo failed; return 0; fi
   elif provider_refused "$f" "$rc"; then
     echo failed; return 0
   fi

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -22,7 +22,8 @@ setup_agents() {
   mkdir -p "$1/bin" "$1/agents.d"
   local n
   for n in good good2 trunc dead echoer chrome terse ratepart ratelim \
-           synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2; do
+           synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2 \
+           blocked permquote; do
     printf '#!/bin/sh\nexit 0\n' > "$1/bin/$n"; chmod +x "$1/bin/$n"
   done
   # ★ The trailing verdict is not decoration. review-live.md asks every reviewer
@@ -143,6 +144,31 @@ A
   # A GENUINE rate limit, no review at all: the case the retry loop is for.
   cat > "$1/agents.d/ratelim.sh" <<'A'
 run_ratelim() { printf 'Error: 429 too many requests.\n'; }
+A
+  # ★ #28, verbatim from a live panel (codex, 2026-08-24). The sandbox broke
+  # before the model could look; it said so, stated NO findings, and then wrote
+  # a verdict of its own. Exit 0, no adapter marker. has_verdict rescued it from
+  # `inconclusive` and it was counted `ok` -- a seat that reviewed nothing,
+  # clearing the diff by silence.
+  cat > "$1/agents.d/blocked.sh" <<'A'
+run_blocked() {
+  echo "I couldn't review the change because every filesystem command failed before execution with:"
+  echo
+  echo '`bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`'
+  echo
+  echo "I therefore could not inspect the diff or run tests, and won't claim findings without evidence."
+  echo
+  echo "Overall verdict: should-fix — review blocked by the execution environment."
+}
+A
+  # The control: a SHORT real review whose one finding is about a permission
+  # error in the diff. Same words, but it states a finding, so it stays ok.
+  cat > "$1/agents.d/permquote.sh" <<'A'
+run_permquote() {
+  echo "REVIEW by permquote"
+  echo "- should-fix: install.sh swallows 'permission denied' from bwrap: and the sandbox setup reports success anyway. I could not inspect the diff of the generated wrapper without a runtime, but the error path is wrong as written."
+  echo "Verdict: ship it after that fix"
+}
 A
   # ★ A COMPLETE synthesis that ends by QUOTING a reviewer's truncation marker,
   # which the synthesis prompt explicitly asks it to report. Exits 0, because
@@ -1214,6 +1240,30 @@ check "and is not binned as unusable"  "[ ! -e '$RS/synthesis.md.failed' ]"
 # The per-run record has to carry the state too: it is the benchmark row a
 # roster decision gets made on.
 check "slots.tsv records the state"    "grep -qP '\tinconclusive\t' '$R/slots.tsv'"
+
+echo "== ★ a sandbox error with a self-written verdict is not a review (#28) =="
+D=$(case_dir env_blocked); S="$D/src"
+git -C "$S" checkout -qb feature; echo x >> "$S/app.js"; git -C "$S" commit -qam f
+OUT=$(run_cadre "$D" review --roster blocked,permquote,good --synth echoer --base main "$S")
+R="$D/state/reviews/$(ls "$D/state/reviews" | head -1)"
+check "blocked seat -> .md.failed"       "ls '$R'/blocked-*.md.failed >/dev/null 2>&1"
+check "and NOT a clean review"           "! ls '$R'/blocked-*.md >/dev/null 2>&1"
+# ★ failed, not inconclusive: the fix is on the box, not in the roster.
+check "and NOT inconclusive"             "! ls '$R'/blocked-*.md.inconclusive >/dev/null 2>&1"
+check "its verdict line did not rescue it" "grep -q 'Overall verdict' '$R'/blocked-*.md.failed"
+check "counts file it as failed"         "grep -q '2 ok, 0 degraded, 0 inconclusive, 1 failed' <<<\"\$OUT\""
+check "excluded from the synthesis"      "! grep -qE '^===== REVIEWER: blocked =====' '$R/synthesis.md'"
+# The control: same vocabulary, one stated finding, stays a review.
+check "short review quoting the error stays ok" "ls '$R'/permquote-*.md >/dev/null 2>&1"
+check "unit: env_blocked matches the artifact" "bash -c \"source '$ROOT/lib/common.sh'; env_blocked '$R'/blocked-*.md.failed\""
+echo 'Error: 429 too many requests.' > "$D/rl.txt"
+# ★ Third person is a review OF sandbox code, not a stopped reviewer.
+printf 'Reviewed the patch. The new diagnostic correctly reports permission denied when the sandbox cannot access the repository. Overall verdict: ship it.\n' > "$D/third.txt"
+check "unit: third-person mention is not env_blocked" "! bash -c \"source '$ROOT/lib/common.sh'; env_blocked '$D/third.txt'\""
+# Length guard: the same apology padded past 2KB is not this shape.
+{ cat "$R"/blocked-*.md.failed; head -c 2100 /dev/zero | tr '\0' 'x'; } > "$D/long.txt"
+check "unit: over 2KB is not env_blocked"  "! bash -c \"source '$ROOT/lib/common.sh'; env_blocked '$D/long.txt'\""
+check "unit: a 429 is not env_blocked"   "! bash -c \"source '$ROOT/lib/common.sh'; env_blocked '$D/rl.txt'\""
 
 echo "== ★ coderabbit's bracket severities are findings =="
 # ★ Measured across three real panels: coderabbit reviews declaring findings=3,


### PR DESCRIPTION
Closes #28.

A seat whose sandbox broke before the model ran was classified `ok`: the model wrote a short apology, no findings, and its own verdict line, and `has_verdict` rescued it from `inconclusive`.

- `env_blocked()` in `lib/common.sh`: ≤2KB, a tool/sandbox error signature AND a first-person "could not inspect the diff" phrasing. Hooked into `classify_run` under the existing findings=0 gate, ahead of `has_verdict`. Files as `failed`, not `inconclusive`, so the report sends the operator to the box.
- Adapter markers still win; the retry loop is untouched (an env failure is not `rate_limited`, so no retries burn).
- Swept against 1,079 real artifacts (321 local, 758 on the review-runner): matches exactly the two bwrap failures from 2026-08-24, zero false positives. Two looser drafts were killed by that sweep and by the codex review (a "could not execute the tests" caveat and a third-person mention); both are now test controls.
- Smoke suite 791/791.