### PR TITLE
Seat: Claude Code's /code-review at each effort level (#42)

### DIFF
--- a/agents.d/claudecr.sh
+++ b/agents.d/claudecr.sh
@@ -1,0 +1,124 @@
+# agentcall adapter: claudecr  (Claude Code's built-in /code-review, per effort level)
+
+notes_claudecr() {
+  cat <<'NOTES'
+Runs Claude Code's own `/code-review <level>` skill headless in the checkout.
+Takes NO prompt: the skill ships its own review strategy, and the level is the
+whole point -- low = one pass over the diff, medium = read changed code in
+context + several finder passes + verify each finding, high = finders and
+verifiers as fresh-context subagents, xhigh = also sweeps for impact outside
+the change. The level rides in the MODEL slot of the spec: claudecr:high.
+No level is refused, not defaulted: a benchmark row that does not say which
+strategy it measured is worse than one that refuses. `ultra` is not offered:
+it is user-triggered, billed, and cloud-only.
+★ Probed 2026-08-29 (claude 2.1.251) on a two-commit detached checkout with
+no branch and no remote, i.e. exactly what run-review.sh builds:
+  - `/code-review low` reviews HEAD against its parent and found the planted
+    double-charge. That IS the change under review, by construction.
+  - passing the base commit as a target (`/code-review low <sha>`) makes it
+    review NOTHING and print "(none)": the skill reads a target as a path or
+    PR, not a base. Never pass one.
+  - the Skill tool being denied does not stop a slash command in -p mode.
+  - with untracked files run-review.sh's checkout is THREE commits and the
+    skill would see only the last; the adapter checks out a squashed
+    two-commit view for the call and restores HEAD after.
+`agentcall --probe claudecr` reports unclear: the generic probe passes no
+level and a level is required. Probe by hand: agentcall claudecr -M low.
+  - text after the slash command is honoured: the format contract below
+    produced bold severity labels and a Verdict: line, which the classifier
+    reads. Without it the output is bare `file:line -- text`, findings=0 and
+    no verdict, filed inconclusive.
+★ High and xhigh dispatch SUBAGENTS by design. That is the same class of
+asymmetry codex.sh records for spawn_agent: a seat that consults other models
+is not a peer of one that cannot. Recorded, not assumed away -- it is what
+you are measuring when you pick this seat.
+Same ro rails as claude.sh: --strict-mcp-config, advisorModel="", and the
+CLAUDE_DENY list, which is why that adapter must stay loaded.
+NOTES
+}
+
+# The binary is `claude`, not `claudecr`: without this, agentcall's installed
+# check looks for a `claudecr` command and every dispatch is NOT INSTALLED.
+bin_claudecr() { printf 'claude'; }
+
+# The skill brings its own brief; the shared prompt is not delivered.
+noprompt_claudecr() { :; }
+
+cannot_claudecr() {
+  # It ignores the prompt, so it cannot merge reviews or grade against a key,
+  # and a security-audit brief never reaches it.
+  echo role:synth
+  echo role:judge
+  echo prompt:security-audit
+}
+
+# ★ The one lever on the shape that arrives (issue #33, same as pi.sh): the
+# classifier reads a bold severity label and a closing Verdict: line, and the
+# skill's native output has neither.
+claudecr_output_contract() {
+  cat <<'CONTRACT'
+Format contract: state each finding under a bold severity label on its own
+line -- **blocking**, **should-fix**, or **nit** -- keep file:line references,
+and end the whole review with a final line starting with `Verdict:` followed
+by one of: blocking, should-fix, no defects found.
+CONTRACT
+}
+
+run_claudecr() {
+  local level="$model" ro=() rc out
+  case "$level" in
+    low|medium|high|xhigh) ;;
+    '')  echo "DID NOT RUN, misconfigured: claudecr needs a level in the model slot (claudecr:low|medium|high|xhigh)"; return 0 ;;
+    *)   echo "DID NOT RUN, misconfigured: claudecr level '$level' is not one of low|medium|high|xhigh"; return 0 ;;
+  esac
+  if [ "$mode" = ro ]; then
+    # ★ Refuse rather than fail open: with CLAUDE_DENY unset the deny list
+    # would be empty and Edit/Write/Agent/Workflow silently back in reach.
+    [ -n "${CLAUDE_DENY:-}" ] || { echo "DID NOT RUN, misconfigured: CLAUDE_DENY is unset; agents.d/claude.sh must be loaded alongside claudecr"; return 0; }
+    # shellcheck disable=SC2206
+    ro=(--strict-mcp-config --settings '{"advisorModel":""}' --disallowedTools $CLAUDE_DENY)
+  fi
+  local arg; arg="/code-review $level"$'\n\n'"$(claudecr_output_contract)"
+  if [ -n "$DRY" ]; then
+    _run timeout -k 30 "$TIMEOUT" claude -p "$arg" "${ro[@]}"
+    return 0
+  fi
+  # ★ The skill reviews HEAD against its parent, and nothing else (probed: a
+  # base passed as a target makes it review nothing). run-review.sh builds
+  # base -> snapshot, but with untracked files it adds a third commit on top,
+  # and HEAD^..HEAD would then be the untracked files alone, silently dropping
+  # every tracked change. So when HEAD's parent is not the base, check out a
+  # squashed view -- HEAD's tree on top of the base -- for the duration of the
+  # call. This checkout is the seat's own disposable copy (run-review.sh gives
+  # every reviewer its own and deletes it after), so moving HEAD costs nothing
+  # and is restored anyway. Found by the codex review of this adapter.
+  local orig="" base="${CADRE_PASS_BASE:-}" parent squash
+  if [ -n "$base" ] && git -C "$dir" rev-parse --verify -q "$base^{commit}" >/dev/null 2>&1; then
+    parent=$(git -C "$dir" rev-parse -q --verify HEAD^ 2>/dev/null || true)
+    if [ "$parent" != "$(git -C "$dir" rev-parse "$base")" ]; then
+      orig=$(git -C "$dir" rev-parse HEAD)
+      squash=$(git -C "$dir" -c user.name=cadre -c user.email=cadre@localhost -c commit.gpgsign=false                  commit-tree "HEAD^{tree}" -p "$base" -m "cadre: change under review (squashed for /code-review)")         && git -C "$dir" checkout -q --detach "$squash" 2>/dev/null         || { echo "DID NOT RUN, could not build the two-commit view /code-review needs in $dir"; return 1; }
+    fi
+  fi
+  # < /dev/null: with nothing on stdin the CLI waits 3s and prints a warning
+  # that would become line 1 of every review.
+  out=$( cd "$dir" && timeout -k 30 "$TIMEOUT" claude -p "$arg" "${ro[@]}" < /dev/null 2>&1 ); rc=$?
+  [ -n "$orig" ] && git -C "$dir" checkout -q --detach "$orig" 2>/dev/null
+  if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+    # Whatever arrived before the kill is a review, cut short: the partial
+    # contract, same as codex.sh and grok.sh. Nonzero as well as the marker.
+    if [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+      printf '%s\n\n' "$out"
+      echo "_TRUNCATED, claudecr:$level was killed at the ${TIMEOUT}s timeout; this review is INCOMPLETE, not a clean pass. Raise CADRE_TIMEOUT; high and xhigh run subagents and take longer._"
+    else
+      echo "DID NOT COMPLETE, claudecr:$level was killed at the ${TIMEOUT}s timeout with no output. Raise CADRE_TIMEOUT; high and xhigh run subagents and take longer."
+    fi
+    return 1
+  fi
+  if [ -z "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+    echo "DID NOT COMPLETE, claudecr:$level printed no review (exit $rc)."
+    return 1
+  fi
+  printf '%s\n' "$out"
+  return "$rc"
+}

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -94,6 +94,9 @@ the last argv word.
 ```
 claude       claude -p --strict-mcp-config --settings '{"advisorModel":""}' \
                   --disallowedTools $CLAUDE_DENY                          [prompt on stdin]
+claudecr     claude -p "/code-review <level>" --strict-mcp-config \
+                  --settings '{"advisorModel":""}' --disallowedTools $CLAUDE_DENY
+                  (level = the model slot: claudecr:low|medium|high|xhigh)  [takes no prompt]
 coderabbit   coderabbit review --committed --base $CADRE_PASS_BASE --agent     [takes no prompt]
 codex        codex exec -s read-only --ignore-user-config \
                   --skip-git-repo-check -C . -o OUTFILE -                  [prompt on stdin]

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -1727,6 +1727,74 @@ contract=$( . "$ROOT/agents.d/pi.sh" >/dev/null 2>&1; pi_output_contract )
 check "pi adapter appends output contract (issue #33)" \
   "grep -q 'Verdict:' <<<\"\$contract\" && grep -qF -- '**blocking**' <<<\"\$contract\""
 
+echo "== ★ claudecr: /code-review per level as a seat (#42) =="
+# Stub `claude` on PATH; the adapter's own contract logic is what is under test.
+CD=$(case_dir claudecr); cp "$ROOT/agents.d/claudecr.sh" "$ROOT/agents.d/claude.sh" "$CD/agents.d/"
+printf '#!/bin/sh\nprintf "%%s\\n" "$@" > "%s/claude.argv"\necho "**blocking**"\necho "src/x.js:3 -- missing await"\necho "Verdict: blocking"\n' "$CD" > "$CD/bin/claude"; chmod +x "$CD/bin/claude"
+OUT=$(CADRE_AGENTS_D="$CD/agents.d" PATH="$CD/bin:$PATH" "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: review passes through"          "grep -q 'missing await' <<<\"\$OUT\" && [ $RC -eq 0 ]"
+check "claudecr: argv leads with the slash command" "head -2 '$CD/claude.argv' | grep -q '^/code-review low'"
+check "claudecr: and appends the format contract"  "grep -q 'Verdict:' '$CD/claude.argv' && grep -qF -- '**blocking**' '$CD/claude.argv'"
+check "claudecr: ro carries the claude deny list"  "grep -q -- '--disallowedTools' '$CD/claude.argv' && grep -qw 'Workflow' '$CD/claude.argv'"
+# ★ Never a base target: probed, it makes the skill review nothing.
+check "claudecr: no base commit in the argv"       "! grep -qE '^[0-9a-f]{40}$' '$CD/claude.argv'"
+# A level is required, and a bad one is refused -- both as misconfiguration,
+# the operator's fault, never a verdict on the model.
+OUT=$(CADRE_AGENTS_D="$CD/agents.d" PATH="$CD/bin:$PATH" "$ROOT/bin/agentcall" claudecr -d /tmp -m ro 2>&1 </dev/null)
+check "claudecr: no level -> DID NOT RUN, misconfigured" "grep -q '^DID NOT RUN, misconfigured: claudecr needs a level' <<<\"\$OUT\""
+OUT=$(CADRE_AGENTS_D="$CD/agents.d" PATH="$CD/bin:$PATH" "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M ultra 2>&1 </dev/null)
+check "claudecr: ultra is refused"                 "grep -q \"^DID NOT RUN, misconfigured: claudecr level 'ultra'\" <<<\"\$OUT\""
+printf 'DID NOT RUN, misconfigured: claudecr level x\n' > "$CD/lvl.txt"
+check "claudecr: and files as misconfigured"       "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(failure_kind '$CD/lvl.txt' 0) = misconfigured ]\""
+# Silence is not a clean pass.
+printf '#!/bin/sh\nexit 0\n' > "$CD/bin/claude"; chmod +x "$CD/bin/claude"
+OUT=$(CADRE_AGENTS_D="$CD/agents.d" PATH="$CD/bin:$PATH" "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M medium 2>&1 </dev/null); RC=$?
+check "claudecr: silent run is DID NOT COMPLETE"   "grep -q '^DID NOT COMPLETE, claudecr:medium printed no review' <<<\"\$OUT\" && [ $RC -ne 0 ]"
+# Nonzero WITH text keeps both: the text is a review, the status is the CLI's.
+printf '#!/bin/sh\necho "**should-fix**"\necho "x.js:1 -- thing"\necho "Verdict: should-fix"\nexit 3\n' > "$CD/bin/claude"
+OUT=$(CADRE_AGENTS_D="$CD/agents.d" PATH="$CD/bin:$PATH" "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: nonzero with text keeps both"     "grep -q 'x.js:1' <<<\"\$OUT\" && [ $RC -eq 3 ]"
+# A clock kill with text on the way is a partial review, not nothing.
+printf '#!/bin/sh\necho "**blocking**"\necho "x.js:1 -- partial"\nexit 124\n' > "$CD/bin/claude"
+OUT=$(CADRE_AGENTS_D="$CD/agents.d" PATH="$CD/bin:$PATH" "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: timeout with text -> _TRUNCATED"  "grep -q 'x.js:1 -- partial' <<<\"\$OUT\" && tail -1 <<<\"\$OUT\" | grep -q '^_TRUNCATED' && [ $RC -ne 0 ]"
+printf '#!/bin/sh\nexit 124\n' > "$CD/bin/claude"
+OUT=$(CADRE_AGENTS_D="$CD/agents.d" PATH="$CD/bin:$PATH" "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: timeout with nothing -> DID NOT COMPLETE" "grep -q '^DID NOT COMPLETE.*timeout with no output' <<<\"\$OUT\" && [ $RC -ne 0 ]"
+# ★ ro must not fail open when claude.sh is not loaded. agentcall always
+# sources the shipped agents.d first, so the only way to test the guard is to
+# source the adapter alone and call run_claudecr with the locals it expects.
+printf '#!/bin/sh\necho "should not run"\n' > "$CD/bin/claude"; chmod +x "$CD/bin/claude"
+OUT=$(PATH="$CD/bin:$PATH" bash -c 'unset CLAUDE_DENY; . "$1"; dir=/tmp mode=ro model=low prompt="" TIMEOUT=5 DRY=""; run_claudecr' _ "$ROOT/agents.d/claudecr.sh" 2>&1 </dev/null)
+check "claudecr: ro without CLAUDE_DENY refuses"   "grep -q 'misconfigured: CLAUDE_DENY is unset' <<<\"\$OUT\" && ! grep -q 'should not run' <<<\"\$OUT\""
+# Dry run shows the real argv, contract included.
+OUT=$(echo hi | CADRE_AGENTS_D="$CD/agents.d" "$ROOT/bin/agentcall" --print-command claudecr -d /tmp -m ro -M xhigh 2>&1)
+check "claudecr: dry run carries the contract"     "grep -q 'code-review' <<<\"\$OUT\" && grep -q 'Verdict' <<<\"\$OUT\""
+# ★ The three-commit checkout: the skill must see base..HEAD, not the last
+# commit alone. The stub records what HEAD^ was when claude ran.
+TR=$(mktemp -d -p "$SANDBOX"); git -C "$TR" init -q; git -C "$TR" -c user.name=c -c user.email=c@x commit -q --allow-empty -m base
+TB=$(git -C "$TR" rev-parse HEAD); echo a > "$TR/a"; git -C "$TR" add a; git -C "$TR" -c user.name=c -c user.email=c@x commit -qm tracked
+echo u > "$TR/u"; git -C "$TR" add u; git -C "$TR" -c user.name=c -c user.email=c@x commit -qm untracked; TH=$(git -C "$TR" rev-parse HEAD)
+printf '#!/bin/sh\ngit rev-parse HEAD^ > "%s/parent.txt"; git diff --name-only HEAD^ HEAD > "%s/files.txt"\necho "**nit**"\necho "a:1 -- x"\necho "Verdict: no defects found"\n' "$CD" "$CD" > "$CD/bin/claude"
+OUT=$(CADRE_AGENTS_D="$CD/agents.d" PATH="$CD/bin:$PATH" CADRE_PASS_BASE="$TB" "$ROOT/bin/agentcall" claudecr -d "$TR" -m ro -M low 2>&1 </dev/null)
+check "claudecr: squashed view has the base as parent" "[ \"\$(cat '$CD/parent.txt')\" = '$TB' ]"
+check "claudecr: and the diff carries BOTH commits"    "grep -qx a '$CD/files.txt' && grep -qx u '$CD/files.txt'"
+check "claudecr: and HEAD is restored after"           "[ \"\$(git -C '$TR' rev-parse HEAD)\" = '$TH' ]"
+# Declarations: it cannot merge, grade, or take a security brief.
+DECL=$( . "$ROOT/agents.d/claudecr.sh" >/dev/null 2>&1; cannot_claudecr )
+check "claudecr: declares role:synth + role:judge" "grep -q '^role:synth$' <<<\"\$DECL\" && grep -q '^role:judge$' <<<\"\$DECL\" && grep -q '^prompt:security-audit$' <<<\"\$DECL\""
+check "claudecr: is promptless"                    "bash -c \"source '$ROOT/lib/common.sh'; CADRE_AGENTS_D='$ROOT/agents.d' is_promptless claudecr\""
+check "claudecr: documented in CLI-REFERENCE"      "grep -q 'claudecr' '$ROOT/docs/CLI-REFERENCE.md'"
+# ★ Installed means `claude` is on PATH, not `claudecr`. Without bin_claudecr
+# the real end-to-end run dispatched the seat as NOT INSTALLED.
+printf '#!/bin/sh\nexit 0\n' > "$CD/bin/claude"; chmod +x "$CD/bin/claude"
+# ★ grep -x, not -qx: under this suite's pipefail a -q that exits on the first
+# match leaves agentcall writing into a closed pipe, and the pipeline reports
+# SIGPIPE (141) for a check that actually matched.
+check "claudecr: installed when claude is"         "CADRE_AGENTS_D='$CD/agents.d' PATH='$CD/bin:$PATH' '$ROOT/bin/agentcall' --installed 2>/dev/null | grep -x claudecr >/dev/null"
+NOCL=$(mktemp -d -p "$SANDBOX"); mkdir -p "$NOCL/bin"
+check "claudecr: not installed without claude"     "! env -i PATH='$NOCL/bin:/usr/bin:/bin' HOME='$HOME' CADRE_AGENTS_D='$CD/agents.d' '$ROOT/bin/agentcall' --installed 2>/dev/null | grep -x claudecr >/dev/null"
+
 echo "== ★ the run dataset =="
 # ★ The record has to be written BEFORE the scratch files it is built from are
 # deleted. It was not, for fourteen panels: status and timing lived only in


### PR DESCRIPTION
Closes #42.

`agents.d/claudecr.sh`: runs Claude Code's built-in `/code-review <level>` headless in the reviewer's checkout. Level in the model slot (`claudecr:low|medium|high|xhigh`), required; `ultra` refused (user-triggered, billed, cloud-only). Promptless; declares `role:synth`, `role:judge`, `prompt:security-audit`.

**Probed (claude 2.1.251) on the exact checkout shape `run-review.sh` builds:**
- bare `/code-review low` reviews HEAD vs parent and found the planted double-charge
- a base commit as a target makes it review nothing ("(none)") — never passed
- Skill tool denied does not stop a slash command in `-p` mode
- text after the command is honoured → the pi-style format contract is appended, so `classify_run` sees severities and a verdict

**Codex review of the first draft found four real defects, all fixed + tested:** the three-commit checkout (untracked files) where the skill would see only the last commit → squashed two-commit view for the call, HEAD restored; partial output discarded on a clock kill → `_TRUNCATED`; `CLAUDE_DENY` unset would fail open → refuses; dry run omitted the contract.

Two real end-to-end `cadre review` runs (plain, and mixed tracked+untracked) filed `ok` with the bug found. Suite 894/894.

Known: `agentcall --probe claudecr` reports unclear (the generic probe passes no level); probe by hand with `-M low`. High/xhigh dispatch subagents by design — recorded in the notes as the same assisted-seat asymmetry codex.sh records.