### PR TITLE
Stop burning retries on things a retry cannot fix

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -644,6 +644,16 @@ has_verdict() {
   tail -12 "$1" | sed "$strip" | grep -qiE '(ship[ -]it|lgtm|looks good|approved?|no (defects|issues|problems|concerns|bugs|blockers)|nothing (worth )?(to )?(flag|report|fix|filing|flagging|flagged)|all (good|clear)|(safe|ready|ok) to merge|recommend merging|^[-*_#> `]*((overall +)?verdict|conclusion|recommendation)|no (blocking|defects)[a-z ]*(found|here)?)'
 }
 
+# The NARROW form of has_verdict, for exempting a short zero-finding review
+# from the rate-limit scan: a labelled verdict line, or one of the unambiguous
+# bottom-line idioms. Deliberately without has_verdict's bare `approved?`,
+# `looks good`, `conclusion` and `recommendation`, each of which a refusal can
+# say ("Request not approved: 429", "Recommendation: retry after 60s").
+explicit_verdict() {
+  local strip='s/^[[:space:]]*//;s/[[:space:]]*$//'
+  tail -12 "$1" | sed "$strip" | grep -qiE '(^[-*_#> `]*(overall +)?verdict[: *_]|\b(ship[ -]it|lgtm|safe to merge|recommend merging|no (defects|issues|problems|bugs|blockers) (found|here))\b)'
+}
+
 # Does this output look like a rate-limit refusal rather than a review?
 # ★ Length-guarded on purpose. A genuine review OF a rate limiter says "rate
 # limit exceeded" while quoting the code, and misreading that as a refusal would
