### PR TITLE
An operator fault is not a reviewer failure (#31)

### DIFF
--- a/docs/ADDING-AN-AGENT.md
+++ b/docs/ADDING-AN-AGENT.md
@@ -61,6 +61,7 @@ an empty failure.
 | a complete review | the review, nothing else | `ok` |
 | review text, cut short | the text, then a line starting `_TRUNCATED` | `degraded` |
 | no review at all | a line starting `DID NOT RUN` or `DID NOT COMPLETE`, then any raw output that helps diagnose it | `failed` |
+| your CLI refused for a reason that is the OPERATOR's to fix (a model the vendor does not serve, a flag this build lacks) | `DID NOT RUN, misconfigured: <why>` | `failed`, reported as MISCONFIGURED rather than as a reviewer failure |
 
 **If the clock is what stopped you, say so on that marker line, with the number:**
 `DID NOT COMPLETE, <agent> was killed at the ${TIMEOUT}s timeout`. It does not

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -866,8 +866,30 @@ content_empty() {  # <file> -> 0 when the file holds no content
 # rc is OPTIONAL. `cadre grade` re-reads .failed artifacts off disk long after
 # the exit code is gone, and the content discriminator still works there -- so
 # with no rc the timeout case is simply not claimed rather than guessed at.
-failure_kind() {  # <file> [rc] -> no-output | timed-out | failed
+# The one copy of the misconfiguration markers, and the line that matched --
+# the renderers quote it, so a marker on line 2 or 3 is quoted, not line 1.
+CADRE_MISCONF_RE="^(NOT INSTALLED: [^ ]+ is not on PATH|agentcall: (unknown agent '|[^ ]+ takes no model, drop|no such directory: |mode must be ro or rw|no prompt \\()|DID NOT RUN, misconfigured: )"
+misconfigured_line() {  # <file> -> the matching marker line, or ""
+  head -3 "$1" 2>/dev/null | grep -E -m1 "$CADRE_MISCONF_RE"
+}
+
+failure_kind() {  # <file> [rc] -> misconfigured | no-output | timed-out | failed
   local f="$1" rc="${2:-}"
+  # ★ FIRST, ahead of every provider-shaped answer (#31): these are things the
+  # OPERATOR did, and they are fixed on this box -- a roster member not on
+  # PATH, a spec with a model on an adapter that takes none, a seat with no
+  # adapter file at all. None of it is evidence about a reviewer, and a sweep
+  # that files it as a reviewer failure manufactures a verdict on a model that
+  # was never called. Every marker here is one the HARNESS writes (run-review
+  # / run-pass's NOT INSTALLED line, agentcall's own die), plus one an adapter
+  # may opt into when its CLI reports a fault it can attribute to configuration
+  # rather than the provider: `DID NOT RUN, misconfigured: <why>`.
+  # Same rails as the other kinds: renderer layer only, classify_run's four
+  # states untouched, so the retry loops keep string-comparing `failed`.
+  # ★ Whole harness sentences, not their first words: a reviewer of THIS repo
+  # opening with "NOT INSTALLED handling is too broad" is a review, and the
+  # first draft of this check filed it as a seat that never ran.
+  if [ -n "$(misconfigured_line "$f")" ]; then echo misconfigured; return 0; fi
   if content_empty "$f"; then echo no-output; return 0; fi
   # ★ THE ADAPTER'S OWN VERDICT BEFORE THE EXIT CODE, the same rail classify_run
   # follows and for the same reason: the adapter is the only layer that watched
@@ -928,6 +950,11 @@ failure_phrase() {  # <file> <rc> [secs] -> leading phrase, no trailing period
     # stop, one level up.
     timed-out)
       echo "TIMED OUT$after$rcp: killed at the ${tmo}s CADRE_TIMEOUT, so this is cadre's clock and not a verdict on the model -- raise CADRE_TIMEOUT and re-run" ;;
+    # ★ Quotes the harness's own line, because it already names the fix (the
+    # binary, the spec, the adapter). No rc: the seat never ran, so there is
+    # no exit status that means anything about it.
+    misconfigured)
+      echo "MISCONFIGURED$after: $(misconfigured_line "$f" | cut -c1-160) -- a fault on this box, not a verdict on the model; fix the roster or the install and re-run" ;;
     *)
       echo "FAILED$after$rcp" ;;
   esac

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -422,7 +422,7 @@ remove that directory and re-run."
   # the silent-denominator bug the nskipped guard was written for, still live on
   # the one path where it costs most: 11 of 12 passes producing nothing scored
   # 0/0 and reported INCONCLUSIVE, indistinguishable from a registry problem.
-  local usable_runs=0 pass_usable=0 aborted="" measurement_failed="" nfiltered=0 window_closed=""
+  local usable_runs=0 pass_usable=0 aborted="" measurement_failed="" nfiltered=0 window_closed="" misconfigured_seat=""
   # ★ Sweep-wide tally behind the fourth "nothing" verdict (#12). A NO OUTPUT
   # streak across every seat of a sweep is evidence about the PROVIDER, not the
   # candidate -- measured when every opencode-go model hung on `Reply with
@@ -551,6 +551,12 @@ remove that directory and re-run."
         elif [ "$prc" -eq 7 ]; then
           skipped="$skipped- $label: NOT MEASURED, every run came back empty (suspect a provider outage)"$'\n'
           provider_empty=1
+        # ★ 9 IS a failed measurement, unlike 6 and 7, because nothing clears
+        # it but the operator -- but the sentence must send them to the roster
+        # or the install, not to the candidate (#31).
+        elif [ "$prc" -eq 9 ]; then
+          skipped="$skipped- $label: NOT MEASURED, the seat is MISCONFIGURED on this box (not installed, bad spec, or no adapter); the reviewer was never called"$'\n'
+          measurement_failed=1; misconfigured_seat=1
         else
           skipped="$skipped- $label: no usable review, run-pass.sh exited $prc"$'\n'
           measurement_failed=1
@@ -627,7 +633,9 @@ remove that directory and re-run."
         # Every other artifact test in this block stays `-s` on purpose -- an
         # empty .partial or .inconclusive really is nothing to report.
         if [ -e "$rf.failed" ]; then
-          if content_empty "$rf.failed"; then
+          if [ "$(failure_kind "$rf.failed")" = misconfigured ]; then
+            why="MISCONFIGURED on this box, the reviewer was never called: $(misconfigured_line "$rf.failed" | cut -c1-120)"
+          elif content_empty "$rf.failed"; then
             why="the provider returned NOTHING (no content in $sl-run$n.md.failed)"
             no_output_runs=$((no_output_runs + 1))
           else
@@ -976,6 +984,18 @@ here -- but nothing expensive was lost, and \`cadre grade $spec $runs\` re-runs
 the judge over what is already on disk. Do not re-review."
       fi
       local tail1="Fix the cause and re-run. Do not quote a number from this file."
+      # ★ The operator's own fault outranks every provider-shaped verdict below
+      # (#31): a seat that is not installed will not come back after a reset
+      # or an outage, and 4's "fix the cause" sends the reader to the tool.
+      # Exit 9, matching run-pass.sh, so a driver can tell "install it" from
+      # "file a bug" without reading the report.
+      if [ -n "$misconfigured_seat" ] && [ -z "$grading_failed" ]; then
+        head1="NOT MEASURED -- SEAT MISCONFIGURED"; rc1=9
+        body1="The seat for \`$spec\` never ran on this box: not installed, a bad spec, or no
+adapter. Nothing about the candidate was observed, so this says nothing about it."
+        tail1="Fix the roster entry or the install, then re-run. Do not quote a number from
+this file, and do not record a verdict about the candidate from it."
+      fi
       # ★ A fourth nothing (#12), and it is a statement about the PROVIDER. Fires
       # only when EVERY failed run of the sweep came back content-empty: one
       # empty artifact is an ordinary failure, a clean sweep of them is an

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -88,7 +88,7 @@ mapfile -t SCRUB < <(scrubbed_env)
 # everything, and the driver above it wrote COMPLETED across a sweep where 27 of
 # 30 requested reviews did not exist. Silence and success must not share an exit
 # code.
-ok_runs=0; bad_runs=0; dead_agents=""; windows=""; no_output_runs=0
+ok_runs=0; bad_runs=0; dead_agents=""; windows=""; no_output_runs=0; misconfigured_runs=0
 
 for r in "${reviewers[@]}"; do
   agent=$(spec_agent "$r"); model=$(spec_model "$r")
@@ -97,6 +97,7 @@ for r in "${reviewers[@]}"; do
   agent_installed "$agent" || {
     echo "  $r: NOT INSTALLED, $runs requested run(s) produced nothing"
     bad_runs=$((bad_runs + runs)); dead_agents="$dead_agents  $r: not installed"$'\n'
+    misconfigured_runs=$((misconfigured_runs + runs))
     continue
   }
   # Capability preflight: a doomed seat must not burn the graded-pass budget.
@@ -209,8 +210,10 @@ for r in "${reviewers[@]}"; do
         bad_runs=$((bad_runs + 1))
         # Counted here so the pass can exit with the provider's cause rather
         # than a generic 4. See the exit-7 block at the bottom of this file.
-        [ "$(failure_kind "$f.failed" "$rc")" = no-output ] &&
-          no_output_runs=$((no_output_runs + 1))
+        case "$(failure_kind "$f.failed" "$rc")" in
+          no-output)     no_output_runs=$((no_output_runs + 1)) ;;
+          misconfigured) misconfigured_runs=$((misconfigured_runs + 1)) ;;
+        esac
         echo "    $(failure_phrase "$f.failed" "$rc" "$took"), kept as $(basename "$f.failed"), not counted as a run" ;;
     esac
 
@@ -264,14 +267,34 @@ echo "  $ok_runs usable, $bad_runs not usable, of $((ok_runs + bad_runs)) reques
 # because the operator's next move is different: 6, the provider's usage window
 # closed (wait for the reset), and 7, every run came back empty (check the
 # endpoint is up). Both mean "nothing is wrong here to fix", which 4 does not.
+# 9 is the operator's own fault (#31): the seat never ran on this box.
+# (8 is taken by bin/cadre's review claim and means "already running".)
 # This comment is the only table of these codes; add to it when you add one.
 if [ "$ok_runs" -eq 0 ] && [ "$bad_runs" -gt 0 ]; then
+  # ★ 9 before all of them (#31): a requested seat that NEVER RAN because of
+  # a fault on this box. Every later pass fails the same way, the fix is the
+  # operator's, and nothing about the candidate was observed -- so it must
+  # not read as 4's "defect to fix in the tool" nor as 6/7's "wait it out".
+  # Fail closed, the way addyosmani/factory's MISCONFIGURED gate refuses
+  # rather than scoring around a gate that was declared and never dispatched.
+  if [ "$misconfigured_runs" -eq "$bad_runs" ]; then
+    {
+      echo "cadre: pass '$label' measured NOTHING because the seat is MISCONFIGURED on this box."
+      [ -n "$dead_agents" ] && printf '%s' "$dead_agents"
+      echo "The reviewer was never called, so this is not evidence about it. Fix the roster"
+      echo "entry or the install and re-run; nothing here scores the candidate either way."
+    } >&2
+    exit 9
+  fi
   # ★ 6 before 4. Both mean "this pass measured nothing", and they prescribe
   # opposite next moves: 4 says the cause is a defect to fix, 6 says the cause is
   # a clock that will clear itself. Reporting a closed window as a failed
   # measurement is how a sweep four minutes short of resuming got a report
   # reading "Fix the cause and re-run" with nothing to fix.
-  if [ -n "$windows" ]; then
+  # ★ ...and not when a misconfigured seat is in the mix: "nothing is wrong
+  # with the tool" would be false, and the operator would wait out a window
+  # for a seat that can never run.
+  if [ -n "$windows" ] && [ "$misconfigured_runs" -eq 0 ]; then
     {
       echo "cadre: pass '$label' measured NOTHING because a provider usage window closed."
       printf '%s' "$windows"

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -655,7 +655,7 @@ REPORT="$OUT/report.md"
   [ -n "${CADRE_GATE_NOTICE:-}" ] && echo "$CADRE_GATE_NOTICE."
 } > "$REPORT"
 
-ok_count=0 degraded_count=0 inconc_count=0 fail_count=0
+ok_count=0 degraded_count=0 inconc_count=0 fail_count=0 misconf_count=0
 for spec in "${reviewers[@]}"; do
   sl=$(slug "$spec")
   case "$(cat "$OUT/.status-$sl" 2>/dev/null)" in
@@ -672,7 +672,15 @@ for spec in "${reviewers[@]}"; do
       echo "  reviewer. See \`$sl.md.inconclusive\`." >> "$REPORT" ;;
     *)
       fail_count=$((fail_count + 1))
-      echo "- \`$spec\` — **FAILED**, see \`$sl.md.failed\`" >> "$REPORT" ;;
+      # ★ Same bucket, different sentence (#31). A seat that never ran because
+      # of a fault on this box is not a reviewer that failed, and the reader
+      # of "FAILED" goes looking for a model problem that does not exist.
+      if [ "$(failure_kind "$OUT/$sl.md.failed")" = misconfigured ]; then
+        misconf_count=$((misconf_count + 1))
+        echo "- \`$spec\` — **MISCONFIGURED**, never ran: $(misconfigured_line "$OUT/$sl.md.failed" | cut -c1-160). A fault on this box, not a reviewer verdict." >> "$REPORT"
+      else
+        echo "- \`$spec\` — **FAILED**, see \`$sl.md.failed\`" >> "$REPORT"
+      fi ;;
   esac
 done
 
@@ -687,6 +695,16 @@ for row in "${skipped_rows[@]}"; do
       echo "- \`$spec\` — SKIPPED by capability preflight ($gate: $reason)." >> "$REPORT" ;;
   esac
 done
+
+# ★ A misconfigured seat is counted under failed above, so the totals stay
+# comparable across runs; this line is where the reader learns the panel was
+# smaller than requested for a reason that is theirs to fix.
+[ "$misconf_count" -gt 0 ] && {
+  echo >> "$REPORT"
+  echo "> $misconf_count requested seat(s) were **MISCONFIGURED** on this box and never ran." >> "$REPORT"
+  echo "> The panel is smaller than the roster asked for. That is not a finding about" >> "$REPORT"
+  echo "> any reviewer; fix the roster or the install and re-run." >> "$REPORT"
+}
 
 # ★ Spell out what degraded costs the reader, once, where the counts are. The
 # tempting read of a short partial review is "it looked and found little".
@@ -733,6 +751,9 @@ for spec in "${reviewers[@]}"; do
   elif [ -s "$OUT/$sl.md.inconclusive" ]; then
     echo "_INCONCLUSIVE. Ran, but returned no findings and no verdict. Not a review._"$'\n' >> "$REPORT"
     head -20 "$OUT/$sl.md.inconclusive" 2>/dev/null | sed 's/^/    /' >> "$REPORT"
+  elif [ "$(failure_kind "$OUT/$sl.md.failed")" = misconfigured ]; then
+    echo "_MISCONFIGURED. The seat never ran; this is a fault on this box, not a review._"$'\n' >> "$REPORT"
+    head -5 "$OUT/$sl.md.failed" 2>/dev/null | sed 's/^/    /' >> "$REPORT"
   else echo "_FAILED. Not a clean review._"$'\n' >> "$REPORT"
        head -20 "$OUT/$sl.md.failed" 2>/dev/null | sed 's/^/    /' >> "$REPORT"
   fi

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -250,6 +250,26 @@ check "gitignored secret excluded"   "! grep -q 'env.local' '$G'"
 check "ignored log excluded"         "! grep -q 'debug.log' '$G'"
 check ".env.example did not refuse"  "[ -n '$G' ]"
 check "missing agent -> FAILED"      "grep -q 'NOT INSTALLED' '$R'/ghost-*.failed"
+# ★ #31: same bucket, different sentence. The operator reads MISCONFIGURED and
+# goes to the roster, not to a reviewer that was never called.
+check "missing agent reads MISCONFIGURED"   "grep -q 'ghost.*MISCONFIGURED' '$R/report.md'"
+check "and not as a reviewer FAILED"        "! grep -qE '^- .ghost. — \*\*FAILED' '$R/report.md'"
+check "report says the panel is smaller"    "grep -q 'never ran' '$R/report.md'"
+check "unit: NOT INSTALLED -> misconfigured" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(failure_kind '$R'/ghost-*.failed) = misconfigured ]\""
+check "unit: phrase names the box, not the model" "bash -c \"source '$ROOT/lib/common.sh'; failure_phrase '$R'/ghost-*.failed '' 0\" | grep -q 'not a verdict on the model'"
+printf 'agentcall: unknown agent %s (have: good)\n' "'nope'" > "$D/ac.txt"
+check "unit: agentcall die -> misconfigured" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(failure_kind '$D/ac.txt' 2) = misconfigured ]\""
+printf 'DID NOT RUN, misconfigured: model gpt-99 is not served by this account\n' > "$D/adm.txt"
+check "unit: adapter opt-in marker -> misconfigured" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(failure_kind '$D/adm.txt' 0) = misconfigured ]\""
+# ★ A reviewer OF this repo opens with the marker's first words. Whole
+# sentences only, or a review is filed as a seat that never ran.
+printf 'NOT INSTALLED handling is too broad in run-review.sh.\n- should-fix: the check matches prose.\nVerdict: ship it after that fix\n' > "$D/prose.txt"
+check "unit: prose starting NOT INSTALLED stays failed" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(failure_kind '$D/prose.txt' 1) = failed ]\""
+# The marker on line 2 is the line that gets quoted, not line 1.
+printf 'cli chrome\nagentcall: unknown agent %s (have: good)\n' "'nope'" > "$D/ac2.txt"
+check "unit: a line-2 marker is the quoted line" "bash -c \"source '$ROOT/lib/common.sh'; failure_phrase '$D/ac2.txt' 2\" | grep -q 'MISCONFIGURED: agentcall: unknown agent'"
+printf 'DID NOT COMPLETE, no text returned (stopReason=Error).\n' > "$D/dnc.txt"
+check "unit: a provider failure stays failed" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(failure_kind '$D/dnc.txt' 1) = failed ]\""
 check "all 4 roster rows in report"  "[ \$(grep -c '^- \`' '$R/report.md') -eq 4 ]"
 
 # ---- three-state reviewer health ---------------------------------------------
@@ -3343,6 +3363,18 @@ check "e2e: the silent pass is still named"  "grep -q 'every run came back EMPTY
 check "e2e: the silent pass exited 7"        "grep -q 'run-pass.sh exited 7' <<<\"\$OUTQ\""
 check "e2e: and the real score survives"     "grep -q 'blocking items hit' '$RQ'"
 check "e2e: half-dead sweep does not exit 7" "[ '$RCQ' -ne 7 ]"
+
+# ★ #31: a candidate that is not on PATH is the operator's fault. The pass
+# fails CLOSED with its own code, and the report sends the reader to the
+# install, not to a verdict on a model that was never called.
+DM=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DM" ghost "$HITBOTH" "$HITBOTH"
+RCM=0; OUTM=$(run_gaunt_all "$DM" good,good2 ghost) || RCM=$?
+check "e2e: misconfigured seat exits run-pass 9" "grep -q 'run-pass.sh exited 9' <<<\"\$OUTM\""
+check "e2e: and says MISCONFIGURED"             "grep -q 'MISCONFIGURED' <<<\"\$OUTM\""
+check "e2e: and is not the outage verdict"      "! grep -q 'came back EMPTY' <<<\"\$OUTM\""
+check "e2e: and cadre run exits 9 too"          "[ '$RCM' -eq 9 ]"
+RM=$(ls "$DM/home"/report-*.md | head -1)
+check "e2e: verdict names the seat, not the model" "grep -q 'Verdict: NOT MEASURED -- SEAT MISCONFIGURED' '$RM'"
 
 echo "== ★ admission control: one review per label at a time (#32) =="
 # The label is the identity of the measurement, so two callers reaching for it


### PR DESCRIPTION
Closes #31.

Not-on-PATH, bad spec, missing adapter: all rendered as reviewer **FAILED** and scored into the panel math.

- `failure_kind` → fourth value `misconfigured`, renderer layer only; `classify_run` untouched. Markers are whole harness sentences + an adapter opt-in `DID NOT RUN, misconfigured: <why>` (documented in ADDING-AN-AGENT.md). The matching line is the one quoted.
- Report rows / per-seat bodies say **MISCONFIGURED**, "a fault on this box, not a reviewer verdict", plus a panel-size note.
- `run-pass.sh` exits **9** (fail closed) when every bad run is misconfigured, ahead of 6/7; refuses the window verdict when a misconfigured seat is mixed in. `grade.sh` carries it to `Verdict: NOT MEASURED -- SEAT MISCONFIGURED`, exit 9.
- Swept against 1,347 real artifacts: zero matches (no reviewer prose trips the markers).
- Codex review of the first draft found four defects (swallowed exit, first-words match, window mix, line-1 quoting); all fixed and covered. Suite 839/839.

Not handled: a vendor rejecting an unknown model name is still `failed` unless the adapter opts in with the new marker; adapters can adopt it one at a time.