### PR TITLE
cadre review: synth seat last, and a panel floor a runner can hear (#29)

### DIFF
--- a/bin/cadre
+++ b/bin/cadre
@@ -118,6 +118,11 @@ Environment:
   CADRE_TEST_CMD  override the detected test command
   CADRE_RETRIES     attempts when a call comes back rate limited (default 3)
   CADRE_RETRY_WAIT  first backoff in seconds, doubling, capped at 600 (default 60)
+  CADRE_PANEL_MIN   `cadre review` exits 10 when fewer usable seats than this
+                    came back (checked after synthesis; every artifact is
+                    intact). Off by default. A runner reads the exit code, not
+                    the report, and should alert rather than post a thin panel
+                    as if it were the one asked for.
 EOF
 }
 
@@ -959,6 +964,25 @@ cmd_review() {
     esac
     is_promptless "$sa" && die "--synth cannot be '$sa': that adapter ignores the prompt and
      ships its own review contract, so it cannot merge reviews."
+    # ★ The synthesizer's own seat runs LAST (#29). On a single-lane runner
+    # the next review starts seconds after this one's synthesize call, and a
+    # roster that lists that account first fires its seat straight into the
+    # provider's burst window: measured 2026-08-25, five runs back to back,
+    # the claude SEAT produced zero reviews while claude-as-synthesizer
+    # worked in every one of them. Every other seat's wall time is the
+    # backoff that seat never got. Stable partition, roster order otherwise.
+    local head_specs=() tail_specs=() moved="" sp
+    for sp in "${specs[@]}"; do
+      if [ "$(spec_agent "$sp")" = "$sa" ]; then
+        tail_specs+=("$sp"); moved="${moved:+$moved, }$sp"
+      else
+        head_specs+=("$sp")
+      fi
+    done
+    if [ -n "$moved" ] && [ "${#head_specs[@]}" -gt 0 ]; then
+      specs=("${head_specs[@]}" "${tail_specs[@]}")
+      echo "  seat order: $moved moved last, it shares the synthesizer's account"
+    fi
   fi
 
   # Single-use labels. Reusing one would hand back the previous review of
@@ -1071,11 +1095,36 @@ cmd_review() {
   # that parked the directory here would have this process finish its merge
   # inside the replacement run's directory.
   [ -n "$synth" ] && [ "$synth" != none ] && cmd_synthesize "$out" "$synth" "${specs[@]}"
+  # ★ Panel floor (#29). The report is honest about a shrunken panel, but a
+  # runner posting the synthesis never reads the report; it reads the exit
+  # code. Below the floor the artifacts are all real and all on disk -- this
+  # is not a failed measurement, so it runs AFTER synthesis -- and 10 says
+  # "you got less than you asked for" in a channel a runner can act on.
+  # Off unless CADRE_PANEL_MIN is set: a floor is a property of a roster.
+  # ★ Still under the claim: this writes report.md, and a --force parking the
+  # directory here would land the note in the replacement run.
+  # ★ A malformed floor is refused, not coerced to "off": CADRE_PANEL_MIN=3x
+  # silently posting a two-seat panel as healthy is the exact failure the
+  # floor exists to stop. Found by the codex review of this change.
+  local floor="${CADRE_PANEL_MIN:-0}" usable=0 sl frc=0
+  local requested=$(( ${#specs[@]} + ${#skipped[@]} ))
+  case "$floor" in *[!0-9]*) rm -f "$out/.claim"; die "CADRE_PANEL_MIN must be a whole number, got '$floor'" ;; esac
+  if [ "${floor:-0}" -gt 0 ]; then
+    for sp in "${specs[@]}"; do
+      sl=$(slug "$sp")
+      { [ -s "$out/$sl.md" ] || [ -s "$out/$sl.md.partial" ]; } && usable=$((usable + 1))
+    done
+    if [ "$usable" -lt "$floor" ]; then
+      echo "> ⚠ **Panel below floor**: $usable of $requested requested seat(s) usable; CADRE_PANEL_MIN is $floor. The reviews above are real; there are fewer of them than the roster asked for." >> "$out/report.md"
+      echo "cadre: PANEL BELOW FLOOR: $usable of $requested requested seat(s) usable, floor $floor (CADRE_PANEL_MIN). Everything on disk is intact; the panel is thinner than you asked for. Exit 10." >&2
+      frc=10
+    fi
+  fi
   # Released on every path. Left behind, a finished run reads as a claim with
   # a dead pid -- reclaimable, so not fatal, but it would park a completed
   # review on the next call instead of refusing to re-measure it.
   rm -f "$out/.claim"
-  return 0
+  return "$frc"
 }
 
 # Merge the reviews. A model too, so the same rate-limit rule applies, and a

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -3530,6 +3530,44 @@ check "claim: pid 0 is not a live holder"        "[ '$RC' -eq 0 ] && [ -s '$D/st
 # No sidecar left behind by any path above.
 check "claim: no .taking sidecars remain"        "! ls -d '$D/state/reviews/'*.taking 2>/dev/null | grep -v pr-6 | grep -q ."
 
+echo "== ★ #29: the synthesizer's seat runs last; a thin panel exits 10 =="
+D=$(case_dir seatorder); S="$D/src"
+git -C "$S" checkout -qb feature; echo x >> "$S/app.js"; git -C "$S" commit -qam f
+OUT=$(run_cadre "$D" review --roster good,good2,terse --synth good --base main --label so "$S")
+check "order: synth's seat moved last"      "grep -q 'seat order: good moved last' <<<\"\$OUT\""
+check "order: good2 dispatched before good" "[ \$(grep -n '^  good2: started' <<<\"\$OUT\" | cut -d: -f1) -lt \$(grep -n '^  good: started' <<<\"\$OUT\" | cut -d: -f1) ]"
+check "order: terse dispatched before good" "[ \$(grep -n '^  terse: started' <<<\"\$OUT\" | cut -d: -f1) -lt \$(grep -n '^  good: started' <<<\"\$OUT\" | cut -d: -f1) ]"
+check "order: all three still reviewed"     "grep -q '3 ok, 0 degraded' <<<\"\$OUT\""
+OUT=$(run_cadre "$D" review --roster good,good2 --synth none --base main --label so2 "$S")
+check "order: no synth, roster order kept"  "! grep -q 'seat order' <<<\"\$OUT\" && [ \$(grep -n '^  good: started' <<<\"\$OUT\" | cut -d: -f1) -lt \$(grep -n '^  good2: started' <<<\"\$OUT\" | cut -d: -f1) ]"
+OUT=$(run_cadre "$D" review --roster good --synth good --base main --label so3 "$S")
+check "order: a synth-only roster is not shuffled" "! grep -q 'seat order' <<<\"\$OUT\""
+# The floor: off by default, exit 10 after synthesis when set and unmet.
+OUT=$(run_cadre "$D" review --roster good,dead --synth none --base main --label fl0 "$S"); RC=$?
+check "floor: off by default"               "[ '$RC' -eq 0 ]"
+OUT=$(CADRE_PANEL_MIN=2 run_cadre "$D" review --roster good,good2,dead --synth echoer --base main --label fl1 "$S"); RC=$?
+check "floor: met -> exit 0"                "[ '$RC' -eq 0 ]"
+OUT=$(CADRE_PANEL_MIN=2 run_cadre "$D" review --roster good,dead,chrome --synth none --base main --label fl2 "$S"); RC=$?
+R="$D/state/reviews/fl2"
+check "floor: unmet -> exit 10"             "[ '$RC' -eq 10 ]"
+check "floor: says how thin"                "grep -q 'PANEL BELOW FLOOR: 1 of 3' <<<\"\$OUT\""
+check "floor: the real review survives"     "ls '$R'/good-*.md >/dev/null 2>&1"
+check "floor: report carries the note"      "grep -q 'Panel below floor' '$R/report.md'"
+check "floor: claim released"               "[ ! -e '$R/.claim' ]"
+# Degraded counts as usable: partial findings are still findings.
+OUT=$(CADRE_PANEL_MIN=2 run_cadre "$D" review --roster good,trunc,dead --synth none --base main --label fl3 "$S"); RC=$?
+check "floor: degraded counts as usable"    "[ '$RC' -eq 0 ]"
+# Synthesis still ran on the thin panel: the artifacts are what a runner posts.
+OUT=$(CADRE_PANEL_MIN=3 run_cadre "$D" review --roster good,good2,dead --synth echoer --base main --label fl4 "$S"); RC=$?
+check "floor: synthesis ran before exit 10" "[ '$RC' -eq 10 ] && [ -s '$D/state/reviews/fl4/synthesis.md' ]"
+# ★ A malformed floor is refused, never silently "off".
+OUT=$(CADRE_PANEL_MIN=3x run_cadre "$D" review --roster good,dead --synth none --base main --label fl5 "$S"); RC=$?
+check "floor: malformed value is refused"   "[ '$RC' -eq 2 ] && grep -q 'whole number' <<<\"\$OUT\""
+check "floor: and releases the claim"       "[ ! -e '$D/state/reviews/fl5/.claim' ]"
+# The denominator is the whole roster, gate-skipped seats included.
+OUT=$(CADRE_PANEL_MIN=2 run_cadre "$D" review --roster 'good,dead,good2?min-lines=99999' --synth none --base main --label fl6 "$S"); RC=$?
+check "floor: gated seats count as requested" "[ '$RC' -eq 10 ] && grep -q 'PANEL BELOW FLOOR: 1 of 3' <<<\"\$OUT\""
+
 echo
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #29 (the backoff half landed in #44).

- **Synth seat last.** Seats sharing the synthesizer's adapter move to the end of the roster (stable partition, announced on the console), so on a single-lane runner that account's seat stops firing into the burst window left by the previous run's synthesize call. `run_one` uses its index only for the checkout name, so order is free.
- **`CADRE_PANEL_MIN`.** After synthesis, fewer usable seats (ok or degraded) than the floor → note in `report.md`, stderr line, **exit 10** (unused beside 2–9). Off by default. Whole roster is the denominator (gate-skipped included). A malformed value dies instead of silently disabling the floor. Claim held through the check.
- 20 new smoke checks; suite 872/872. Codex review of the first draft found the malformed-value coercion, the claim-release ordering, and the denominator; all fixed.

Bot side (deployed separately): `review-pr.sh` sets `CADRE_PANEL_MIN=3` and, on exit 10, still posts but leads the comment with a thin-panel warning.