@@ -1151,7 +1161,19 @@ classify_run() {
     # length-guard claim was only true above 2KB. A refusal that happens to
     # open with "critical:" slips through here and lands on the judge instead,
     # which is the cheaper direction: a destroyed real review is unrecoverable.
-    if rate_limited "$f" && [ "$(review_findings "$f")" -eq 0 ]; then echo failed; return 0; fi
+    # ★ ...and never states a BOTTOM LINE either. Measured 2026-08-29 on the
+    # live runner: a 1.4KB clean review of a comment-only diff about a 429
+    # throttle -- "there is no rate-limit check ... Verdict: ship it" -- had
+    # findings=0, matched the scan, was retried three times over 250s of the
+    # seat's quota, and was filed failed under a DID NOT COMPLETE banner. The
+    # discriminator provider_refused() already names: a refusal is something
+    # the CLI RETURNS, a verdict is something the model WRITES. A refusal
+    # that happens to say "ship it" lands on the judge, the cheap direction.
+    # ★ explicit_verdict, not has_verdict: the broad gate accepts a bare
+    # "approved" or a leading "Recommendation:", and "Request not approved:
+    # 429" / "Recommendation: retry after 60s" are refusal shapes. Found by
+    # the codex review of this change.
+    if rate_limited "$f" && [ "$(review_findings "$f")" -eq 0 ] && ! explicit_verdict "$f"; then echo failed; return 0; fi
     # ★ #28. A seat whose sandbox broke before the model could look wrote a
     # short apology, no findings, and a verdict of its own -- and that verdict
     # carried it past the inconclusive test below into `ok`. Checked here with

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -560,6 +560,25 @@ run_one() {
     # classify_run left both halves alive; a test on the end-to-end path is what
     # found them, after the unit-level order was already correct.
     [ "$(classify_run "$f.part" "$rc")" = failed ] || break
+    # ★ The benchmark path's three refusals, in the benchmark path's order, and
+    # this path never had them. Measured on the live runner, 2026-08-29: the
+    # copilot seat's "You have exceeded your monthly quota" matched the rate
+    # scan below and was retried three times at 60/120/240s -- on 164 reviews,
+    # 31,322 seconds of a single-lane queue waiting on an account that no
+    # backoff could refill. A usage window is the same waste with a reset time
+    # attached. Neither is a throughput ceiling; neither gets a retry.
+    if provider_window_closed "$f.part"; then
+      { echo "DID NOT COMPLETE, provider usage window closed, not retried: $(head -c 160 "$f.part" | tr '\n' ' ')"
+        cat "$f.part"; } > "$f.part.tmp" && mv "$f.part.tmp" "$f.part"
+      echo "  $spec: ⏸ usage window CLOSED, not a rate limit; not retried" >> "$log"
+      break
+    fi
+    if quota_exhausted "$f.part"; then
+      { echo "DID NOT COMPLETE, out of budget, not retried: $(head -c 160 "$f.part" | tr '\n' ' ')"
+        cat "$f.part"; } > "$f.part.tmp" && mv "$f.part.tmp" "$f.part"
+      echo "  $spec: ⛔ OUT OF BUDGET, not a rate limit; not retried" >> "$log"
+      break
+    fi
     rate_limited "$f.part" || break
     if [ "$attempt" -ge "${CADRE_RETRIES:-3}" ]; then
       # ★ PREPENDED, in the documented contract shape. Appending is the one

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -23,7 +23,7 @@ setup_agents() {
   local n
   for n in good good2 trunc dead echoer chrome terse ratepart ratelim \
            synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2 \
-           blocked permquote; do
+           blocked permquote ratereview budget window; do
     printf '#!/bin/sh\nexit 0\n' > "$1/bin/$n"; chmod +x "$1/bin/$n"
   done
   # ★ The trailing verdict is not decoration. review-live.md asks every reviewer
@@ -144,6 +144,32 @@ A
   # A GENUINE rate limit, no review at all: the case the retry loop is for.
   cat > "$1/agents.d/ratelim.sh" <<'A'
 run_ratelim() { printf 'Error: 429 too many requests.\n'; }
+A
+  # ★ A short CLEAN review of throttle code, verbatim shape from the live
+  # runner (2026-08-29): findings=0, the words "429" and "rate limited" in the
+  # body, a verdict at the end. The keyword scan binned it and burned three
+  # retries. A refusal never states a bottom line; this does.
+  # ★ Verbatim shapes from the live runner. A budget refusal and a closed usage
+  # window both match the rate scan; neither is cleared by backoff.
+  cat > "$1/agents.d/budget.sh" <<'A'
+run_budget() { printf 'You have exceeded your monthly quota (Request ID: F443:1788AA:4F7ACB)\n'; }
+A
+  cat > "$1/agents.d/window.sh" <<'A'
+# Nonzero like the real claude CLI: with exit 0 this text is `inconclusive`
+# (no rate keyword, no findings, no verdict) and never reaches the retry loop.
+run_window() { printf "You've hit your session limit · resets 5am (UTC)\n"; return 1; }
+A
+  # Unquoted heredoc on purpose: the call counter's path is baked in, because
+  # the adapter runs under a scrubbed environment and cannot be told it.
+  cat > "$1/agents.d/ratereview.sh" <<A
+run_ratereview() {
+  echo x >> "$1/ratereview.calls"
+  echo "Comment-only diff. The old comment claimed the in-app 429 was the only throttle,"
+  echo "but there is no rate-limit check anywhere in this route; the new comment says so."
+  echo "No behavior changed, so nothing is rate limited differently. No new defects."
+  echo
+  echo "Verdict: ship it"
+}
 A
   # ★ #28, verbatim from a live panel (codex, 2026-08-24). The sandbox broke
   # before the model could look; it said so, stated NO findings, and then wrote
@@ -1565,6 +1591,34 @@ R="$D/state/reviews/ratelim"
 check "a real rate limit still fails"   "ls '$R'/ratelim-*.md.failed >/dev/null 2>&1"
 check "give-up note leads the file"     "head -1 '$R'/ratelim-*.md.failed | grep -q '^DID NOT COMPLETE, rate limited'"
 check "and the error text is kept"      "grep -q '429 too many requests' '$R'/ratelim-*.md.failed"
+# ★ The verdict is the discriminator. Same words, zero findings, a bottom line:
+# a review, filed ok, and NOT retried -- the retries are the expensive half.
+OUT=$(CADRE_RETRIES=3 CADRE_RETRY_WAIT=1 run_cadre "$D" review --roster ratereview --synth none \
+      --base main --label ratereview "$S")
+R="$D/state/reviews/ratereview"
+check "clean review of throttle code is ok"  "ls '$R'/ratereview-*.md >/dev/null 2>&1"
+check "and not filed failed"                 "! ls '$R'/ratereview-*.md.failed >/dev/null 2>&1"
+check "and was never retried"                "! grep -q 'rate limited, waiting' <<<\"\$OUT\""
+check "and the adapter was called exactly once" "[ \$(wc -l < '$D/ratereview.calls') -eq 1 ]"
+# The refusal shapes has_verdict would have let through.
+printf 'Request not approved: 429 rate limit exceeded.\n' > "$D/notapproved.txt"
+check "unit: 'not approved: 429' is still failed" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(classify_run '$D/notapproved.txt' 0) = failed ]\""
+printf 'Error: rate limit exceeded.\nRecommendation: retry after 60 seconds.\n' > "$D/recommend.txt"
+check "unit: 'Recommendation: retry' is still failed" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(classify_run '$D/recommend.txt' 0) = failed ]\""
+# ★ Budget and window refusals: filed failed, NOT retried. The retries were
+# 8.7 hours of a single-lane queue on the live runner.
+OUT=$(CADRE_RETRIES=3 CADRE_RETRY_WAIT=1 run_cadre "$D" review --roster budget,window,good --synth none \
+      --base main --label budget "$S")
+R="$D/state/reviews/budget"
+check "budget refusal is failed"             "ls '$R'/budget-*.md.failed >/dev/null 2>&1"
+check "budget refusal is not retried"        "! grep -q 'rate limited, waiting' <<<\"\$OUT\""
+check "budget refusal is named"              "grep -q 'OUT OF BUDGET' <<<\"\$OUT\""
+check "budget banner leads the artifact"     "head -1 '$R'/budget-*.md.failed | grep -q 'out of budget, not retried'"
+check "window refusal is failed"             "ls '$R'/window-*.md.failed >/dev/null 2>&1"
+check "window refusal is named"              "grep -q 'usage window CLOSED' <<<\"\$OUT\""
+check "window banner leads the artifact"     "head -1 '$R'/window-*.md.failed | grep -q 'usage window closed, not retried'"
+check "the rest of the panel still ran"      "ls '$R'/good-*.md >/dev/null 2>&1"
+check "unit: a refusal with no verdict is still failed" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(classify_run '$R'/../ratelim/ratelim-*.md.failed 0) = failed ]\""
 
 echo "== ★ a synthesis QUOTING a marker is not a truncated synthesis =="
 # The synthesis prompt asks the model to report which reviewers were cut off, so


