### PR TITLE
A spent model tier is a clock, not a failed measurement (#48)

### DIFF
--- a/agents.d/claudecr.sh
+++ b/agents.d/claudecr.sh
@@ -34,6 +34,12 @@ is not a peer of one that cannot. Recorded, not assumed away -- it is what
 you are measuring when you pick this seat.
 Same ro rails as claude.sh: --strict-mcp-config, advisorModel="", and the
 CLAUDE_DENY list, which is why that adapter must stay loaded.
+★ The seat inherits the CLI's DEFAULT model, so the per-model weekly tier it
+spends is whatever ~/.claude/settings.json points at -- and that can change
+between passes of one sweep, silently. Pinning the model for a benchmark run
+is the caller's job today. When that tier runs out the CLI says "You've
+reached your <Model> limit. Switch to another model to continue.", which
+cadre reads as a usage window and not as a measurement (#48).
 NOTES
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -820,10 +820,23 @@ provider_window_closed() {
   # So the REMEDY stands in for the reset as the discriminator. "Switch to
   # another model" is a sentence only a PER-MODEL window can say: a spend cap
   # names a payment page ("raise it at", "recharge your account") precisely
-  # because no other model on the account would help. Both halves are required,
-  # so a review that merely discusses model limits does not trip it.
+  # because no other model on the account would help.
+  #
+  # ★ The remedy has to be ISSUED, not mentioned -- start of a line or start of
+  # a sentence. Both halves alone were not enough, measured against this repo's
+  # own prose while writing the fix:
+  #
+  #   blocking: the retry path reached your rate limit ceiling and should
+  #   switch to another model provider
+  #   The docs say you have reached your quota limit; the fix is to switch to
+  #   another model.
+  #
+  # Both matched, and the second one has no findings and no verdict, so it
+  # would have reached classify_run's guards and STOPPED A SWEEP over a review.
+  # A refusal instructs; prose refers. The real string ends the previous
+  # sentence first: "... limit. Switch to another model to continue."
   if grep -qiE 'reached your [a-z0-9. ]{0,20}limit' "$f" \
-     && grep -qi 'switch to another model' "$f"; then return 0; fi
+     && grep -qiE '(^|[.!?][[:space:]]+)switch to another model' "$f"; then return 0; fi
   grep -qiE '(session|weekly|daily|hourly|usage|[0-9]+[ -]?hour) limit|quota reached' "$f" || return 1
   grep -qiE 'reset' "$f"
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -835,8 +835,23 @@ provider_window_closed() {
   # would have reached classify_run's guards and STOPPED A SWEEP over a review.
   # A refusal instructs; prose refers. The real string ends the previous
   # sentence first: "... limit. Switch to another model to continue."
+  #
+  # ★★ AND IT YIELDS TO THE OTHER TWO, which is the opposite of the rule the
+  # stated-reset branch below follows. That branch deliberately claims
+  # "You've hit your usage limit - resets 3pm" out of quota_exhausted's hands,
+  # because a stated reset PROVES waiting clears it. A remedy proves nothing of
+  # the kind, and a multi-model router can phrase either of the others this way:
+  #
+  #   You've reached your rate limit. Switch to another model to continue.
+  #   You've reached your monthly spend limit. Switch to another model to continue.
+  #
+  # Window is asked FIRST in both dispatch paths, so without this a throughput
+  # ceiling loses its retries and -- far worse -- a spend cap is reported as a
+  # clock that will clear itself, and the operator waits out a window that money
+  # is the only thing that opens. Found by the codex review of this change.
   if grep -qiE 'reached your [a-z0-9. ]{0,20}limit' "$f" \
-     && grep -qiE '(^|[.!?][[:space:]]+)switch to another model' "$f"; then return 0; fi
+     && grep -qiE '(^|[.!?][[:space:]]+)switch to another model' "$f" \
+     && ! rate_limited "$f" && ! quota_exhausted "$f"; then return 0; fi
   grep -qiE '(session|weekly|daily|hourly|usage|[0-9]+[ -]?hour) limit|quota reached' "$f" || return 1
   grep -qiE 'reset' "$f"
 }
@@ -1225,11 +1240,19 @@ classify_run() {
     # exits 0, so it landed in `inconclusive` and run-pass aborted the sweep as a
     # failed measurement -- with the regex fixed and this line missing, it still
     # would.
-    # ★ Same findings=0 guard as its two neighbours, plus explicit_verdict for
-    # the reason the rate scan grew one: a short clean review that quotes a
-    # session limit and then signs off is a review, and this is the check that
-    # would otherwise STOP a whole sweep over it.
-    if provider_window_closed "$f" && [ "$(review_findings "$f")" -eq 0 ] && ! explicit_verdict "$f"; then echo failed; return 0; fi
+    # ★ Same findings=0 guard as its two neighbours -- but has_verdict, the
+    # BROAD one, where the rate scan above uses the narrow explicit_verdict. The
+    # blast radius is what moves the line. A wrong `failed` on the rate path
+    # costs one run; a wrong `failed` here stops the ENTIRE SWEEP at exit 6 and
+    # sends the operator off to wait out a window that never closed, and the
+    # re-run does it again. So this one protects a real review as hard as it can
+    # and accepts the pre-existing exit 4 as the cost of a miss.
+    # ★ Safe in the other direction, checked against every refusal in the
+    # corpus one by one: not one of them states a bottom line at all. The
+    # shapes explicit_verdict exists to exclude -- "Request not approved: 429",
+    # "Recommendation: retry after 60s" -- are RATE refusals, and a rate refusal
+    # never reaches this line.
+    if provider_window_closed "$f" && [ "$(review_findings "$f")" -eq 0 ] && ! has_verdict "$f"; then echo failed; return 0; fi
   elif provider_refused "$f" "$rc"; then
     echo failed; return 0
   fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -803,6 +803,27 @@ provider_window_closed() {
   # The upgrade pitch is a red herring: it states a reset, so waiting clears it.
   # Safe against kiro's "rate limit reached: Request quota exceeded" -- that is
   # `quota exceeded`, stays on the retry path where a throughput ceiling belongs.
+  # ★ A MODEL-TIER window is the one shape that states NO reset, so it gets
+  # its own two-half test rather than another alternative in the pattern below,
+  # which the `reset` requirement would refuse anyway. Measured 2026-08-30
+  # benchmarking the claudecr seat (#48), verbatim:
+  #
+  #   You've reached your Fable 5 limit. Switch to another model to continue.
+  #
+  # It matched nothing at all -- no 429, no period word, no stated reset -- so
+  # it fell through to `inconclusive` and one spent model tier was reported as a
+  # failed measurement of the candidate. The account was healthy: the five-hour
+  # bucket sat at 5% and the all-model weekly at 59%, and only the one tier was
+  # at 100%. Its reset is real and knowable, it just lives in the usage endpoint
+  # and not in the message.
+  #
+  # So the REMEDY stands in for the reset as the discriminator. "Switch to
+  # another model" is a sentence only a PER-MODEL window can say: a spend cap
+  # names a payment page ("raise it at", "recharge your account") precisely
+  # because no other model on the account would help. Both halves are required,
+  # so a review that merely discusses model limits does not trip it.
+  if grep -qiE 'reached your [a-z0-9. ]{0,20}limit' "$f" \
+     && grep -qi 'switch to another model' "$f"; then return 0; fi
   grep -qiE '(session|weekly|daily|hourly|usage|[0-9]+[ -]?hour) limit|quota reached' "$f" || return 1
   grep -qiE 'reset' "$f"
 }
@@ -1182,6 +1203,20 @@ classify_run() {
     # bottom line. `failed`, not `inconclusive`: the report must send the
     # operator to the box, not to the roster.
     if env_blocked "$f" && [ "$(review_findings "$f")" -eq 0 ]; then echo failed; return 0; fi
+    # ★ #48. A window refusal that exits ZERO never reached the refusal chain at
+    # all. Both dispatch paths ask provider_window_closed() only about a run this
+    # function already called `failed`, and every window in the corpus until now
+    # arrived with a nonzero exit, so the rc test below did that binning for
+    # free. The model-tier limit does not: "You've reached your <Model> limit.
+    # Switch to another model to continue." states no findings and no verdict and
+    # exits 0, so it landed in `inconclusive` and run-pass aborted the sweep as a
+    # failed measurement -- with the regex fixed and this line missing, it still
+    # would.
+    # ★ Same findings=0 guard as its two neighbours, plus explicit_verdict for
+    # the reason the rate scan grew one: a short clean review that quotes a
+    # session limit and then signs off is a review, and this is the check that
+    # would otherwise STOP a whole sweep over it.
+    if provider_window_closed "$f" && [ "$(review_findings "$f")" -eq 0 ] && ! explicit_verdict "$f"; then echo failed; return 0; fi
   elif provider_refused "$f" "$rc"; then
     echo failed; return 0
   fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1252,6 +1252,12 @@ classify_run() {
     # shapes explicit_verdict exists to exclude -- "Request not approved: 429",
     # "Recommendation: retry after 60s" -- are RATE refusals, and a rate refusal
     # never reaches this line.
+    # ★ And that makes the guards here IDENTICAL to the inconclusive test at the
+    # bottom of this function -- findings=0 and no broad bottom line, the same
+    # two predicates. So this branch can only ever move a run from
+    # `inconclusive` to `failed`. It cannot reach a run that would have been
+    # `ok`, which is the only direction that destroys a real review. Keep the
+    # two in step if either one moves.
     if provider_window_closed "$f" && [ "$(review_findings "$f")" -eq 0 ] && ! has_verdict "$f"; then echo failed; return 0; fi
   elif provider_refused "$f" "$rc"; then
     echo failed; return 0

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -540,7 +540,7 @@ remove that directory and re-run."
         # go looking for a defect. Kept out of $measurement_failed for exactly
         # that reason -- see provider_window_closed() in lib/common.sh.
         if [ "$prc" -eq 6 ]; then
-          skipped="$skipped- $label: NOT MEASURED, the provider's usage window closed (resume after its reset)"$'\n'
+          skipped="$skipped- $label: NOT MEASURED, the provider's usage window closed (resume once it reopens)"$'\n'
           window_closed=1
         # ★ 7 gets the same treatment as 6 and for the same reason: the pass
         # measured nothing, but the cause is on the provider's side and clears
@@ -1047,7 +1047,10 @@ file, and do not record a verdict about the candidate from it."
         body1="A provider usage window closed mid-sweep, so this pass never got to run.
 That is a clock, not a defect: nothing is wrong with the tool, the key or the
 candidate, and every review already on disk is intact and still counted."
-        tail1="Resume after the reset time above. There is nothing here to fix, and no
+        # ★ Not "resume after the reset time above" (#48): a model-tier window
+        # names a remedy instead of a time, so that sentence pointed at a line
+        # that was never printed. run-pass quotes whatever the provider said.
+        tail1="Resume when that window reopens. There is nothing here to fix, and no
 number to quote."
       fi
       {
@@ -1120,7 +1123,7 @@ ambiguous. Tighten the key and re-grade. Do not pick a judge."
     # unchanged either way -- a short denominator still cannot recommend a seat.
     local fixit="Restore the missing keys or checkouts and re-run before slotting anything."
     [ -n "$window_closed" ] &&
-      fixit="A provider usage window closed mid-sweep, so the missing passes are a clock and not a defect: wait for the reset named above, then re-run to resume. Every review already on disk is reused."
+      fixit="A provider usage window closed mid-sweep, so the missing passes are a clock and not a defect: wait for that window to reopen, then re-run to resume. Every review already on disk is reused."
     case "$slot" in
       SEAT:*|INCONCLUSIVE)
         reason="$nskipped registered pass(es) never ran, so $blocking_hit/$blocking_total is a partial denominator and not the benchmark you registered. $fixit On the passes that did run: $reason"
@@ -1327,7 +1330,7 @@ ambiguous. Tighten the key and re-grade. Do not pick a judge."
   # disk are reused, which is what made resuming the 2026-07-28 sweep cost four
   # reviews instead of thirty.
   if [ -n "$window_closed" ]; then
-    echo "cadre: a provider usage window closed, so the sweep is INCOMPLETE. Exit 6: wait for the reset, then re-run to resume." >&2
+    echo "cadre: a provider usage window closed, so the sweep is INCOMPLETE. Exit 6: wait for the window to reopen, then re-run to resume." >&2
     return 6
   fi
 }

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -88,7 +88,7 @@ mapfile -t SCRUB < <(scrubbed_env)
 # everything, and the driver above it wrote COMPLETED across a sweep where 27 of
 # 30 requested reviews did not exist. Silence and success must not share an exit
 # code.
-ok_runs=0; bad_runs=0; dead_agents=""; windows=""; no_output_runs=0; misconfigured_runs=0
+ok_runs=0; bad_runs=0; dead_agents=""; windows=""; windows_reset=""; no_output_runs=0; misconfigured_runs=0
 
 for r in "${reviewers[@]}"; do
   agent=$(spec_agent "$r"); model=$(spec_model "$r")
@@ -237,6 +237,11 @@ for r in "${reviewers[@]}"; do
     if [ -n "$window" ]; then
       bad_runs=$((bad_runs + (runs - n)))
       windows="$windows  $r: usage window closed after run$n -- $(head -c 200 "$f.failed" 2>/dev/null | tr '\n' ' ')"$'\n'
+      # ★ Asked of the REFUSAL, not of the line above it (#48). That line
+      # carries the agent name and a 200-byte excerpt, so an agent called
+      # `resetter` would supply the word and a reset past the excerpt would be
+      # missed -- both of them wrong about the only thing this flag decides.
+      grep -qi 'reset' "$f.failed" 2>/dev/null && windows_reset=1
       echo "    ⏸ $r's usage window is CLOSED, not a rate limit and not a budget."
       echo "cadre: $r hit a provider usage window on pass $label. Waiting clears it; the refusal is quoted above." >&2
       break
@@ -304,7 +309,7 @@ if [ "$ok_runs" -eq 0 ] && [ "$bad_runs" -gt 0 ]; then
       # REMEDY instead, and the reset only exists in the provider's usage API.
       # Printing "resume after the reset time quoted above" over text that
       # quotes no time sends the operator hunting for a line nobody wrote.
-      if printf '%s' "$windows" | grep -qi 'reset'; then
+      if [ -n "$windows_reset" ]; then
         echo "Resume after the reset time quoted above."
       else
         echo "This refusal does not state its reset; check the provider's usage"

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -238,7 +238,7 @@ for r in "${reviewers[@]}"; do
       bad_runs=$((bad_runs + (runs - n)))
       windows="$windows  $r: usage window closed after run$n -- $(head -c 200 "$f.failed" 2>/dev/null | tr '\n' ' ')"$'\n'
       echo "    ⏸ $r's usage window is CLOSED, not a rate limit and not a budget."
-      echo "cadre: $r hit a provider usage window on pass $label. Waiting clears it; see the reset time above." >&2
+      echo "cadre: $r hit a provider usage window on pass $label. Waiting clears it; the refusal is quoted above." >&2
       break
     fi
 
@@ -299,7 +299,17 @@ if [ "$ok_runs" -eq 0 ] && [ "$bad_runs" -gt 0 ]; then
       echo "cadre: pass '$label' measured NOTHING because a provider usage window closed."
       printf '%s' "$windows"
       echo "Nothing is wrong with the tool, the key, or the candidate, and nothing"
-      echo "already on disk was lost. Resume after the reset time quoted above."
+      echo "already on disk was lost."
+      # ★ Not every window states its reset (#48): a model-tier limit names a
+      # REMEDY instead, and the reset only exists in the provider's usage API.
+      # Printing "resume after the reset time quoted above" over text that
+      # quotes no time sends the operator hunting for a line nobody wrote.
+      if printf '%s' "$windows" | grep -qi 'reset'; then
+        echo "Resume after the reset time quoted above."
+      else
+        echo "This refusal does not state its reset; check the provider's usage"
+        echo "page for when the window reopens, then resume."
+      fi
     } >&2
     exit 6
   fi

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -23,7 +23,7 @@ setup_agents() {
   local n
   for n in good good2 trunc dead echoer chrome terse ratepart ratelim \
            synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2 \
-           blocked permquote ratereview budget window; do
+           blocked permquote ratereview budget window tier; do
     printf '#!/bin/sh\nexit 0\n' > "$1/bin/$n"; chmod +x "$1/bin/$n"
   done
   # ★ The trailing verdict is not decoration. review-live.md asks every reviewer
@@ -158,6 +158,14 @@ A
 # Nonzero like the real claude CLI: with exit 0 this text is `inconclusive`
 # (no rate keyword, no findings, no verdict) and never reaches the retry loop.
 run_window() { printf "You've hit your session limit · resets 5am (UTC)\n"; return 1; }
+A
+  # ★ #48. A model-tier window, and the reason it needs its own stub is the
+  # RETURN CODE: every other window in the corpus exits nonzero, so classify_run
+  # binned it `failed` on the rc test and the refusal chain got asked. This one
+  # exits 0 -- observed on the claudecr seat -- so with only the regex fixed it
+  # still lands `inconclusive` and still aborts the sweep.
+  cat > "$1/agents.d/tier.sh" <<'A'
+run_tier() { printf "You've reached your Fable 5 limit. Switch to another model to continue.\n"; }
 A
   # Unquoted heredoc on purpose: the call counter's path is baked in, because
   # the adapter runs under a scrubbed environment and cannot be told it.
@@ -1607,7 +1615,7 @@ printf 'Error: rate limit exceeded.\nRecommendation: retry after 60 seconds.\n' 
 check "unit: 'Recommendation: retry' is still failed" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(classify_run '$D/recommend.txt' 0) = failed ]\""
 # ★ Budget and window refusals: filed failed, NOT retried. The retries were
 # 8.7 hours of a single-lane queue on the live runner.
-OUT=$(CADRE_RETRIES=3 CADRE_RETRY_WAIT=1 run_cadre "$D" review --roster budget,window,good --synth none \
+OUT=$(CADRE_RETRIES=3 CADRE_RETRY_WAIT=1 run_cadre "$D" review --roster budget,window,tier,good --synth none \
       --base main --label budget "$S")
 R="$D/state/reviews/budget"
 check "budget refusal is failed"             "ls '$R'/budget-*.md.failed >/dev/null 2>&1"
@@ -1617,6 +1625,13 @@ check "budget banner leads the artifact"     "head -1 '$R'/budget-*.md.failed | 
 check "window refusal is failed"             "ls '$R'/window-*.md.failed >/dev/null 2>&1"
 check "window refusal is named"              "grep -q 'usage window CLOSED' <<<\"\$OUT\""
 check "window banner leads the artifact"     "head -1 '$R'/window-*.md.failed | grep -q 'usage window closed, not retried'"
+# ★ #48, the same treatment for a window that exits ZERO. Before the fix this
+# one was `inconclusive`: it never reached the refusal chain, so it was neither
+# named nor kept out of the retry loop.
+check "tier limit is failed"                 "ls '$R'/tier-*.md.failed >/dev/null 2>&1"
+check "tier limit is not retried"            "[ \$(grep -c 'rate limited, waiting' <<<\"\$OUT\") -eq 0 ]"
+check "tier banner leads the artifact"       "head -1 '$R'/tier-*.md.failed | grep -q 'usage window closed, not retried'"
+check "tier refusal text is kept"            "grep -q 'Switch to another model' '$R'/tier-*.md.failed"
 check "the rest of the panel still ran"      "ls '$R'/good-*.md >/dev/null 2>&1"
 check "unit: a refusal with no verdict is still failed" "bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(classify_run '$R'/../ratelim/ratelim-*.md.failed 0) = failed ]\""
 
@@ -2687,6 +2702,45 @@ head -c 2100 /dev/zero | tr '\0' 'x' > "$QB"
 printf "hit your session limit, resets at midnight\n" >> "$QB"
 check "window: too big to be a refusal" "! $WC"
 
+# ★★ A MODEL-TIER window (#48), verbatim from benchmarking the claudecr seat.
+# It is the first window in the corpus that states NO reset -- the reset is real
+# and sits in the provider's usage API, the message names a REMEDY instead -- so
+# the stated-reset test every case above turns on refuses it. It matched none of
+# the three classifiers, so a spent tier was filed as a failed measurement of the
+# candidate: it cost the last pass of `high` and all 12 of `xhigh`.
+printf "You've reached your Fable 5 limit. Switch to another model to continue.\n" > "$QB"
+check "window: model tier caught"        "$WC"
+check "window: tier is NOT a budget"     "! $QE"
+check "window: tier is NOT a rate limit" "! $RL"
+# ★ BOTH halves are required, and each alone is a shape that must not trip it.
+# A spend cap names a payment page and never another model, which is why the
+# remedy can stand in for the reset at all.
+printf "You've reached your monthly spend limit. Raise it at claude.ai/settings/usage\n" > "$QB"
+check "window: tier half alone is not"   "! $WC"
+check "window: that one stays a budget"  "$QE"
+printf 'The retry advice says to switch to another model, which is wrong here.\n' > "$QB"
+check "window: remedy half alone is not" "! $WC"
+
+# ★★ THE HALF THE REGEX DOES NOT FIX. Both dispatch paths ask
+# provider_window_closed() only about a run classify_run already called `failed`,
+# and every window above arrives with a NONZERO exit, so the rc test did that
+# binning for free. The tier limit exits 0 -- no findings, no verdict, no rate
+# keyword -- so it landed `inconclusive`, the refusal chain was never consulted,
+# and the sweep aborted with exit 4. Pinned at rc 0 on purpose.
+CJ="bash -c \"source '$ROOT/lib/common.sh'; [ \\\$(classify_run '$QB' 0) = failed ]\""
+printf "You've reached your Fable 5 limit. Switch to another model to continue.\n" > "$QB"
+check "window: tier at rc 0 is failed"   "$CJ"
+printf "You've hit your session limit · resets 7:10pm (America/New_York)\n" > "$QB"
+check "window: a stated reset too"       "$CJ"
+# ★ ...and a real review is not caught by it. Same shape as the 2026-08-29
+# measurement that put explicit_verdict on the rate scan: a short clean review
+# that quotes a usage window and signs off. This check is the one that would
+# otherwise STOP a whole sweep over a review.
+{ printf 'The banner text says "You have hit your session limit, resets 7:10pm"\n'
+  printf 'and nothing else in this diff changed. No new defects.\n\n'
+  printf 'Verdict: ship it\n'; } > "$QB"
+check "window: a review quoting one is not" "! $CJ"
+
 # A candidate that is out of budget: refuses, and counts how often it was asked.
 budget_case() {  # budget_case <dir>
   local d="$1" sha
@@ -2750,12 +2804,38 @@ check "window: p2 marked NOT ATTEMPTED" "grep -q 'p2: NOT ATTEMPTED' <<<\"\$OUT\
 check "window: verdict names the window" "grep -q 'Verdict: NOT MEASURED -- PROVIDER WINDOW CLOSED' <<<\"\$OUT\""
 check "window: NOT 'NOTHING MEASURED'"   "! grep -q 'Verdict: NOTHING MEASURED' <<<\"\$OUT\""
 check "window: does not say fix it"      "! grep -q 'Fix the cause and re-run' <<<\"\$OUT\""
-check "window: says resume after reset"  "grep -q 'Resume after the reset time above' <<<\"\$OUT\""
+check "window: says resume when it reopens" "grep -q 'Resume when that window reopens' <<<\"\$OUT\""
 # The reset time is the one fact a driver needs to schedule its own resumption,
 # so it is quoted verbatim rather than parsed into a sleep in lib/.
 check "window: quotes the reset time"    "grep -q 'resets 7:10pm' <<<\"\$OUT\""
 # ★ THE ONE THAT REACHES A DRIVER THAT IS NOT READING STDOUT.
 check "window: exit 6, not 4"            "[ '$RC' -eq 6 ]"
+
+# ★★ #48, the benchmark path for a window that states NO reset and exits ZERO.
+# Two separate defects had to be fixed for this to reach exit 6 at all: the
+# classifier never matched the string, and classify_run binned it `inconclusive`
+# so the refusal chain was never asked. Measured on the claudecr seat: it cost
+# the last pass of `high` and all 12 of `xhigh`, reported as exit 4, "fix the
+# cause", about a tier that had nothing wrong with it.
+D=$(mktemp -d -p "$SANDBOX"); budget_case "$D"
+cat > "$D/agents.d/broke.sh" <<A
+run_broke() {
+  echo call >> "$D/calls"
+  echo "You've reached your Fable 5 limit. Switch to another model to continue."
+}
+A
+OUT=$(CADRE_HOME="$D/home" CADRE_WORK="$D/work" CADRE_AGENTS_D="$D/agents.d" \
+      CADRE_JUDGE=good PATH="$D/bin:$PATH" "$ROOT/bin/cadre" run broke 2 2>&1); RC=$?
+check "tier: asked exactly ONCE"       "[ \$(wc -l < '$D/calls') -eq 1 ]"
+check "tier: says window CLOSED"       "grep -q 'usage window is CLOSED' <<<\"\$OUT\""
+check "tier: not called a budget"      "! grep -q 'OUT OF BUDGET' <<<\"\$OUT\""
+check "tier: not a failed measurement" "! grep -q 'Fix the cause and re-run' <<<\"\$OUT\""
+check "tier: exit 6, not 4"            "[ '$RC' -eq 6 ]"
+# ★ And the instruction has to match the refusal it was given. This one names a
+# remedy, not a time, so "resume after the reset time quoted above" would send
+# the operator looking for a line no provider printed.
+check "tier: no reset time promised"   "! grep -q 'Resume after the reset time quoted above' <<<\"\$OUT\""
+check "tier: says where the reset is"  "grep -q \"check the provider's usage\" <<<\"\$OUT\""
 
 # ★★ THE PATH THE REAL INCIDENT TOOK, and the one above does NOT cover it. Above,
 # the window closes on the FIRST pass, so graded_passes is 0 and the run lands in
@@ -2783,7 +2863,7 @@ check "partial window: says INCOMPLETE"  "grep -q 'Verdict: INCOMPLETE, not slot
 # "restore the missing keys or checkouts" sends the operator hunting a broken
 # registry when a clock stopped the sweep and there is nothing to restore.
 check "partial window: not 'restore keys'" "! grep -q 'Restore the missing keys' <<<\"\$OUT\""
-check "partial window: says wait + resume" "grep -q 'wait for the reset named above' <<<\"\$OUT\""
+check "partial window: says wait + resume" "grep -q 'wait for that window to reopen' <<<\"\$OUT\""
 check "partial window: exit 6"           "[ '$RC' -eq 6 ]"
 
 # A PARTIAL failure must NOT abort. 1 of 2 runs is still a review worth grading,

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -1626,8 +1626,11 @@ check "window refusal is failed"             "ls '$R'/window-*.md.failed >/dev/n
 check "window refusal is named"              "grep -q 'usage window CLOSED' <<<\"\$OUT\""
 check "window banner leads the artifact"     "head -1 '$R'/window-*.md.failed | grep -q 'usage window closed, not retried'"
 # ★ #48, the same treatment for a window that exits ZERO. Before the fix this
-# one was `inconclusive`: it never reached the refusal chain, so it was neither
-# named nor kept out of the retry loop.
+# one was `inconclusive`, so the refusal chain was never asked and the artifact
+# was never named a window. It was not retried either way -- the loop breaks on
+# anything classify_run does not call `failed` -- so these four pin the naming
+# and the filing, not the retry. (The retry is what the benchmark path's exit-6
+# test below pins.)
 check "tier limit is failed"                 "ls '$R'/tier-*.md.failed >/dev/null 2>&1"
 check "tier limit is not retried"            "[ \$(grep -c 'rate limited, waiting' <<<\"\$OUT\") -eq 0 ]"
 check "tier banner leads the artifact"       "head -1 '$R'/tier-*.md.failed | grep -q 'usage window closed, not retried'"
@@ -2732,6 +2735,20 @@ check "window: mid-sentence remedy is not" "! $WC"
 # ★ ...and a CLI that wraps its line still counts: the remedy starts the line.
 printf "You've reached your Fable 5 limit.\nSwitch to another model to continue.\n" > "$QB"
 check "window: wrapped tier still caught"  "$WC"
+# ★★ AND THE TIER BRANCH YIELDS TO THE OTHER TWO, which is the opposite of the
+# rule the stated-reset branch follows. A stated reset PROVES waiting clears it,
+# so it is worth taking "usage limit - resets 3pm" out of the budget matcher's
+# hands. A remedy proves nothing of the kind, and a multi-model router can
+# phrase either of the others this way. Window is asked FIRST in both dispatch
+# paths, so without this a throughput ceiling loses its retries and a spend cap
+# is reported as a clock that will clear itself -- the operator then waits out a
+# window that only money opens. Found by the codex review of this change.
+printf "You've reached your rate limit. Switch to another model to continue.\n" > "$QB"
+check "window: yields to a rate limit"   "! $WC"
+check "window: and it still retries"     "$RL"
+printf "You've reached your monthly spend limit. Switch to another model to continue.\n" > "$QB"
+check "window: yields to a spend cap"    "! $WC"
+check "window: and it stays a budget"    "$QE"
 
 # ★★ THE HALF THE REGEX DOES NOT FIX. Both dispatch paths ask
 # provider_window_closed() only about a run classify_run already called `failed`,
@@ -2752,6 +2769,16 @@ check "window: a stated reset too"       "$CJ"
   printf 'and nothing else in this diff changed. No new defects.\n\n'
   printf 'Verdict: ship it\n'; } > "$QB"
 check "window: a review quoting one is not" "! $CJ"
+# ★ ...and the BROAD bottom line counts here, where the rate scan demands the
+# narrow one. A wrong `failed` on the rate path costs one run; a wrong `failed`
+# on this path stops the whole sweep at exit 6 and the re-run does it again, so
+# this guard protects a real review as hard as it can. None of these three would
+# survive explicit_verdict.
+for bl in 'Looks good to me.' 'LGTM' 'Recommendation: merge as is.'; do
+  { printf 'A short note on the session limit banner, which resets 7:10pm.\n\n'
+    printf '%s\n' "$bl"; } > "$QB"
+  check "window: '$bl' saves the review" "! $CJ"
+done
 
 # A candidate that is out of budget: refuses, and counts how often it was asked.
 budget_case() {  # budget_case <dir>
@@ -2848,6 +2875,21 @@ check "tier: exit 6, not 4"            "[ '$RC' -eq 6 ]"
 # the operator looking for a line no provider printed.
 check "tier: no reset time promised"   "! grep -q 'Resume after the reset time quoted above' <<<\"\$OUT\""
 check "tier: says where the reset is"  "grep -q \"check the provider's usage\" <<<\"\$OUT\""
+# ★ ...and that decision reads the REFUSAL, not the line cadre wrote about it.
+# That line carries the agent name and a 200-byte excerpt of the text, so an
+# agent named `resetter` supplied the word `reset` all by itself and got the
+# operator sent looking for a time nobody printed. Found by the codex review.
+D=$(mktemp -d -p "$SANDBOX"); budget_case "$D"
+printf '#!/bin/sh\nexit 0\n' > "$D/bin/resetter"; chmod +x "$D/bin/resetter"
+cat > "$D/agents.d/resetter.sh" <<A
+run_resetter() {
+  echo "You've reached your Fable 5 limit. Switch to another model to continue."
+}
+A
+OUT=$(CADRE_HOME="$D/home" CADRE_WORK="$D/work" CADRE_AGENTS_D="$D/agents.d" \
+      CADRE_JUDGE=good PATH="$D/bin:$PATH" "$ROOT/bin/cadre" run resetter 1 2>&1); RC=$?
+check "tier: agent name is not a reset"  "! grep -q 'Resume after the reset time quoted above' <<<\"\$OUT\""
+check "tier: resetter still exits 6"     "[ '$RC' -eq 6 ]"
 
 # ★★ THE PATH THE REAL INCIDENT TOOK, and the one above does NOT cover it. Above,
 # the window closes on the FIRST pass, so graded_passes is 0 and the run lands in

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -2720,6 +2720,18 @@ check "window: tier half alone is not"   "! $WC"
 check "window: that one stays a budget"  "$QE"
 printf 'The retry advice says to switch to another model, which is wrong here.\n' > "$QB"
 check "window: remedy half alone is not" "! $WC"
+# ★★ AND THE REMEDY HAS TO BE ISSUED, NOT MENTIONED. Both halves alone were not
+# enough: these two are this repo's own review prose, and both matched a first
+# draft of the pattern. The second one is the dangerous shape -- no findings, no
+# verdict -- so it would have passed classify_run's guards and STOPPED A SWEEP
+# over a review. A refusal instructs; prose refers.
+printf 'blocking: the retry path reached your rate limit ceiling and should switch to another model provider\n' > "$QB"
+check "window: prose naming both is not"  "! $WC"
+printf 'The docs say you have reached your quota limit; the fix is to switch to another model.\n' > "$QB"
+check "window: mid-sentence remedy is not" "! $WC"
+# ★ ...and a CLI that wraps its line still counts: the remedy starts the line.
+printf "You've reached your Fable 5 limit.\nSwitch to another model to continue.\n" > "$QB"
+check "window: wrapped tier still caught"  "$WC"
 
 # ★★ THE HALF THE REGEX DOES NOT FIX. Both dispatch paths ask
 # provider_window_closed() only about a run classify_run already called `failed`,


### PR DESCRIPTION
Closes #48.

Benchmarking the `claudecr` seat, the CLI returned exactly:

```
You've reached your Fable 5 limit. Switch to another model to continue.
```

That matched none of the four refusal classifiers — no 429, no period word, no
stated reset — so the run landed `inconclusive`, `run-pass.sh` exited 4, and one
spent per-model tier was reported as a **failed measurement of the candidate**.
It cost the last pass of `high` and all 12 of `xhigh`. The account was healthy:
the five-hour bucket at 5%, the all-model weekly at 59%, only the one tier at
100%, with its reset sitting in the usage endpoint and nowhere in the message.

## Two defects, and the regex alone fixes neither

**`provider_window_closed()` gets a second, three-part test.** Every window in
the corpus until now is caught by a **stated reset**. This one states a
**remedy** instead, and "switch to another model" is a sentence only a per-model
window can say — a spend cap names a payment page precisely because no other
model on the account would help.

**`classify_run()` is the half the pattern does not reach.** Both dispatch paths
ask `provider_window_closed()` only about a run this function already called
`failed`, and every window in the corpus arrives with a **nonzero exit**, so the
rc test did that binning for free. This one exits 0, so it was `inconclusive`
and the refusal chain was never consulted. With the regex fixed and this line
missing, the sweep still aborts.

## Three narrowings, each paid for

| draft | what it let through | fix |
| --- | --- | --- |
| both halves anywhere | this repo's own review prose: *"the fix is to switch to another model"* — no findings, no verdict, so it clears the guards and stops a sweep | the remedy has to be **issued**: start of a line or start of a sentence |
| window asked first, unconditionally | `You've reached your monthly spend limit. Switch to another model...` reported as a clock that clears itself, so the operator waits out a window only money opens | the tier branch **yields** to `rate_limited` and `quota_exhausted` |
| `! explicit_verdict` | a real short review ending `LGTM` or `Conclusion:` binned `failed`, stopping the sweep | `! has_verdict`, the broad gate — see below |

The last one is a deliberate split from the line above it. A wrong `failed` on
the rate path costs one run; a wrong `failed` here stops the **entire sweep** at
exit 6 and the re-run does it again. So this guard protects a real review as
hard as it can and accepts the pre-existing exit 4 as the cost of a miss. It is
safe in the other direction — not one refusal in the corpus states a bottom line
at all — and it sidesteps `explicit_verdict`'s `\b`, a GNU extension the repo
otherwise bans.

## Wording

The instruction has to match the refusal it was given. *"Resume after the reset
time quoted above"* points at a line no provider printed when the window names a
remedy. `run-pass.sh` now says it only when the refusal states one, and that
decision reads the **refusal**, not the line cadre wrote about it — that line
carries the agent name, so an agent called `resetter` supplied the word by
itself. `grade.sh`'s three verdict strings say "wait for the window to reopen".

`agents.d/claudecr.sh` records that the seat inherits the CLI's default model,
so the tier it spends is whatever `settings.json` points at and can change
between passes of one sweep. Pinning it for a benchmark run is still the
caller's job.

## Tests

894 → 926. **Fifteen fail against `main`**, including a zero-exit *session*
limit, which was the same latent hole one shape back.

Reviewed by codex on this branch: it found the rate/budget shadowing, the
`explicit_verdict` gap, the `$windows` variable bug, and one false claim in a
test comment. All four are fixed here.