### PR TITLE
One JSON slicer, and it does not depend on RS (#26)

### DIFF
--- a/bin/cadre
+++ b/bin/cadre
@@ -1480,14 +1480,10 @@ cmd_settle() {
   # brace-counting scan does not. Anything that still is not JSON -- no object
   # at all, or a truncated one -- fails jq and is refused below, which is the
   # direction that has to stay safe.
+  # ★ extract_json_slice() in lib/common.sh, which grade.sh's fallback also
+  # calls: two copies of this that had to agree were one copy too many (#26).
   local js
-  js=$(printf '%s' "$raw" \
-       | sed -e '/^[[:space:]]*```/d' \
-       | awk 'BEGIN{RS="\0"} {
-             i=index($0,"{"); if(!i) exit; s=substr($0,i);
-             for(k=length(s);k>0;k--) if(substr(s,k,1)=="}") { printf "%s", substr(s,1,k); exit }
-           }' \
-       | jq -c . 2>/dev/null) || js=""
+  js=$(printf '%s' "$raw" | extract_json_slice | jq -c . 2>/dev/null) || js=""
   # ★ Two causes, one message, so say both. An adapter that truncates now exits
   # nonzero even when the JSON it printed parses fine, and reporting that as
   # "did not return usable JSON" describes the wrong problem to whoever has to

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -988,6 +988,44 @@ failure_phrase() {  # <file> <rc> [secs] -> leading phrase, no trailing period
 # like a real measurement and pulls every mean toward the floor -- the rule
 # aggregate.sh and grade.sh already follow, now with a type that can express it.
 
+# The relaxed JSON slice, on stdin: drop fence lines, then take the first `{` to
+# the LAST `}`. Survives prose on either side of the block and an unbalanced
+# brace inside a string, which the balanced scan in grade.sh cannot -- that scan
+# stays first, because on a reply echoing prompt text with braces it finds the
+# clean object and this slice would not.
+#
+# ★ ONE copy, because there were two that had to agree: grade.sh's fallback and
+# the settle judge in bin/cadre. #26.
+#
+# ★ No `RS`. Both copies slurped by setting awk's record separator to a NUL,
+# which is a gawk extension: in awk source `"\0"` is a NUL-terminated
+# string, so an awk that reads it as C does sees the EMPTY string -- which is
+# awk paragraph mode, splitting on blank lines instead of slurping. A judge that
+# answers with prose, a blank line, then a fenced JSON block would leave the
+# JSON in a later record, `index($0,"{")` would find nothing, and a judge that
+# answered correctly would be reported as one that "failed or stopped early".
+# In settle that direction is worse than a wrong answer, because its exit status
+# is a stopping rule and an empty match reads as "nothing new is left".
+# NOT REPRODUCED: this box has only gawk, which slurps under --posix and
+# --traditional too, and no BSD awk was available to confirm the paragraph-mode
+# read. The RS dependency is removed rather than the failure measured. README
+# names bash 4.4+ and macOS, and a test already bans GNU-only sed/grep escapes
+# for the same reason, so the portable form is the one to ship either way.
+# Accumulating in END is identical on gawk: same first-{ to last-} over the
+# same bytes.
+extract_json_slice() {
+  sed -e '/^[[:space:]]*```/d' \
+  | awk '
+      { buf = buf $0 "\n" }
+      END {
+        i = index(buf, "{"); if (!i) exit 1
+        s = substr(buf, i)
+        for (k = length(s); k > 0; k--)
+          if (substr(s, k, 1) == "}") { printf "%s", substr(s, 1, k); exit 0 }
+        exit 1
+      }'
+}
+
 # One field value, escaped for JSON. Backslash BEFORE quote, or the escape this
 # adds is itself re-escaped. Control characters are dropped rather than encoded:
 # one event is one LINE, and a stray newline inside a value would split it into

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -35,24 +35,6 @@ extract_json() {
   '
 }
 
-# ★ The fallback for what the scan above cannot parse: an UNBALANCED brace
-# inside a JSON string. "The judge's format never has them" stopped being true
-# the day `quotes` became required -- a verbatim reviewer sentence about shell
-# or C code carries a lone { or } routinely, the depth count never returns to
-# zero, and a valid grade was recorded UNUSABLE with the judge blamed for it.
-# Same shape cmd_settle already uses: drop fence lines, slice first { to last
-# }, let jq be the arbiter. Tried second, not first, because on a reply that
-# echoes prompt text with braces the balanced scan finds the clean object and
-# this slice would not.
-extract_json_relaxed() {
-  sed -e '/^[[:space:]]*```/d' \
-  | awk 'BEGIN{RS="\0"} {
-      i=index($0,"{"); if(!i) exit 1; s=substr($0,i)
-      for(k=length(s);k>0;k--) if(substr(s,k,1)=="}") { printf "%s", substr(s,1,k); exit }
-      exit 1
-    }'
-}
-
 grade_one() {
   local keyfile="$1" review="$2" out="$3" raw attempt=1 w
   [ -s "$review" ] || { echo "$UNUSABLE" > "$out"; return; }
@@ -77,8 +59,17 @@ grade_one() {
   local parsed=0
   printf '%s' "$raw" | extract_json > "$out" 2>/dev/null
   jq -e '.items' "$out" >/dev/null 2>&1 && parsed=1
+  # ★ The fallback for what the scan above cannot parse: an UNBALANCED brace
+  # inside a JSON string. "The judge's format never has them" stopped being true
+  # the day `quotes` became required -- a verbatim reviewer sentence about shell
+  # or C code carries a lone { or } routinely, the depth count never returns to
+  # zero, and a valid grade was recorded UNUSABLE with the judge blamed for it.
+  # extract_json_slice() is the same code cmd_settle uses, one copy in
+  # lib/common.sh (#26). Tried SECOND, not first, because on a reply that echoes
+  # prompt text with braces the balanced scan finds the clean object and this
+  # slice would not.
   if [ "$parsed" -eq 0 ]; then
-    printf '%s' "$raw" | extract_json_relaxed > "$out" 2>/dev/null
+    printf '%s' "$raw" | extract_json_slice > "$out" 2>/dev/null
     jq -e '.items' "$out" >/dev/null 2>&1 && parsed=1
   fi
   # ★ Keep what the judge actually said when it does not parse. UNUSABLE with no

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -2006,13 +2006,18 @@ check "review file left alone"        "grep -q 'timestamps are strings' '$D/revi
 # with qwen judging a real panel. Every stub above returns bare JSON, which is
 # exactly why the suite was green while live settle was broken: judge stubs are
 # tidier than judges.
-for shape in fenced tagged prose_after leading_prose; do
+for shape in fenced tagged prose_after leading_prose blank_before; do
   case $shape in
     fenced)        pre='```';     post='```' ;;
     tagged)        pre='```json'; post='```' ;;
     prose_after)   pre='```json'; post='```
 Let me know if you want more detail.' ;;
     leading_prose) pre='Here is the match:
+```json'; post='```' ;;
+    # ★ #26: prose, a BLANK LINE, then the block. The one shape an awk in
+    # paragraph mode splits, leaving the JSON in a record the slicer never reads.
+    blank_before)  pre='Here is the match:
+
 ```json'; post='```' ;;
   esac
   cat > "$D/agents.d/judgestub.sh" <<A
@@ -2042,6 +2047,33 @@ J
 A
 OUT=$(run_cadre "$D" settle "$D/review.md" --judge judgestub 2>&1)
 check "braces inside strings survive" "grep -q 'returns early' <<<\"\$OUT\""
+
+# ★★ #26. Both copies of this slicer used to slurp by setting awk's record
+# separator to a NUL, which is a gawk extension: in awk source "\0" is a
+# NUL-terminated string, so an awk that reads it as C does sees the EMPTY string
+# -- and an empty RS is awk PARAGRAPH mode, splitting on blank lines instead of
+# slurping. The JSON then sits in a record the slicer never reads and a judge
+# that answered correctly is reported as one that "failed or stopped early".
+# In settle that is the bad direction twice over: its exit status is a stopping
+# rule, so an empty match reads as "nothing new is left".
+# NOT REPRODUCED on a real BSD awk -- this box has only gawk, which slurps under
+# --posix and --traditional too. So the hazard is MEASURED by forcing paragraph
+# mode explicitly rather than asserted from the docs, and the fix is the removal
+# of the dependency, not a confirmed platform bug.
+cat > "$D/oldslice.awk" <<'A'
+BEGIN{RS=""}
+{ i=index($0,"{"); if(!i) exit 1; s=substr($0,i)
+  for(k=length(s);k>0;k--) if(substr(s,k,1)=="}") { printf "%s", substr(s,1,k); exit }
+  exit 1 }
+A
+printf 'Here is the match:\n\n{"findings":[]}\n' > "$D/para.txt"
+check "paragraph mode really loses it"  "[ -z \"\$(awk -f '$D/oldslice.awk' '$D/para.txt')\" ]"
+check "the shipped slicer keeps it"     "bash -c \"source '$ROOT/lib/common.sh'; extract_json_slice < '$D/para.txt'\" | grep -q findings"
+# ★ And ONE copy, so the two cannot drift apart again -- which is how the first
+# of them was fixed for the trailing fence and the other was not.
+check "no RS left for an awk to misread" "! grep -rqE 'BEGIN\{ *RS' '$ROOT/lib/common.sh' '$ROOT/lib/grade.sh' '$ROOT/bin/cadre'"
+check "grade.sh calls the shared slicer" "grep -q 'extract_json_slice' '$ROOT/lib/grade.sh'"
+check "settle calls the shared slicer"   "grep -q 'extract_json_slice' '$ROOT/bin/cadre'"
 # Still has to REFUSE a fenced block that is not complete JSON.
 cat > "$D/agents.d/judgestub.sh" <<'A'
 run_judgestub() {

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -2060,6 +2060,9 @@ check "braces inside strings survive" "grep -q 'returns early' <<<\"\$OUT\""
 # --posix and --traditional too. So the hazard is MEASURED by forcing paragraph
 # mode explicitly rather than asserted from the docs, and the fix is the removal
 # of the dependency, not a confirmed platform bug.
+# ★ The first check below is EVIDENCE, not a regression guard: it exercises the
+# old shape under forced paragraph mode and passes with this commit reverted, on
+# purpose. The guards are the three source pins at the end of the block.
 cat > "$D/oldslice.awk" <<'A'
 BEGIN{RS=""}
 { i=index($0,"{"); if(!i) exit 1; s=substr($0,i)


### PR DESCRIPTION
Closes #26.

Two copies of the relaxed model-JSON slice — `grade.sh`'s fallback and the
`settle` judge in `bin/cadre` — both slurped stdin by setting awk's record
separator to a NUL. That is a gawk extension. In awk source `"\0"` is a
NUL-terminated string, so an awk that reads it as C does sees the **empty
string**, and an empty `RS` is awk **paragraph mode**: it splits on blank lines
instead of slurping.

A judge that answers with prose, a blank line, then a fenced JSON block would
leave the JSON in a later record, `index($0,"{")` would find nothing, and a
judge that answered correctly would be reported as one that "failed or stopped
early". `settle` is the worse of the two places for it: its exit status is a
stopping rule, so an empty match reads as *"nothing new is left"*.

## What is and is not claimed

**Not reproduced on a real BSD awk.** This box has only gawk, which slurps under
`--posix` and `--traditional` too, and no other awk was available. This removes
the RS dependency rather than confirming a platform bug — the honest claim is
the smaller one.

It is a strict subtraction. Accumulating in `END` is identical on gawk: same
first-`{` to last-`}` over the same bytes. The README already names macOS, and a
test bans GNU-only sed and grep escapes for the same reason, so the portable
form is the one to ship either way.

## Tests

The hazard is **measured, not asserted**: a check forces paragraph mode
explicitly (`RS=""`) over the exact prose-blank-JSON shape and shows the old
slice loses the block while the shipped one keeps it. That check is labelled
evidence rather than a guard — it passes with this commit reverted, on purpose.
The settle shape loop gains `blank_before` end to end, and three source pins
hold the single copy: no `BEGIN{RS` anywhere in `lib/` or `bin/`, and both call
sites naming `extract_json_slice`.

894 → 902; four fail against `main`.

## Structure

`extract_json_slice()` lives in `lib/common.sh` with the fence strip folded in,
so the two halves that had to agree are one function. `grade.sh`'s
brace-balanced `extract_json` is untouched and still tried **first**: on a reply
echoing prompt text with braces it finds the clean object and this slice would
not.

Reviewed by grok on this branch. It compared old and new on empty input, no `{`,
no `}`, `}` before `{`, no trailing newline, CRLF, a lone brace inside a string,
two objects, and a 16MB dump — byte-identical stdout in every case — and traced
both call sites to confirm neither one's control flow changed under
`set -uo pipefail`. Its one nit, that the paragraph-mode check is evidence
rather than a regression guard, is now said out loud in the file.