### PR DESCRIPTION
Two live-runner defects found while mapping #29, both measured 2026-08-29.

**A clean review of throttle code was retried 3× and filed failed.** The claude seat's review of a comment-only diff about a 429 throttle (findings=0, "Verdict: ship it") matched `rate_limited()`; 250s of quota burned, then filed under a `DID NOT COMPLETE` banner. `classify_run`'s rate-limit bin now also requires no explicit verdict, on the principle `provider_refused()` already states: a refusal is what the CLI returns, a verdict is what the model writes. `explicit_verdict()` is the narrow form of `has_verdict` (labelled verdict line or an unambiguous idiom), since the broad gate accepts "Request not approved: 429" (codex finding). Sweep of 255 real `.failed` artifacts: exactly one flips to `ok` (the bug's own), all 201 genuine refusals stay `failed`.

**The live path retried budget refusals as rate limits.** Copilot's "exceeded your monthly quota" was retried at 60/120/240s on every review: 164 runs, **31,322 s** (8.7 h) of the single-lane queue. `run-review.sh` now has `run-pass.sh`'s `provider_window_closed` / `quota_exhausted` short-circuits in the same order, with their own banners and greppable log lines.

Tests count adapter invocations (called exactly once), cover both refusal shapes, and both short-circuits. Suite 854/854.

Related: #29 (its "three attempts with short backoff" premise is partly this bug; seat order and a panel floor remain open there).