### PR TITLE
cadre review: one run per label at a time (#32)

### DIFF
--- a/bin/cadre
+++ b/bin/cadre
@@ -71,7 +71,13 @@ then run that panel on the code you are about to ship.
       --roster a,b,c     override $CADRE_HOME/roster
       --jobs N           reviewers in parallel (default 1; they share rate limits)
       --synth <spec>     merge the reviews with this agent (default $CADRE_SYNTH)
-      --label <name>     output dir name; labels are single-use
+      --label <name>     output dir name; labels are single-use, and a label
+                         under review by another caller exits 8 (not an error:
+                         the run exists, go back to sleep). A label whose run
+                         died is reclaimed and the dead dir parked as
+                         <label>.stale.<epoch>.
+      --force            re-measure a label that already holds a finished
+                         review; never displaces a live run
       --prerun <cmd>     run <cmd> once on a throwaway copy of the checkout and
                          give every reviewer the transcript. Off unless you ask.
   cadre passes                          list registered passes
@@ -642,9 +648,136 @@ resolve_roster() {
   printf '%s\n' "${out[@]}"
 }
 
+# Take the review claim at $out, or say why not. Returns 0 holding the claim,
+# 8 when a LIVE run holds it, 2 (die) when the label is spent.
+#
+# The record is three lines in $out/.claim: pid, host, started (epoch). Liveness
+# is `kill -0` when the host matches; a claim from another host cannot be
+# probed, so it is live until CADRE_CLAIM_TTL (default 4h, comfortably past a
+# whole panel at the 900s per-seat timeout) and stale after. Stale means the
+# holder died, and a dead run's directory is PARKED as $out.stale.<epoch>, never
+# deleted: whatever it wrote is evidence about why it died.
+#
+# ★ The record lives under $CADRE_HOME/reviews, beside prompt.txt, which
+# cmd_review already refuses to place inside the target: a reviewer's cwd is a
+# $CADRE_WORK checkout and cannot reach it by relative path.
+# ★ --force never displaces a live run. A human who wants to re-measure a sha is
+# doing something legitimate; a human who wants to kill someone else's run in
+# flight is doing something else, and gets the pid to do it with.
+claim_review() {  # <out> <force> -> 0 | 8 | exits
+  local out="$1" force="${2:-0}" claim="$1/.claim" host now
+  host="${HOSTNAME:-$(uname -n)}"
+  if ! mkdir "$out" 2>/dev/null; then
+    # ★ The loser's path is inspect -> park -> recreate, three steps that are
+    # not atomic together: two losers on one label both decide the holder is
+    # dead, the first parks and recreates, the second parks the FIRST's live
+    # run. A sidecar directory serialises the whole sequence; a caller that
+    # cannot take it is looking at someone mid-reclaim, which is a live run.
+    local gate="$out.taking"
+    # A gate older than a minute has no owner: the reclaim inside it is a
+    # handful of renames, so a caller that died mid-way is the only thing
+    # that leaves one, and without this every later call would read it as a
+    # reclaim in progress, forever.
+    if ! mkdir "$gate" 2>/dev/null; then
+      claim_dir_fresh "$gate" || rmdir "$gate" 2>/dev/null
+      mkdir "$gate" 2>/dev/null || {
+        echo "cadre: $(basename "$out") is being reclaimed by another caller right now. Nothing to do; this is not a failure." >&2
+        return 8
+      }
+    fi
+    local rc=0
+    claim_reclaim "$out" "$force" "$host" || rc=$?
+    rmdir "$gate" 2>/dev/null
+    case "$rc" in 0) ;; 8) return 8 ;; *) exit "$rc" ;; esac
+  fi
+  # ★ Written whole, then renamed: `>` truncates first, and a contender that
+  # reads the file in that instant sees an empty record. Four lines: the
+  # fourth is this process's start time as ps prints it, the identity that
+  # tells a pid apart from its reincarnation after a reboot.
+  now=$(date +%s)
+  printf '%s\n%s\n%s\n%s\n' "$$" "$host" "$now" "$(claim_pstart "$$")" > "$claim.tmp" \
+    && mv "$claim.tmp" "$claim" || {
+    rm -f "$claim.tmp"; rmdir "$out" 2>/dev/null; die "cannot write $claim"
+  }
+  return 0
+}
+
+claim_pstart() {  # <pid> -> the process start time as a string, or ""
+  ps -o lstart= -p "$1" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//'
+}
+
+# Inside the sidecar: decide whether $out's holder is alive, and if not, park
+# the directory and take a fresh one. 0 = $out is ours (empty, unclaimed).
+claim_reclaim() {  # <out> <force> <host> -> 0 | 8 | exits
+  local out="$1" force="$2" host="$3" claim="$1/.claim"
+  local cpid="" chost="" cstart="" cpstart="" reason="" when
+  [ -f "$claim" ] && { read -r cpid; read -r chost; read -r cstart; read -r cpstart; } < "$claim"
+  if [ -n "$cpid" ] && [ -n "$cstart" ]; then
+    if claim_live "$cpid" "$chost" "$cstart" "$host" "$cpstart"; then
+      when=$(date -d "@$cstart" 2>/dev/null || date -r "$cstart" 2>/dev/null || echo "epoch $cstart")
+      echo "cadre: $out is being reviewed right now by pid $cpid on $chost (since $when). Nothing to do; this is not a failure." >&2
+      return 8
+    fi
+    reason="pid $cpid on $chost is gone"
+  elif [ -s "$out/report.md" ]; then
+    # ★ Not die: the sidecar is held here, and an exit inside it would leave
+    # the gate behind, so every later caller reads a reclaim in progress.
+    [ "$force" = 1 ] || {
+      echo "cadre: $out already holds a finished review. Labels are single-use: pick another --label, or --force to re-measure the same target on purpose." >&2
+      return 2
+    }
+    reason="re-measured with --force"
+  elif claim_dir_fresh "$out"; then
+    # ★ No record (or a record with no pid in it) and no report is what the
+    # WINNER looks like between its mkdir and its first write. That window is
+    # milliseconds, so a directory younger than a minute is busy, not dead;
+    # older than that with nothing in it is a run that died before it could
+    # say so.
+    echo "cadre: $out was just claimed by another caller. Nothing to do; this is not a failure." >&2
+    return 8
+  else
+    reason="no claim and no report, a run died before either"
+  fi
+  # $$ in the name: two reclaims in the same second must not share a park, or
+  # GNU mv nests the second directory inside the first.
+  local park="$out.stale.$(date +%s).$$"
+  mv "$out" "$park" || { echo "cadre: cannot park $out" >&2; return 2; }
+  echo "cadre: reclaimed $(basename "$out") ($reason); the old directory is parked at $park"
+  mkdir "$out" 2>/dev/null || {
+    echo "cadre: $out was claimed by another caller while reclaiming it. Nothing to do; this is not a failure." >&2
+    return 8
+  }
+  return 0
+}
+
+claim_dir_fresh() {  # <dir> -> 0 when modified within the last 60s
+  local age
+  age=$(( $(date +%s) - $(stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0) ))
+  [ "$age" -lt 60 ]
+}
+
+# ★ `kill -0` alone is false-live after a reboot: pids restart low and a
+# leftover claim's pid belongs to some daemon forever -- issue #32 again with
+# a quieter symptom. So a same-host pid is the holder only if it is alive AND
+# its start time matches the one the claim recorded; a different start time is
+# a reincarnation. The TTL is the fallback for what cannot be probed: another
+# host, or a ps that prints no start time. A live, identity-matched run is
+# never displaced by the clock, however long its panel takes.
+claim_live() {  # <pid> <host> <started> <this-host> [pstart] -> 0 when alive
+  local pid="$1" chost="$2" started="$3" host="$4" pstart="${5:-}" cur
+  case "$pid" in ''|0|*[!0-9]*) return 1 ;; esac
+  case "$started" in ''|*[!0-9]*) return 1 ;; esac
+  if [ "$chost" = "$host" ]; then
+    kill -0 "$pid" 2>/dev/null || return 1
+    cur=$(claim_pstart "$pid")
+    if [ -n "$pstart" ] && [ -n "$cur" ]; then [ "$cur" = "$pstart" ]; return $?; fi
+  fi
+  [ $(( $(date +%s) - started )) -lt "${CADRE_CLAIM_TTL:-14400}" ]
+}
+
 cmd_review() {
   init_home; need git; need jq
-  local base="" roster_arg="" jobs=1 synth="${CADRE_SYNTH:-}" label="" repo=""
+  local base="" roster_arg="" jobs=1 synth="${CADRE_SYNTH:-}" label="" repo="" force=0
   local prerun="${CADRE_PRERUN:-}" full=0 all_seats=0
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -656,6 +789,7 @@ cmd_review() {
       --synth)  synth="${2:?--synth needs an agent spec}"; shift 2 ;;
       --label)  label="${2:?--label needs a name}"; shift 2 ;;
       --prerun) prerun="${2:?--prerun needs a command}"; shift 2 ;;
+      --force)  force=1; shift ;;
       -*) die "review: unknown option '$1'" ;;
       *)  repo="$1"; shift ;;
     esac
@@ -846,7 +980,16 @@ cmd_review() {
   fi
   local out="$CADRE_HOME/reviews/$label"
   mkdir -p "$CADRE_HOME/reviews" || die "cannot create $CADRE_HOME/reviews"
-  mkdir "$out" 2>/dev/null || die "$out already exists. Pick another --label."
+  # ★ Admission control (#32). The label IS the identity of the measurement --
+  # a runner keys it `<repo>-<pr>-<sha>` -- so two callers reaching for the
+  # same one compute the same path, and `mkdir` is the atomic claim: first one
+  # wins. What the bare mkdir could not tell a loser was WHY it lost, and the
+  # three answers call for opposite responses: a live run means go back to
+  # sleep (exit 8), a finished one means the label is spent (die, or --force
+  # to re-measure on purpose), and a crashed one means reclaim it, because a
+  # wedged claim is invisible and the operator's only symptom is "the runner
+  # stopped reviewing". The claim record and its rules are in claim_review.
+  claim_review "$out" "$force" || exit $?
 
   # ★ Say it when the panel is less independent than it looks. This is the ONE
   # property the whole tool rests on, and it is the easiest to lose by accident
@@ -915,6 +1058,7 @@ cmd_review() {
   CADRE_PRERUN="$prerun" CADRE_SKIPPED="$skipped_env" CADRE_GATE_NOTICE="$gate_notice" \
     "$CADRE_ROOT/lib/run-review.sh" "$repo" "$base" "$out" "$jobs" "${specs[@]}" || rrc=$?
   if [ "$rrc" -ne 0 ]; then
+    rm -f "$out/.claim"
     # rmdir, not rm -rf: it succeeds only when the directory is empty, so a run
     # that died before writing anything leaves nothing behind, and one that
     # produced partial output keeps it. An empty review dir reads as a review
@@ -923,7 +1067,14 @@ cmd_review() {
     return "$rrc"
   fi
 
+  # ★ Still claimed through synthesis: it writes into $out too, and a --force
+  # that parked the directory here would have this process finish its merge
+  # inside the replacement run's directory.
   [ -n "$synth" ] && [ "$synth" != none ] && cmd_synthesize "$out" "$synth" "${specs[@]}"
+  # Released on every path. Left behind, a finished run reads as a claim with
+  # a dead pid -- reclaimable, so not fatal, but it would park a completed
+  # review on the next call instead of refusing to re-measure it.
+  rm -f "$out/.claim"
   return 0
 }
 

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -288,8 +288,8 @@ printf '# good\n' > "$D/state/roster"
 OUT=$(run_cadre "$D" review --base main "$S")
 check "all-commented roster refused"  "grep -q 'commented out' <<<\"\$OUT\""
 OUT=$(run_cadre "$D" review --roster good --label reuse --base main "$S")
-OUT=$(run_cadre "$D" review --roster good --label reuse --base main "$S")
-check "label is single-use"           "grep -q 'already exists' <<<\"\$OUT\""
+OUT=$(run_cadre "$D" review --roster good --label reuse --base main "$S"); RC=$?
+check "label is single-use"           "grep -q 'already holds a finished review' <<<\"\$OUT\" && [ '$RC' -eq 2 ]"
 
 echo "== user-declared roster seat gates =="
 # One added line is below the declared threshold. The all-skipped case is still
@@ -3293,6 +3293,106 @@ check "e2e: the silent pass is still named"  "grep -q 'every run came back EMPTY
 check "e2e: the silent pass exited 7"        "grep -q 'run-pass.sh exited 7' <<<\"\$OUTQ\""
 check "e2e: and the real score survives"     "grep -q 'blocking items hit' '$RQ'"
 check "e2e: half-dead sweep does not exit 7" "[ '$RCQ' -ne 7 ]"
+
+echo "== ★ admission control: one review per label at a time (#32) =="
+# The label is the identity of the measurement, so two callers reaching for it
+# compute the same path and `mkdir` decides. The loser has to hear WHY it lost:
+# a live run is "go back to sleep" (exit 8), a finished one is a spent label
+# (refuse, or --force), a dead one is reclaimed with the corpse parked.
+D=$(case_dir claim); S="$D/src"
+git -C "$S" checkout -qb feature; echo x >> "$S/app.js"; git -C "$S" commit -qam f
+run_cadre "$D" review --roster good --synth none --base main --label pr-1 "$S" >/dev/null
+L="$D/state/reviews/pr-1"
+check "claim: a finished run leaves no .claim"   "[ -s '$L/report.md' ] && [ ! -e '$L/.claim' ]"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-1 "$S"); RC=$?
+check "claim: a spent label refuses"             "[ '$RC' -eq 2 ]"
+check "claim: and says how to re-measure"        "grep -q -- '--force' <<<\"\$OUT\""
+check "claim: refusing parks nothing"            "! ls -d '$L'.stale.* >/dev/null 2>&1"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-1 --force "$S"); RC=$?
+check "claim: --force re-measures (exit 0)"      "[ '$RC' -eq 0 ]"
+check "claim: --force parked the old review"     "ls -d '$L'.stale.* >/dev/null 2>&1"
+check "claim: --force says it reclaimed"         "grep -q 'reclaimed pr-1' <<<\"\$OUT\""
+check "claim: and the new review is real"        "[ -s '$L/report.md' ]"
+# A LIVE claim: this test shell's own pid, which is certainly alive.
+mkdir -p "$D/state/reviews/pr-2"
+printf '%s\n%s\n%s\n' "$$" "${HOSTNAME:-$(uname -n)}" "$(date +%s)" > "$D/state/reviews/pr-2/.claim"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-2 "$S"); RC=$?
+check "claim: a live run exits 8"                "[ '$RC' -eq 8 ]"
+check "claim: and names the holder"              "grep -q \"pid $$\" <<<\"\$OUT\""
+check "claim: and says it is not a failure"      "grep -q 'not a failure' <<<\"\$OUT\""
+check "claim: live dir untouched"                "[ -f '$D/state/reviews/pr-2/.claim' ] && [ ! -e '$D/state/reviews/pr-2/report.md' ]"
+# ★ --force never displaces a live run.
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-2 --force "$S"); RC=$?
+check "claim: --force still exits 8 on a live run" "[ '$RC' -eq 8 ]"
+check "claim: and parked nothing"                "! ls -d '$D/state/reviews/pr-2.stale.'* >/dev/null 2>&1"
+# A DEAD claim: a pid that has already exited, same host.
+( : ) & DEADPID=$!; wait "$DEADPID" 2>/dev/null
+mkdir -p "$D/state/reviews/pr-3"; echo "half-written" > "$D/state/reviews/pr-3/prompt.txt"
+printf '%s\n%s\n%s\n' "$DEADPID" "${HOSTNAME:-$(uname -n)}" "$(date +%s)" > "$D/state/reviews/pr-3/.claim"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-3 "$S"); RC=$?
+check "claim: a dead holder is reclaimed"        "[ '$RC' -eq 0 ] && [ -s '$D/state/reviews/pr-3/report.md' ]"
+check "claim: the corpse is parked, not deleted" "grep -q half-written '$D'/state/reviews/pr-3.stale.*/prompt.txt"
+check "claim: reclaim is announced"              "grep -q 'is gone' <<<\"\$OUT\""
+# A claim from ANOTHER host cannot be probed: live inside the TTL, stale past it.
+mkdir -p "$D/state/reviews/pr-4"
+printf '%s\n%s\n%s\n' "1" "some-other-box" "$(( $(date +%s) - 60 ))" > "$D/state/reviews/pr-4/.claim"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-4 "$S"); RC=$?
+check "claim: foreign host inside TTL is live"   "[ '$RC' -eq 8 ]"
+OUT=$(CADRE_CLAIM_TTL=30 run_cadre "$D" review --roster good --synth none --base main --label pr-4 "$S"); RC=$?
+check "claim: foreign host past TTL is reclaimed" "[ '$RC' -eq 0 ] && [ -s '$D/state/reviews/pr-4/report.md' ]"
+# A failed run releases the claim too, and the empty dir is still removed.
+OUT=$(run_cadre "$D" review --roster ghost --synth none --base main --label pr-5 "$S"); RC=$?
+check "claim: a failed run leaves no .claim"     "[ ! -e '$D/state/reviews/pr-5/.claim' ]"
+# ★ Identity, not just a live pid. The claim carries the holder's process
+# start time; a live pid with a different one is a reincarnation.
+mkdir -p "$D/state/reviews/pr-10"
+printf '%s\n%s\n%s\n%s\n' "$$" "${HOSTNAME:-$(uname -n)}" "$(date +%s)" "$(ps -o lstart= -p $$ | tr -s ' ' | sed 's/^ //;s/ $//')" > "$D/state/reviews/pr-10/.claim"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-10 "$S"); RC=$?
+check "claim: matching start time is live (8)"   "[ '$RC' -eq 8 ]"
+printf '%s\n%s\n%s\n%s\n' "$$" "${HOSTNAME:-$(uname -n)}" "$(date +%s)" "Thu Jan  1 00:00:00 1970" > "$D/state/reviews/pr-10/.claim"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-10 "$S"); RC=$?
+check "claim: live pid, other start time = dead"  "[ '$RC' -eq 0 ] && [ -s '$D/state/reviews/pr-10/report.md' ]"
+# A half-written record (the winner's publication window) is busy, not dead.
+mkdir -p "$D/state/reviews/pr-11"; : > "$D/state/reviews/pr-11/.claim"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-11 "$S"); RC=$?
+check "claim: an empty .claim on a fresh dir is busy" "[ '$RC' -eq 8 ]"
+# A sidecar with no owner (older than a minute) is recovered, not obeyed.
+mkdir -p "$D/state/reviews/pr-12.taking"; touch -d '-2 minutes' "$D/state/reviews/pr-12.taking" 2>/dev/null || touch -A -000200 "$D/state/reviews/pr-12.taking"
+mkdir -p "$D/state/reviews/pr-12"; touch -d '-2 minutes' "$D/state/reviews/pr-12" 2>/dev/null || touch -A -000200 "$D/state/reviews/pr-12"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-12 "$S"); RC=$?
+check "claim: an abandoned sidecar is recovered" "[ '$RC' -eq 0 ] && [ -s '$D/state/reviews/pr-12/report.md' ] && [ ! -d '$D/state/reviews/pr-12.taking' ]"
+# The claim is held through synthesis and released after it.
+OUT=$(run_cadre "$D" review --roster good,good2 --synth echoer --base main --label pr-13 "$S"); RC=$?
+check "claim: released after synthesis"          "[ -s '$D/state/reviews/pr-13/synthesis.md' ] && [ ! -e '$D/state/reviews/pr-13/.claim' ]"
+# ★ Two losers on one label: the reclaim sequence is serialised by a sidecar,
+# and a caller that finds the sidecar taken is looking at a live reclaim.
+mkdir -p "$D/state/reviews/pr-6" "$D/state/reviews/pr-6.taking"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-6 "$S"); RC=$?
+check "claim: a reclaim in progress exits 8"     "[ '$RC' -eq 8 ]"
+check "claim: and parks nothing"                 "! ls -d '$D/state/reviews/pr-6.stale.'* >/dev/null 2>&1"
+# ★ The winner between its mkdir and its first write: no record, no report, a
+# directory seconds old. Busy, not dead.
+mkdir -p "$D/state/reviews/pr-7"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-7 "$S"); RC=$?
+check "claim: a fresh empty dir is busy (8)"     "[ '$RC' -eq 8 ]"
+check "claim: and is left alone"                 "[ -d '$D/state/reviews/pr-7' ] && ! ls -d '$D/state/reviews/pr-7.stale.'* >/dev/null 2>&1"
+# The same dir two minutes old is a run that died before it could say so.
+touch -d '-2 minutes' "$D/state/reviews/pr-7" 2>/dev/null || touch -A -000200 "$D/state/reviews/pr-7"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-7 "$S"); RC=$?
+check "claim: an old empty dir is reclaimed"     "[ '$RC' -eq 0 ] && [ -s '$D/state/reviews/pr-7/report.md' ]"
+# ★ pid reuse after a reboot: a same-host claim whose pid is alive but whose
+# start is past the TTL is dead. pid 1 is always alive.
+mkdir -p "$D/state/reviews/pr-8"
+printf '%s\n%s\n%s\n' "1" "${HOSTNAME:-$(uname -n)}" "$(( $(date +%s) - 20000 ))" > "$D/state/reviews/pr-8/.claim"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-8 "$S"); RC=$?
+check "claim: same-host live pid past TTL is dead" "[ '$RC' -eq 0 ] && [ -s '$D/state/reviews/pr-8/report.md' ]"
+# pid 0 is the process group, so kill -0 0 always succeeds; it is not a holder.
+mkdir -p "$D/state/reviews/pr-9"
+printf '%s\n%s\n%s\n' "0" "${HOSTNAME:-$(uname -n)}" "$(date +%s)" > "$D/state/reviews/pr-9/.claim"
+OUT=$(run_cadre "$D" review --roster good --synth none --base main --label pr-9 "$S"); RC=$?
+check "claim: pid 0 is not a live holder"        "[ '$RC' -eq 0 ] && [ -s '$D/state/reviews/pr-9/report.md' ]"
+# No sidecar left behind by any path above.
+check "claim: no .taking sidecars remain"        "! ls -d '$D/state/reviews/'*.taking 2>/dev/null | grep -v pr-6 | grep -q ."
 
 echo
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
Closes #32.

`cadre review` had no admission control: two callers on the same label both built checkouts, both burned seat capacity, both posted. The `mkdir` on the label's directory was already atomic; this makes the loser's answer distinct.

- `.claim` record (pid, host, started, process start time) beside `prompt.txt`, written via tmp+`mv`.
- Live holder → **exit 8**, "nothing to do; not a failure" (unused beside 2/3/4/6/7). Finished label → refuse, or `--force`. Dead holder → corpse parked as `<label>.stale.<t>.<pid>`, label taken.
- `--force` never displaces a live run. Claim held through synthesis.
- Same-host liveness = pid alive **and** start time matches (pid reuse after reboot is a reincarnation). `CADRE_CLAIM_TTL` (4h) only for unprobeable hosts.
- Reclaim serialised by a sidecar dir; abandoned sidecar (>60s) recovered. No record + no report + dir <60s old = the winner mid-publication, busy.
- 24 smoke checks; suite 813/813.

Two-model review of the first draft (grok + codex) found the park race, pid reuse, the publication window, and a `die` inside the sidecar that would have wedged the label; all fixed and covered.