### PR TITLE
Name the inputs and the schema on every run record (#37, #20)

### DIFF
--- a/bin/cadre
+++ b/bin/cadre
@@ -1164,11 +1164,16 @@ cmd_receipts() {
     NF < 5 || $3 == "" { next }
     {
       fam = $3
-      # ★ A missing or empty column 8 is UNKNOWN, printed "?", never defaulted to
-      # a version. Those rows straddle the change this grouping exists to keep
-      # apart, and calling them by any version number would assert the one thing
-      # nothing on disk can tell us.
-      v = (NF >= 8 && $8 != "") ? $8 : "?"
+      # ★ A missing, empty or NON-NUMERIC column 8 is UNKNOWN, printed "?", never
+      # defaulted to a version. Those rows straddle the change this grouping
+      # exists to keep apart, and calling them by any version number would assert
+      # the one thing nothing on disk can tell us.
+      # ★ The numeric test is not belt-and-braces. A dataset written by the old
+      # lib/aggregate.sh puts `source` in column 8, so `recorded` and
+      # `reconstructed` arrived here as two schema names and split every family
+      # in the table -- receipts accepts any directory, and a stale dataset dir
+      # is a directory.
+      v = (NF >= 8 && $8 ~ /^[0-9]+$/) ? $8 : "?"
       key = fam SUBSEP v
       if (!(key in keys)) { keys[key] = 1; famof[key] = fam; vof[key] = v; nver[fam]++ }
       seats[key]++

--- a/bin/cadre
+++ b/bin/cadre
@@ -1139,8 +1139,16 @@ cmd_review() {
 # Sum only what slots.tsv measured. Old and reconstructed rows have no prompt
 # length, and a receipt command that guesses one would turn missing history into
 # a confident spend number.
+#
+# ★ Rows are grouped by (family, SCHEMA), not by family (#20). `secs` changed
+# meaning for one class of row -- a failed seat used to carry a blank and now
+# carries its measured seconds -- and neither value is wrong, so the totals are
+# not wrong either; a single total over both is. Splitting the row is the
+# strongest available answer: there is no unqualified number to misread, and a
+# family that appears twice is itself the notice. Nothing is dropped, so panels
+# that predate the column stay readable, which is the other half of the ask.
 cmd_receipts() {
-  local roots=() d f raw rows missing tab=$'\t'
+  local roots=() d f raw rows missing spanning harness_list nharness no_harness tab=$'\t'
   if [ "$#" -eq 0 ]; then roots=("$CADRE_HOME/reviews")
   else roots=("$@")
   fi
@@ -1156,50 +1164,98 @@ cmd_receipts() {
     NF < 5 || $3 == "" { next }
     {
       fam = $3
-      seats[fam]++
-      run_key = fam SUBSEP FILENAME SUBSEP $1
-      if (!(run_key in seen)) { seen[run_key] = 1; runs[fam]++ }
-      if      ($4 == "ok")           ok[fam]++
-      else if ($4 == "degraded")     degraded[fam]++
-      else if ($4 == "inconclusive") inconclusive[fam]++
-      else if ($4 == "skipped")      skipped[fam]++
-      else                             failed[fam]++
+      # ★ A missing or empty column 8 is UNKNOWN, printed "?", never defaulted to
+      # a version. Those rows straddle the change this grouping exists to keep
+      # apart, and calling them by any version number would assert the one thing
+      # nothing on disk can tell us.
+      v = (NF >= 8 && $8 != "") ? $8 : "?"
+      key = fam SUBSEP v
+      if (!(key in keys)) { keys[key] = 1; famof[key] = fam; vof[key] = v; nver[fam]++ }
+      seats[key]++
+      run_key = key SUBSEP FILENAME SUBSEP $1
+      if (!(run_key in seen)) { seen[run_key] = 1; runs[key]++ }
+      if      ($4 == "ok")           ok[key]++
+      else if ($4 == "degraded")     degraded[key]++
+      else if ($4 == "inconclusive") inconclusive[key]++
+      else if ($4 == "skipped")      skipped[key]++
+      else                             failed[key]++
       review = ($5 ~ /^[0-9]+$/) ? $5 : 0
-      review_bytes[fam] += review
-      if ($6 ~ /^[0-9]+$/) { secs[fam] += $6; have_secs[fam] = 1 }
+      review_bytes[key] += review
+      if ($6 ~ /^[0-9]+$/) { secs[key] += $6; have_secs[key] = 1 }
       prompt = 0
       if (NF < 7 || $7 == "") missing_prompt++
-      else if ($7 ~ /^[0-9]+$/) { prompt = $7; prompt_bytes[fam] += prompt }
+      else if ($7 ~ /^[0-9]+$/) { prompt = $7; prompt_bytes[key] += prompt }
       else missing_prompt++
-      est_tokens[fam] += int((prompt + review) / 4)
+      est_tokens[key] += int((prompt + review) / 4)
+      # Harness identity is a property of the COMPARISON, not of a family, so it
+      # is counted across every row the command was pointed at (#37).
+      if (NF >= 11 && $11 != "") { if (!($11 in harness)) harness[$11] = 1 }
+      else no_harness++
     }
     END {
-      for (fam in seats) {
-        sec = have_secs[fam] ? secs[fam] : ""
-        printf "R\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%d\t%d\n", \
-          fam, runs[fam], seats[fam], ok[fam], degraded[fam], \
-          inconclusive[fam], failed[fam], skipped[fam], sec, prompt_bytes[fam], \
-          review_bytes[fam], est_tokens[fam]
+      for (key in keys) {
+        sec = have_secs[key] ? secs[key] : ""
+        printf "R\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\n", \
+          famof[key], runs[key], seats[key], ok[key], degraded[key], \
+          inconclusive[key], failed[key], skipped[key], sec, prompt_bytes[key], \
+          review_bytes[key], est_tokens[key], vof[key], nver[famof[key]]
       }
       printf "M\t%d\n", missing_prompt
+      for (h in harness) printf "H\t%s\n", h
+      printf "N\t%d\n", no_harness + 0
     }
   ' "${slot_files[@]}")
 
   missing=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "M" { print $2 }')
+  # -k14 breaks the tie so a family split across schemas prints in a stable
+  # order; without it the two halves swap between runs and a diff of two
+  # receipts reads as a change.
   rows=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "R"' \
-    | sort -t "$tab" -k13,13nr -k2,2)
+    | sort -t "$tab" -k13,13nr -k2,2 -k14,14)
 
-  printf '%-24s %5s %5s %4s %8s %12s %6s %7s %8s %10s %10s %11s\n' \
-    FAMILY RUNS SEATS OK DEGRADED INCONCLUSIVE FAILED SKIPPED SECS PROMPT_KB REVIEW_KB 'EST. TOKENS'
+  printf '%-24s %5s %5s %4s %8s %12s %6s %7s %8s %10s %10s %11s %7s\n' \
+    FAMILY RUNS SEATS OK DEGRADED INCONCLUSIVE FAILED SKIPPED SECS PROMPT_KB REVIEW_KB 'EST. TOKENS' SCHEMA
   printf '%s\n' "$rows" | awk -v FS="$tab" '
     $1 == "R" {
-      printf "%-24s %5d %5d %4d %8d %12d %6d %7d %8s %10.1f %10.1f %11d\n", \
-        $2, $3, $4, $5, $6, $7, $8, $9, $10, $11 / 1024, $12 / 1024, $13
+      printf "%-24s %5d %5d %4d %8d %12d %6d %7d %8s %10.1f %10.1f %11d %7s\n", \
+        $2, $3, $4, $5, $6, $7, $8, $9, $10, $11 / 1024, $12 / 1024, $13, $14
     }
   '
   if [ "${missing:-0}" -gt 0 ]; then
     echo
     echo "$missing rows predate prompt-byte capture; their prompt spend is not counted."
+  fi
+
+  spanning=$(printf '%s\n' "$rows" | awk -v FS="$tab" '$1 == "R" && $15 > 1 { print $2 }' \
+    | sort -u | paste -sd, - | sed 's/,/, /g')
+  if [ -n "$spanning" ]; then
+    echo
+    echo "Listed on more than one row, one per slots.tsv schema: $spanning."
+    echo "Those rows are NOT comparable and were not added together. Schema ? predates the column and spans the change to what a failed seat's SECS means."
+  fi
+
+  harness_list=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "H" { print $2 }' \
+    | sort | paste -sd, - | sed 's/,/, /g')
+  nharness=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "H"' | grep -c . || true)
+  no_harness=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "N" { print $2 }')
+  # ★ Said out loud on BOTH branches. The agreement case is the one worth
+  # printing: an absent warning is indistinguishable from a check that never
+  # ran, and this line is the only place the comparison's harness identity
+  # surfaces at all.
+  if [ "${nharness:-0}" -gt 1 ]; then
+    echo
+    echo "Harness: these rows span ${nharness} versions ($harness_list). Seats measured under different harnesses are not a like-for-like comparison."
+  elif [ "${nharness:-0}" -eq 1 ]; then
+    echo
+    if [ "${no_harness:-0}" -eq 0 ]; then
+      echo "Harness: every row ran against $harness_list."
+    else
+      echo "Harness: every row that names one ran against $harness_list."
+    fi
+  fi
+  if [ "${no_harness:-0}" -gt 0 ]; then
+    [ "${nharness:-0}" -gt 0 ] || echo
+    echo "Harness: ${no_harness} row(s) name none, so whether they match the rest is unknown."
   fi
 }
 

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -98,6 +98,29 @@ no diagnostic in the pipeline.
 Tests: "by: without -a the whole review is suppressed", "by: the pre-existing
 claims survive", "by: the finding after the bad byte is claimed".
 
+**12. A published number names the inputs that produced it.** Every row of
+`slots.tsv` and every `complete` record carries a content hash for the rendered
+prompt, for the adapter file(s) that ran, and for the harness files that shape a
+review (`lib/common.sh`, `lib/run-review.sh`, `lib/run-pass.sh`, `lib/grade.sh`,
+`lib/prompts/*`). `prompt_bytes` was a size, so two prompts of equal length were
+one row; `CADRE_PROMPT_FILE` replaces the brief wholesale, which made the
+highest-leverage input the least described. The hash is EMPTY, never zero and
+never faked, when it could not be determined — a reconstructed row, a promptless
+adapter, or a box with no sha256 tool. `cadre receipts` states whether every row
+in a comparison ran against the same harness, on both branches.
+Tests: "adapter hash is per adapter", "one harness hash for the panel",
+"sha: a missing input is EMPTY", "harness: a split is called out",
+"harness: agreement is stated".
+
+**13. Receipts do not average across a schema change.** `slots.tsv` rows carry
+the schema version that wrote them, and `cadre receipts` groups by
+(family, schema) rather than by family. Rows written before the column existed
+print schema `?` — unknown, not a default — because they straddle the change to
+what `secs` means on a failed seat and nothing on disk separates the halves.
+Nothing is excluded, so older panels stay readable.
+Tests: "mixed: one row per schema", "mixed: the two secs never merge",
+"mixed: pre-#19 panels still read".
+
 ## Non-goals, named
 
 - **The preflight reads filenames, plus content for exactly four config
@@ -114,6 +137,11 @@ claims survive", "by: the finding after the bad byte is claimed".
   target-pick time.
 - **Receipts do not measure hidden reasoning tokens, provider billing, or
   in-CLI retries.** METHOD.md §6.
+- **The input hashes are provenance, not tamper-proofing.** They are computed
+  by the same tree they describe, so anyone who can edit `lib/` can edit what
+  gets hashed. What they buy is that a comparison spanning an edit becomes
+  visible instead of silent. Nothing here is a signature and nothing verifies
+  a tree against a published manifest.
 - **A scratch file in the tree is a source file to the harness.** Planning
   notes, TODO dumps and other author-written artifacts ride into the checkout
   like any other file — tracked, or untracked-but-not-gitignored (carried on

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -100,17 +100,34 @@ claims survive", "by: the finding after the bad byte is claimed".
 
 **12. A published number names the inputs that produced it.** Every row of
 `slots.tsv` and every `complete` record carries a content hash for the rendered
-prompt, for the adapter file(s) that ran, and for the harness files that shape a
-review (`lib/common.sh`, `lib/run-review.sh`, `lib/run-pass.sh`, `lib/grade.sh`,
-`lib/prompts/*`). `prompt_bytes` was a size, so two prompts of equal length were
-one row; `CADRE_PROMPT_FILE` replaces the brief wholesale, which made the
-highest-leverage input the least described. The hash is EMPTY, never zero and
-never faked, when it could not be determined — a reconstructed row, a promptless
-adapter, or a box with no sha256 tool. `cadre receipts` states whether every row
-in a comparison ran against the same harness, on both branches.
-Tests: "adapter hash is per adapter", "one harness hash for the panel",
-"sha: a missing input is EMPTY", "harness: a split is called out",
-"harness: agreement is stated".
+prompt, for the adapter code that ran, and for the harness files that shape a
+review (`bin/agentcall`, `lib/common.sh`, `lib/run-review.sh`,
+`lib/run-pass.sh`, `lib/grade.sh`, `lib/prompts/*`). `prompt_bytes` was a size,
+so two prompts of equal length were one row; `CADRE_PROMPT_FILE` replaces the
+brief wholesale, which made the highest-leverage input the least described.
+
+`adapter_sha` covers the files `agentcall` would source that define anything for
+that agent — both copies of `<agent>.sh`, and any other file in either directory
+mentioning `_<agent>(`. It sources every `*.sh` in both directories into one
+namespace, so a foreign file defining `run_<agent>()` is a different reviewer
+behind an otherwise unchanged adapter file.
+
+**The hash is EMPTY whenever it could not be fully determined** — a
+reconstructed row, a promptless adapter that received no shared brief, a box
+with no sha256 tool, an unreadable or missing input, or any hashing step that
+exits non-zero. Never a zero, never a partial digest: the digest of an empty
+read is *stable*, so two runs that both failed would compare EQUAL, which is the
+one answer this field must never give. Per-file digests are hashed rather than
+concatenated bytes, so no pair of inputs can straddle a field boundary and
+collide.
+
+`cadre receipts` states whether every row in a comparison ran against the same
+harness, on both branches — agreement and disagreement.
+Tests: "adapter hash is per adapter", "adapter hash sees a foreign override",
+"and ignores an unrelated adapter", "one harness hash for the panel",
+"harness: agentcall is hashed", "sha: an unreadable input is EMPTY",
+"sha: never the digest of nothing", "sha: file boundaries are kept",
+"harness: a split is called out", "harness: agreement is stated".
 
 **13. Receipts do not average across a schema change.** `slots.tsv` rows carry
 the schema version that wrote them, and `cadre receipts` groups by
@@ -118,8 +135,11 @@ the schema version that wrote them, and `cadre receipts` groups by
 print schema `?` — unknown, not a default — because they straddle the change to
 what `secs` means on a failed seat and nothing on disk separates the halves.
 Nothing is excluded, so older panels stay readable.
+Column 8 is read as a version only when it *reads* as one: a dataset written by
+the older `lib/aggregate.sh` carries `source` there, and `recorded` /
+`reconstructed` would otherwise have split every family into two named schemas.
 Tests: "mixed: one row per schema", "mixed: the two secs never merge",
-"mixed: pre-#19 panels still read".
+"mixed: pre-#19 panels still read", "olddata: a source word is never a schema".
 
 ## Non-goals, named
 

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -59,15 +59,21 @@ about which model reviews *better* needs that path, not this file.
   print as `?` and are listed on their own row.
 - **prompt_sha** / **adapter_sha** / **harness_sha** — 12-hex content hashes of
   the three inputs that decide what a seat saw: the rendered prompt as
-  dispatched, the adapter file(s) that ran (both the shipped one and a user
-  override, since `agentcall` sources both), and the harness files that shape a
-  review. `prompt_bytes` is a size — two prompts that differ but happen to be
+  dispatched, the adapter code that ran, and the harness files that shape a
+  review (including `bin/agentcall`, which decides whether the brief arrives on
+  stdin or in argv; `bin/cadre` is deliberately excluded, so a CLI edit does not
+  invalidate stored comparisons). `adapter_sha` covers both copies of
+  `<agent>.sh` *and* any other file in either adapter directory mentioning
+  `_<agent>(` — `agentcall` sources every `*.sh` in both into one namespace, so
+  a foreign file defining `run_<agent>()` is a different reviewer. `prompt_bytes` is a size — two prompts that differ but happen to be
   the same length are indistinguishable by it, and `CADRE_PROMPT_FILE` replaces
   the brief wholesale, so the input with the largest effect on a review was the
   one the record described least. All three are **EMPTY when undetermined** and
   never zeroed: a reconstructed row, a promptless adapter that received no
-  shared brief, or a machine with no `sha256sum`/`shasum`. This is provenance,
-  not tamper-proofing — see `docs/ASSURANCE_CASE.md`.
+  shared brief, a machine with no `sha256sum`/`shasum`, or an input that could
+  not be read in full. The digest of an empty read is *stable*, so a partial
+  answer here would make two failed runs compare equal. This is provenance, not
+  tamper-proofing — see `docs/ASSURANCE_CASE.md`.
 - **source** — `recorded` (written live by `run-review.sh`, with status and
   timing measured and prompt size present on new rows) or `reconstructed`
   (rebuilt from artifacts after the fact). Reconstructed rows have **no timing

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -25,7 +25,7 @@ about which model reviews *better* needs that path, not this file.
 
 ## slots.tsv — one row per reviewer slot
 
-    panel  slot  family  status  bytes  secs  prompt_bytes  source
+    panel  slot  family  status  bytes  secs  prompt_bytes  v  prompt_sha  adapter_sha  harness_sha  source
 
 - **status** — `ok` / `degraded` / `inconclusive` / `failed` / `skipped`.
   `skipped` means the user-declared roster gate did not hold, so no prompt was
@@ -49,13 +49,33 @@ about which model reviews *better* needs that path, not this file.
 - **prompt_bytes** — size of the exact prompt dispatched to the seat, captured
   by the harness at dispatch time. It is empty for rows that predate this field
   and for reconstructed rows; cadre never guesses it from surviving files.
+- **v** — the `slots.tsv` schema version that wrote the row: what these columns
+  mean and which rule filled them. A row **without** it is not version 1, it is
+  **unknown**, and `cadre receipts` groups on it rather than guessing. The
+  distinction it protects: `secs` on a *failed* seat used to be blank and is now
+  the measured seconds. Neither convention is wrong, and a total that spans both
+  is a number nobody can interpret. Rows that predate the column straddle that
+  change and nothing on disk can separate the halves after the fact, so they
+  print as `?` and are listed on their own row.
+- **prompt_sha** / **adapter_sha** / **harness_sha** — 12-hex content hashes of
+  the three inputs that decide what a seat saw: the rendered prompt as
+  dispatched, the adapter file(s) that ran (both the shipped one and a user
+  override, since `agentcall` sources both), and the harness files that shape a
+  review. `prompt_bytes` is a size — two prompts that differ but happen to be
+  the same length are indistinguishable by it, and `CADRE_PROMPT_FILE` replaces
+  the brief wholesale, so the input with the largest effect on a review was the
+  one the record described least. All three are **EMPTY when undetermined** and
+  never zeroed: a reconstructed row, a promptless adapter that received no
+  shared brief, or a machine with no `sha256sum`/`shasum`. This is provenance,
+  not tamper-proofing — see `docs/ASSURANCE_CASE.md`.
 - **source** — `recorded` (written live by `run-review.sh`, with status and
   timing measured and prompt size present on new rows) or `reconstructed`
   (rebuilt from artifacts after the fact). Reconstructed rows have **no timing
   or prompt size at all**: the per-slot scratch files were deleted when the
   panel finished, and fourteen panels ran before timing capture was fixed. Both
   fields are left EMPTY rather than zeroed, because a zero would average like a
-  real measurement and drag every mean toward the floor.
+  real measurement and drag every mean toward the floor. The four provenance
+  columns follow the same rule for the same reason.
 
 ## panels.tsv — one row per panel
 

--- a/lib/aggregate.sh
+++ b/lib/aggregate.sh
@@ -35,9 +35,12 @@ PANELS="$OUT_D/panels.tsv"
 # specific way: the artifacts carry status and size but NOT elapsed time or the
 # dispatched prompt size, so `secs` and `prompt_bytes` are empty for them.
 # Empty, not zero -- a zero would average like a real measurement and silently
-# pull every mean toward the floor.
+# pull every mean toward the floor. The four provenance columns (#20, #37) obey
+# the same rule and for the same reason: a reconstructed row has no schema
+# version and no input hashes, and inventing either would let it compare equal
+# to a row that was actually measured.
 {
-  printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tsource\n'
+  printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tv\tprompt_sha\tadapter_sha\tharness_sha\tsource\n'
   for d in "$REVIEWS"/*/; do
     [ -d "$d" ] || continue
     p=$(basename "$d")
@@ -46,8 +49,11 @@ PANELS="$OUT_D/panels.tsv"
       # awk preserves adjacent tab fields. Bash read treats tab as IFS whitespace
       # and collapsed an empty secs field, shifting skipped prompt_bytes=0 into
       # seconds and turning the measured zero back into missing data.
+      # A panel written before the provenance columns existed simply has no $8..$11
+      # and awk yields EMPTY for each -- which is the right answer, and the one
+      # `cadre receipts` groups on. Nothing here backfills them.
       awk -F '\t' -v OFS='\t' -v panel="$p" '
-        $2 != "" { print panel, $2, $3, $4, $5, $6, $7, "recorded" }
+        $2 != "" { print panel, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, "recorded" }
       ' "$d/slots.tsv"
       continue
     fi
@@ -87,7 +93,7 @@ PANELS="$OUT_D/panels.tsv"
       fi
       bytes=0
       [ -n "$art" ] && bytes=$(wc -c < "$art" | tr -d ' ')
-      printf '%s\t%s\t%s\t%s\t%s\t\t\treconstructed\n' \
+      printf '%s\t%s\t%s\t%s\t%s\t\t\t\t\t\t\treconstructed\n' \
         "$p" "$spec" "$(spec_family "$spec")" "$st" "$bytes"
     done
   done
@@ -108,7 +114,11 @@ PANELS="$OUT_D/panels.tsv"
     did="unknown"
     [ -n "$bt" ] && [ -n "$rt" ] && did="${bt:0:8}..${rt:0:8}"
     n=0 o=0 g=0 u=0 f=0
-    while IFS=$'\t' read -r pp _s _fam st _b _sec _prompt _src; do
+    # Only $1 and $4 are used, and both sit before the first field that can be
+    # empty -- which matters, because tab is IFS WHITESPACE and a plain read
+    # collapses the empty runs further right. The trailing names are declared to
+    # match the header, not relied on.
+    while IFS=$'\t' read -r pp _s _fam st _b _sec _prompt _v _psha _asha _hsha _src; do
       [ "$pp" = "$p" ] || continue
       # A gated-off seat is retained in slots.tsv as operational provenance but
       # was never on the reviewing panel, so it cannot pad the seat denominator.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -82,28 +82,62 @@ if command -v sha256sum >/dev/null 2>&1; then SHA_CMD="sha256sum"
 elif command -v shasum >/dev/null 2>&1; then SHA_CMD="shasum -a 256"
 fi
 
-# content_sha <file>... -- 12 hex chars over the files' bytes, concatenated in
-# the order given. EMPTY if any input is missing: a hash that silently describes
-# a subset is worse than none, because it compares equal to a run that had the
-# same subset for a different reason.
+# content_sha <file>... -- 12 hex chars identifying the files' contents, in the
+# order given. EMPTY if any input is missing, unreadable, or fails to hash.
+#
+# ★ Hashes the per-file DIGESTS, not the concatenated bytes. Concatenation has
+# no field boundary, so `#a` + `x=1` and `#` + `ax=1` both hash `#ax=1` and
+# compare EQUAL -- two adapter sets that source differently, reported as one.
+# A fixed-width hex block per file cannot run into its neighbour.
+#
+# ★ And every step is checked, because the failure mode here is not a missing
+# value, it is a CONFIDENT one. `cat -- /proc/1/mem | sha256sum` exits 0 down the
+# pipe and prints e3b0c44298fc, the digest of nothing -- stable, so two runs that
+# both failed to read an input compare equal, which is the exact opposite of
+# what these fields are for. Anything short of a full read returns EMPTY.
 content_sha() {
   [ -n "$SHA_CMD" ] || return 0
-  local f
-  for f in "$@"; do [ -f "$f" ] || return 0; done
   [ "$#" -gt 0 ] || return 0
-  # shellcheck disable=SC2086  # SHA_CMD may carry an argument (shasum -a 256)
-  cat -- "$@" | $SHA_CMD | cut -c1-12
+  local f d out=""
+  for f in "$@"; do
+    [ -f "$f" ] && [ -r "$f" ] || return 0
+    # pipefail inside the substitution's own subshell, so a read error anywhere
+    # in the pipe is a refusal rather than a digest of what got through.
+    # shellcheck disable=SC2086  # SHA_CMD may carry an argument (shasum -a 256)
+    d=$(set -o pipefail; $SHA_CMD < "$f" | cut -d' ' -f1) || return 0
+    [ -n "$d" ] || return 0
+    out="$out$d"
+  done
+  # shellcheck disable=SC2086
+  printf '%s' "$out" | $SHA_CMD | cut -c1-12
 }
 
-# The adapter files that ACTUALLY load for an agent, in agentcall's order.
-# ★ BOTH, when both exist. agentcall sources the shipped file and then the user
-# one, so hashing only the override describes half of what ran -- the same
-# partial-override shape that once left a shipped noprompt_ marker alive
-# underneath a user adapter that supported prompts.
+# The files agentcall would source that define anything for this agent, in
+# agentcall's own load order: the shipped dir first, then the user dir, each
+# glob-sorted, because content_sha is order-sensitive and so is sourcing.
+#
+# ★ BOTH copies of `<agent>.sh` when both exist. agentcall sources the shipped
+# file and then the user one, so hashing only the override describes half of
+# what ran -- the same partial-override shape that once left a shipped
+# noprompt_ marker alive underneath a user adapter that supported prompts.
+#
+# ★ And NOT only the files named after the agent. agentcall sources every *.sh
+# in both dirs into ONE namespace, so a `zzz.sh` defining run_<agent>() replaces
+# the shipped function while `<agent>.sh` is untouched -- a different reviewer,
+# an identical hash. Any file mentioning `_<agent>(` is counted in.
+# Over-inclusion is the safe direction here, the same way mention-crediting is
+# in coverage-per-changeset: a hash covering too much can only produce a false
+# "this changed", never a false "this is the same".
 adapter_files() {
-  local a="$1" d
+  local a="$1" d f
   for d in "$CADRE_ROOT/agents.d" "${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}"; do
-    if [ -f "$d/$a.sh" ]; then printf '%s\n' "$d/$a.sh"; fi
+    [ -d "$d" ] || continue
+    for f in "$d"/*.sh; do
+      [ -f "$f" ] || continue
+      if [ "$f" = "$d/$a.sh" ] || grep -qF "_$a(" "$f" 2>/dev/null; then
+        printf '%s\n' "$f"
+      fi
+    done
   done
 }
 
@@ -121,7 +155,15 @@ adapter_sha() {
 # an edit. Content, not revision.
 # sort, because find's order is filesystem-dependent and an unstable input order
 # would make the same tree hash differently on two machines.
-HARNESS_FILES=(lib/common.sh lib/run-review.sh lib/run-pass.sh lib/grade.sh)
+#
+# ★ bin/agentcall is IN. It is what actually spawns the CLI, and it decides
+# whether the brief arrives on stdin or in argv -- change it and every seat
+# receives something different while nothing else in the record moves.
+# ★ bin/cadre is deliberately OUT. It is the driver: argument parsing, the
+# report, `receipts`. Folding it in would invalidate every stored comparison on
+# any CLI edit, which is a false "these are not like-for-like" -- the one error
+# this field must not make, since its whole job is to be believed when it fires.
+HARNESS_FILES=(bin/agentcall lib/common.sh lib/run-review.sh lib/run-pass.sh lib/grade.sh)
 harness_sha() {
   local f files=()
   for f in "${HARNESS_FILES[@]}"; do files+=("$CADRE_ROOT/$f"); done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -60,6 +60,84 @@ slug() {
   printf '%s-%s' "$safe" "$h"
 }
 
+
+# ---- content identity (#37) --------------------------------------------------
+# ★ A benchmark whose inputs are not pinned is not reproducible, however careful
+# the grading is. `prompt_bytes` is a SIZE: two prompts that differ but happen to
+# be the same length are indistinguishable in the record, and CADRE_PROMPT_FILE
+# replaces the brief wholesale, so the input with the largest effect on a review
+# is the one the record described least. These hashes close that.
+#
+# Scope is PROVENANCE, not tamper-proofing. A local hash cannot stop anyone
+# editing the tree; it makes a comparison across an edit visible instead of
+# silent. docs/ASSURANCE_CASE.md says so where the guarantees are listed.
+#
+# ★ Never cksum as a substitute. It is already used for slug() where a collision
+# costs a filename, but a 32-bit CRC collides often enough that "same hash" would
+# stop meaning "same bytes" -- which is the only property these fields are for.
+# No sha256 tool on the box means EMPTY, which every consumer already reads as
+# unknown; a weaker hash under the same column name would read as measured.
+SHA_CMD=""
+if command -v sha256sum >/dev/null 2>&1; then SHA_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then SHA_CMD="shasum -a 256"
+fi
+
+# content_sha <file>... -- 12 hex chars over the files' bytes, concatenated in
+# the order given. EMPTY if any input is missing: a hash that silently describes
+# a subset is worse than none, because it compares equal to a run that had the
+# same subset for a different reason.
+content_sha() {
+  [ -n "$SHA_CMD" ] || return 0
+  local f
+  for f in "$@"; do [ -f "$f" ] || return 0; done
+  [ "$#" -gt 0 ] || return 0
+  # shellcheck disable=SC2086  # SHA_CMD may carry an argument (shasum -a 256)
+  cat -- "$@" | $SHA_CMD | cut -c1-12
+}
+
+# The adapter files that ACTUALLY load for an agent, in agentcall's order.
+# ★ BOTH, when both exist. agentcall sources the shipped file and then the user
+# one, so hashing only the override describes half of what ran -- the same
+# partial-override shape that once left a shipped noprompt_ marker alive
+# underneath a user adapter that supported prompts.
+adapter_files() {
+  local a="$1" d
+  for d in "$CADRE_ROOT/agents.d" "${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}"; do
+    if [ -f "$d/$a.sh" ]; then printf '%s\n' "$d/$a.sh"; fi
+  done
+}
+
+adapter_sha() {
+  local files=()
+  mapfile -t files < <(adapter_files "$1")
+  [ "${#files[@]}" -gt 0 ] || return 0
+  content_sha "${files[@]}"
+}
+
+# One hash over every harness file that shapes a review.
+# ★ `cadre:` in the manifest is a git short sha, and it says nothing at all
+# while lib/ is dirty -- which is the normal state of the tree whenever any of
+# this is being worked on, and exactly when a comparison is most likely to span
+# an edit. Content, not revision.
+# sort, because find's order is filesystem-dependent and an unstable input order
+# would make the same tree hash differently on two machines.
+HARNESS_FILES=(lib/common.sh lib/run-review.sh lib/run-pass.sh lib/grade.sh)
+harness_sha() {
+  local f files=()
+  for f in "${HARNESS_FILES[@]}"; do files+=("$CADRE_ROOT/$f"); done
+  while IFS= read -r f; do files+=("$f"); done \
+    < <(find "$CADRE_ROOT/lib/prompts" -type f -name '*.md' -print 2>/dev/null | LC_ALL=C sort)
+  content_sha "${files[@]}"
+}
+
+# ★ slots.tsv schema version, stamped on every row THIS harness writes (#20).
+# It describes the ROW, not the run: what the columns mean and which rule
+# produced them. A row without it is not "version 1", it is UNKNOWN -- rows
+# predating this column span the #19 change to what `secs` means on a failed
+# seat, and nothing on disk can tell those halves apart after the fact. That is
+# why `cadre receipts` groups by it instead of guessing a default.
+SLOTS_SCHEMA_V=2
+
 need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed"; }
 
 trim() { local s="$1"; s="${s#"${s%%[![:space:]]*}"}"; printf '%s' "${s%"${s##*[![:space:]]}"}"; }

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -22,7 +22,7 @@ REPO="${1:?usage: run-review.sh <repo> <base-rev> <out-dir> <jobs> <spec ...>}"
 BASE_REV="${2-}"
 MODE=diff; [ -n "$BASE_REV" ] || MODE=target
 OUT="${3:?need an out dir}"
-# ★ NOT `.log-*`, `.status-*` or `.len-*`. Those three globs are wiped at the
+# ★ NOT `.log-*`, `.status-*`, `.len-*` or `.sha-*`. Those four globs are wiped at the
 # bottom of this file, and a record that a cleanup line can match is a record
 # that will eventually be deleted by someone extending that line. The name is
 # the enforcement. Per-panel and under $OUT, because `cadre receipts` finds
@@ -411,6 +411,14 @@ else
   render_review_prompt "$CADRE_ROOT/lib/prompts/$BRIEF" "$BASE" "$TPL" "$PRERUN_FILE" > "$PROMPT"
 fi
 
+# ★ Frozen HERE, once, before a single seat is dispatched (#37). Recomputing per
+# seat would let a mid-panel edit land in half the rows and read as two seats
+# legitimately disagreeing about the harness, which is the opposite of what the
+# field is for. Same reasoning as docs/METHOD.md's refusal to edit lib/ mid-sweep,
+# made checkable instead of asked for.
+HARNESS_SHA=$(harness_sha)
+PROMPT_SHA=$(content_sha "$PROMPT")
+
 # ★ Capability preflight BEFORE any paid call. A seat whose adapter (or model)
 # has declared it cannot do this job is skipped loudly, not dispatched. Same
 # skipped-seat path as roster gates: slots.tsv status, report line, out of
@@ -463,6 +471,11 @@ unset _kept _spec _block _decl _reason
   # would split into rows that parse as other fields.
   [ -n "$PRERUN_FILE" ] && echo "prerun:    exit $PRERUN_RC | $(printf '%s' "$CADRE_PRERUN" | tr '\n' ' ')"
   echo "prompt:    $(cksum < "$PROMPT" | cut -d' ' -f1)"
+  # ★ Content, beside the revision, not instead of it. `cadre:` is a git sha and
+  # goes stale the moment lib/ is dirty; this one changes with the bytes. Kept
+  # here as well as on every row so a panel killed before slots.tsv was written
+  # still says which harness produced its artifacts.
+  echo "harness:   ${HARNESS_SHA:-unknown}"
   echo "cadre:     $(git -C "$CADRE_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 } > "$OUT/manifest.txt"
 
@@ -485,23 +498,36 @@ mapfile -t SCRUB < <(scrubbed_env)
 # measured, and record_event turns an empty numeric into `null`. Bytes come from
 # the artifact rather than any log line, so the number always describes the file
 # that is actually on disk.
+#
+# ★ The hashes are read from the DISPATCH scratch file, not recomputed here.
+# Recomputing would describe the tree as it stands after the seat finished,
+# which on a long panel is a different tree than the one that was reviewed --
+# and the whole point of the field is to make that difference visible.
+# They are STRINGS, not `#` numerics: EMPTY means "not determined" and must stay
+# an empty field, where a numeric null would print the same but claim a measure.
 record_complete() {  # <slug> <spec> <state> [rc] [secs]
-  local sl="$1" spec="$2" state="$3" rc="${4:-}" secs="${5:-}" art bytes
+  local sl="$1" spec="$2" state="$3" rc="${4:-}" secs="${5:-}" art bytes shaf
   art="$OUT/$sl.md"
   [ -s "$art" ] || art="$OUT/$sl.md.partial"
   [ -s "$art" ] || art="$OUT/$sl.md.inconclusive"
   [ -s "$art" ] || art="$OUT/$sl.md.failed"
   bytes=$(wc -c < "$art" 2>/dev/null | tr -d ' ')
+  shaf="$OUT/.sha-$sl"
   record_event "$RUNLOG" event=complete panel="$(basename "$OUT")" \
     seat="$spec" family="$(spec_family "$spec")" slug="$sl" \
     state="$state" "rc#=$rc" "secs#=$secs" "bytes#=${bytes:-0}" \
-    "prompt_bytes#=$(cat "$OUT/.len-$sl" 2>/dev/null)" "ts#=$(date +%s)"
+    "prompt_bytes#=$(cat "$OUT/.len-$sl" 2>/dev/null)" \
+    "v#=$SLOTS_SCHEMA_V" \
+    prompt_sha="$(sed -n 1p "$shaf" 2>/dev/null)" \
+    adapter_sha="$(sed -n 2p "$shaf" 2>/dev/null)" \
+    harness_sha="$HARNESS_SHA" "ts#=$(date +%s)"
 }
 
 run_one() {
   local spec="$1" idx="$2"
   local sl; sl=$(slug "$spec")
   local f="$OUT/$sl.md" log="$OUT/.log-$sl" st="$OUT/.status-$sl" len="$OUT/.len-$sl"
+  local shaf="$OUT/.sha-$sl"
   local agent model dir attempt=1 rc w start took
   agent=$(spec_agent "$spec"); model=$(spec_model "$spec")
 
@@ -510,6 +536,14 @@ run_one() {
   # prompt. Overwrite it at the dispatch site so adapter failures still retain
   # the exact prompt size after the scratch files disappear.
   echo 0 > "$len"
+  # ★ Line 1 prompt, line 2 adapter (#37). Written BEFORE the installed check,
+  # so a seat that never runs still records which adapter file was consulted --
+  # "the adapter is missing" and "the adapter is present and broken" are
+  # different facts and the row should not need the console to tell them apart.
+  # Line 1 stays EMPTY until dispatch: the prompt this seat is charged for is
+  # the one agentcall actually receives, and a promptless adapter never receives
+  # one at all.
+  printf '\n%s\n' "$(adapter_sha "$agent")" > "$shaf"
   # ★ Recorded BEFORE anything can go wrong, which is the entire reason the log
   # is append-only rather than assembled at the end: a panel killed here leaves
   # proof this seat was dispatched. Every `return` below has a matching
@@ -543,7 +577,16 @@ run_one() {
   start=$(date +%s)
   # Promptless adapters use their own contract; zero is the exact number of
   # shared-brief bytes they send to their provider.
-  if ! is_promptless "$agent"; then wc -c < "$PROMPT" | tr -d ' ' > "$len"; fi
+  if ! is_promptless "$agent"; then
+    wc -c < "$PROMPT" | tr -d ' ' > "$len"
+    # ★ EMPTY for a promptless adapter, never the hash of a prompt it did not
+    # get. `prompt_bytes` records a measured 0 there because zero shared-brief
+    # bytes really were sent; the identity of a prompt that was never dispatched
+    # is not zero, it is unknown, and a sha of the empty string would compare
+    # equal across every promptless seat as if they shared an input.
+    local asha; asha=$(sed -n 2p "$shaf" 2>/dev/null)
+    printf '%s\n%s\n' "$PROMPT_SHA" "$asha" > "$shaf"
+  fi
   while :; do
     "${SCRUB[@]}" CADRE_AGENTS_D="${CADRE_AGENTS_D:-$CADRE_HOME/agents.d}" \
       CADRE_PASS_BASE="$BASE" \
@@ -639,9 +682,16 @@ run_one() {
 # `secs` stays null, because nothing was timed.
 for row in "${skipped_rows[@]}"; do
   IFS=$'\t' read -r sk_spec _sk_gate _sk_reason <<< "$row"
+  # prompt_sha is EMPTY for the same reason prompt_bytes is a measured 0: the
+  # seat sent nothing, so there is no dispatched prompt to identify. The adapter
+  # and the harness are still recorded -- the gate that skipped it is a harness
+  # decision, and which version made it is exactly what a later reader asks.
   record_event "$RUNLOG" event=complete panel="$(basename "$OUT")" \
     seat="$sk_spec" family="$(spec_family "$sk_spec")" slug="$(slug "$sk_spec")" \
-    state=skipped "rc#=" "secs#=" "bytes#=0" "prompt_bytes#=0" "ts#=$(date +%s)"
+    state=skipped "rc#=" "secs#=" "bytes#=0" "prompt_bytes#=0" \
+    "v#=$SLOTS_SCHEMA_V" prompt_sha= \
+    adapter_sha="$(adapter_sha "$(spec_agent "$sk_spec")")" \
+    harness_sha="$HARNESS_SHA" "ts#=$(date +%s)"
 done
 
 i=0; running=0
@@ -809,14 +859,22 @@ slot_rows=$(
   # reasoning aggregate.sh gives for trusting the roster line over filenames.
   # A seat with no completion event prints `failed` with EMPTY secs: it did not
   # take zero seconds, it was never measured.
-  all_complete=$(record_rows "$RUNLOG" complete seat family state bytes secs prompt_bytes)
+  # ★ `v` is a CONSTANT here, not a field read back from the record (#20). It
+  # describes the ROW -- which columns these are and which rule wrote them --
+  # and this harness wrote every row below, including one for a seat that left
+  # no completion event at all. Reading it from the record would blank exactly
+  # that row and lose the provenance for the only row whose provenance is in
+  # question.
+  all_complete=$(record_rows "$RUNLOG" complete seat family state bytes secs prompt_bytes \
+                   prompt_sha adapter_sha harness_sha)
   for spec in "${reviewers[@]}"; do
     rec_row=$(printf '%s\n' "$all_complete" | awk -F '\t' -v s="$spec" '$1 == s { print; exit }')
     rec_row="${rec_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt <<< "$rec_row"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt r_psha r_asha r_hsha <<< "$rec_row"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
       "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
-      "${r_state:-failed}" "${r_bytes:-0}" "$r_secs" "$r_prompt"
+      "${r_state:-failed}" "${r_bytes:-0}" "$r_secs" "$r_prompt" \
+      "$SLOTS_SCHEMA_V" "$r_psha" "$r_asha" "${r_hsha:-$HARNESS_SHA}"
   done
   # Skipped seats come from the same stream, for the same reason: one source, so
   # a change to how spend is recorded cannot land in one renderer and not the
@@ -826,10 +884,11 @@ slot_rows=$(
     IFS=$'\t' read -r spec _gate _reason <<< "$row"
     rec_row=$(printf '%s\n' "$all_complete" | awk -F '\t' -v s="$spec" '$1 == s { print; exit }')
     rec_row="${rec_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt <<< "$rec_row"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt r_psha r_asha r_hsha <<< "$rec_row"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
       "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
-      "${r_state:-skipped}" "${r_bytes:-0}" "$r_secs" "${r_prompt:-0}"
+      "${r_state:-skipped}" "${r_bytes:-0}" "$r_secs" "${r_prompt:-0}" \
+      "$SLOTS_SCHEMA_V" "$r_psha" "$r_asha" "${r_hsha:-$HARNESS_SHA}"
   done
 )
 printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
@@ -848,7 +907,7 @@ printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
     # Tabs are IFS whitespace, so plain `read` collapses the empty secs field in
     # a skipped row. Translate to a non-whitespace delimiter before splitting.
     slot_row="${slot_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _run spec _fam st bytes secs prompt_bytes <<< "$slot_row"
+    IFS=$'\034' read -r _run spec _fam st bytes secs prompt_bytes _v _psha _asha _hsha <<< "$slot_row"
     prompt_kb=""
     if [ -n "${prompt_bytes:-}" ]; then
       prompt_kb=$(awk -v n="$prompt_bytes" 'BEGIN { printf "%.1f", n / 1024 }')
@@ -872,7 +931,7 @@ printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
   echo "> Estimated as bytes/4 of what the harness sent and received. Hidden reasoning tokens are invisible from outside the CLI and are NOT in this number: a seat that thinks long and answers short costs more than its row shows. This is a relative-spend signal, not a bill."
 } >> "$REPORT"
 
-rm -f "$OUT"/.log-* "$OUT"/.status-* "$OUT"/.len-*
+rm -f "$OUT"/.log-* "$OUT"/.status-* "$OUT"/.len-* "$OUT"/.sha-*
 echo
 skipped_count=${#skipped_rows[@]}
 if [ "$skipped_count" -gt 0 ]; then

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -1951,6 +1951,54 @@ check "sha: order changes the hash"  "[ \"\$(content_sha '$CS/a' '$CS/b')\" != \
 # reason, so it reads as agreement where there is none.
 check "sha: a missing input is EMPTY" "[ -z \"\$(content_sha '$CS/a' '$CS/nope')\" ]"
 check "sha: no input at all is EMPTY" "[ -z \"\$(content_sha)\" ]"
+# ★ The worst shape this function can produce is not a missing value, it is a
+# CONFIDENT one. The first cut piped `cat -- "$@"` into sha256sum: cat printed
+# "Permission denied" to stderr, the pipe exited 0, and the digest of NOTHING
+# came back -- e3b0c44298fc, which is STABLE, so two runs that both failed to
+# read an input compared EQUAL. Every happy-path check above passed while that
+# held; a second-opinion reviewer found it.
+printf 'secret' > "$CS/locked"; chmod 000 "$CS/locked"
+check "sha: an unreadable input is EMPTY" "[ -z \"\$(content_sha '$CS/locked' 2>/dev/null)\" ]"
+check "sha: never the digest of nothing"  "! content_sha '$CS/locked' 2>/dev/null | grep -q e3b0c44298fc"
+check "sha: a directory is EMPTY"         "[ -z \"\$(content_sha '$CS' 2>/dev/null)\" ]"
+chmod 644 "$CS/locked"
+# ★ Concatenating raw bytes has no field boundary, so '#a' + 'x=1' and '#' +
+# 'ax=1' are both '#ax=1' and hash IDENTICALLY -- two adapter sets that source
+# to different code, reported as one input. Hashing the per-file digests gives
+# every file a fixed-width block that cannot run into its neighbour.
+printf '#a' > "$CS/c1"; printf 'x=1' > "$CS/c2"; printf '#' > "$CS/c3"; printf 'ax=1' > "$CS/c4"
+check "sha: file boundaries are kept" \
+  "[ \"\$(content_sha '$CS/c1' '$CS/c2')\" != \"\$(content_sha '$CS/c3' '$CS/c4')\" ]"
+
+# ---- what the harness hash covers (#37) --------------------------------------
+# ★ bin/agentcall is what spawns the CLI and decides whether the brief arrives
+# on stdin or in argv. Left out of the set, an agentcall edit changes what every
+# seat receives while prompt_sha, adapter_sha and harness_sha all hold still.
+check "harness: agentcall is hashed"     "printf '%s\n' \"\${HARNESS_FILES[@]}\" | grep -qx 'bin/agentcall'"
+# ★ ...and bin/cadre is deliberately NOT. It is the driver -- argument parsing,
+# the report, receipts -- and folding it in would invalidate every stored
+# comparison on any CLI edit. A field whose whole job is to be believed when it
+# fires must not fire on that.
+check "harness: bin/cadre is left out"   "! printf '%s\n' \"\${HARNESS_FILES[@]}\" | grep -qx 'bin/cadre'"
+check "harness: every named file exists" "for f in \"\${HARNESS_FILES[@]}\"; do [ -f '$ROOT'/\$f ] || exit 1; done"
+
+# ---- the adapter namespace, not just the adapter file (#37) ------------------
+# ★ agentcall sources EVERY *.sh in both dirs into ONE namespace, so a foreign
+# `zzz.sh` defining run_<agent>() replaces the shipped function while
+# <agent>.sh is byte-identical: a different reviewer behind an unchanged hash.
+# The per-adapter check further up passed the entire time this was live.
+AD=$(mktemp -d -p "$SANDBOX"); mkdir -p "$AD/agents.d"
+printf 'run_probe() { echo shipped; }\n' > "$AD/agents.d/probe.sh"
+ASHA_BASE=$(CADRE_ROOT="$ROOT" CADRE_AGENTS_D="$AD/agents.d" adapter_sha probe)
+printf 'run_probe() { echo hijacked; }\n' > "$AD/agents.d/zzz.sh"
+ASHA_HIJ=$(CADRE_ROOT="$ROOT" CADRE_AGENTS_D="$AD/agents.d" adapter_sha probe)
+check "adapter hash sees a foreign override" "[ -n '$ASHA_BASE' ] && [ '$ASHA_BASE' != '$ASHA_HIJ' ]"
+# ★ ...and stays put for an adapter that cannot touch this seat. Hashing the
+# whole directory would close the hole above and break this, which is why
+# membership is "mentions _<agent>(" rather than "is in agents.d".
+printf 'run_other() { echo unrelated; }\n' > "$AD/agents.d/zzz.sh"
+ASHA_OTHER=$(CADRE_ROOT="$ROOT" CADRE_AGENTS_D="$AD/agents.d" adapter_sha probe)
+check "and ignores an unrelated adapter"     "[ '$ASHA_BASE' = '$ASHA_OTHER' ]"
 
 RJ=$(mktemp -d -p "$SANDBOX"); RL="$RJ/runs.jsonl"
 record_event "$RL" event=complete seat='codex:gpt-5.5' "secs#=12" "rc#=0"
@@ -2116,6 +2164,21 @@ check "harness: both are named"        "grep -q '111111111111, 222222222222' <<<
 printf 'r3\tc\topenai\tok\t10\t1\t10\t2\tpppppppppppp\taaaaaaaaaaaa\t111111111111\n' > "$RF/harness/slots.tsv"
 OUT=$(run_cadre "$D" receipts "$RF/harness")
 check "harness: agreement is stated"   "grep -q 'every row ran against 111111111111' <<<\"\$OUT\""
+
+# ★ receipts takes ANY directory, and a stale `cadre dataset` output dir is a
+# directory. The dataset written by the old lib/aggregate.sh puts `source` in
+# column 8 -- exactly where the schema version now lives -- so `recorded` and
+# `reconstructed` came back as two schema NAMES and split every family in the
+# table. Column 8 is a version only when it reads as one.
+mkdir -p "$RF/olddataset"
+printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tsource\n' > "$RF/olddataset/slots.tsv"
+printf 'p1\tc\topenai\tok\t100\t2\t200\trecorded\n' >> "$RF/olddataset/slots.tsv"
+printf 'p2\tc\topenai\tok\t100\t\t\treconstructed\n' >> "$RF/olddataset/slots.tsv"
+OUT=$(run_cadre "$D" receipts "$RF/olddataset")
+check "olddata: one row, not one per source"  "[ \$(awk '\$1 == \"openai\"' <<<\"\$OUT\" | wc -l) -eq 1 ]"
+check "olddata: the schema reads unknown"     "awk '\$1 == \"openai\" && \$13 == \"?\" { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "olddata: a source word is never a schema" "! awk '\$13 == \"recorded\" || \$13 == \"reconstructed\" { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "olddata: both rows still counted"      "awk '\$1 == \"openai\" && \$3 == 2 { f=1 } END { exit !f }' <<<\"\$OUT\""
 
 echo "== ★ settled-decisions ledger =="
 # ★ The loop-breaker. Cadre reviews once, but anything that WRAPS it re-raises

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -423,7 +423,7 @@ OUT=$(run_cadre "$D" review --roster 'good ?min-lines=2' --base main "$S"); RC=$
 R="$D/state/reviews/$(ls "$D/state/reviews" | head -1)"
 check "gate: below threshold exits clean" "[ $RC -eq 0 ]"
 check "gate: skip is loud in report"      "grep -qF -- '- \`good\` — SKIPPED by its roster gate (?min-lines=2: diff is 1 lines).' '$R/report.md'"
-check "gate: skipped slot has zero spend" "grep -qP '\tgood\t.*\tskipped\t0\t\t0\$' '$R/slots.tsv'"
+check "gate: skipped slot has zero spend" "grep -qP '\tgood\t.*\tskipped\t0\t\t0\t2\t' '$R/slots.tsv'"
 check "gate: receipt keeps empty seconds"  "grep -qF '| \`good\` | skipped |  | 0.0 | 0.0 | 0 |' '$R/report.md'"
 check "gate: console counts the skip"      "grep -q '0 ok, 0 degraded, 0 inconclusive, 0 failed, 1 skipped' <<<\"\$OUT\""
 check "gate: no prompt reached the seat"   "[ ! -e '$R/good.md' ]"
@@ -506,7 +506,7 @@ R="$D/state/reviews/$(ls "$D/state/reviews" | head -1)"
 check "cap: blocked seat exits clean"   "[ $RC -eq 0 ]"
 check "cap: skip names declaration"     "grep -qF -- '- \`refuses\` — SKIPPED by capability preflight (role:reviewer:' '$R/report.md'"
 check "cap: reason is in the report"    "grep -q 'declared unable to serve as a reviewer' '$R/report.md'"
-check "cap: skipped slot has zero spend" "grep -qP '\trefuses\t.*\tskipped\t0\t\t0\$' '$R/slots.tsv'"
+check "cap: skipped slot has zero spend" "grep -qP '\trefuses\t.*\tskipped\t0\t\t0\t2\t' '$R/slots.tsv'"
 check "cap: no prompt reached the seat" "[ ! -e '$R'/refuses-*.md ] && [ -z \"\$(ls '$R'/refuses-* 2>/dev/null)\" ]"
 check "cap: sibling seat still ran"     "grep -qP '\tgood\t.*\tok\t' '$R/slots.tsv'"
 check "cap: console counts the skip"    "grep -q '1 ok, 0 degraded, 0 inconclusive, 0 failed, 1 skipped' <<<\"\$OUT\""
@@ -541,7 +541,7 @@ OUT=$(CADRE_STACK='Please run a full security audit of this codebase for vulnera
   run_cadre "$D" review --roster audithate --label audit2 --base main "$S")
 R="$D/state/reviews/audit2"
 check "cap: audit-shaped stack blocks" "grep -qF 'SKIPPED by capability preflight (prompt:security-audit:' '$R/report.md'"
-check "cap: audit skip in slots.tsv"   "grep -qP '\taudithate\t.*\tskipped\t0\t\t0\$' '$R/slots.tsv'"
+check "cap: audit skip in slots.tsv"   "grep -qP '\taudithate\t.*\tskipped\t0\t\t0\t2\t' '$R/slots.tsv'"
 
 # Model-keyed: cerebras/* is role:reviewer-only. Any adapter:cerebras/... is
 # blocked as a reviewer and accepted as a judge.
@@ -1882,7 +1882,7 @@ check "it survives the cleanup"     "[ ! -e '$R/.status-good' ]"
 check "one row per roster seat"     "[ \$(wc -l < '$R/slots.tsv') -eq 2 ]"
 check "a good seat is ok"           "grep -qP '\tgood\t.*\tok\t' '$R/slots.tsv'"
 check "a dead seat is failed"       "grep -qP '\tdead\t.*\tfailed\t' '$R/slots.tsv'"
-check "timing and prompt captured"  "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*\$' '$R/slots.tsv'"
+check "timing and prompt captured"  "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*\t2\t' '$R/slots.tsv'"
 # ★ CHANGED with #2, deliberately. A failed seat used to carry EMPTY secs, and
 # not because anything decided it should: the old reconstruction grepped the
 # console log for "in Ns", the failure line says "after Ns", the pattern missed,
@@ -1891,9 +1891,9 @@ check "timing and prompt captured"  "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*
 # then failed cost exactly that much -- dropping it understated real spend.
 # The empty-is-not-zero rule still holds where it is true; the seat that was
 # never timed at all is asserted below.
-check "failed seat keeps its prompt"  "grep -qP '\tfailed\t[0-9]+\t[0-9]*\t[1-9][0-9]*\$' '$R/slots.tsv'"
+check "failed seat keeps its prompt"  "grep -qP '\tfailed\t[0-9]+\t[0-9]*\t[1-9][0-9]*\t2\t' '$R/slots.tsv'"
 check "failed seat's time is measured, not blank" \
-  "grep -qP '\tfailed\t[0-9]+\t[0-9]+\t[1-9][0-9]*\$' '$R/slots.tsv'"
+  "grep -qP '\tfailed\t[0-9]+\t[0-9]+\t[1-9][0-9]*\t2\t' '$R/slots.tsv'"
 check "report has receipt table"    "grep -qF '| seat | status | secs | prompt KB | review KB | est. tokens |' '$R/report.md'"
 check "receipt caveat is explicit" "grep -qF '> Estimated as bytes/4 of what the harness sent and received. Hidden reasoning tokens are invisible from outside the CLI and are NOT in this number: a seat that thinks long and answers short costs more than its row shows. This is a relative-spend signal, not a bill.' '$R/report.md'"
 # ★ A seat that produced NO artifact must still appear. Deriving rows from
@@ -1909,11 +1909,49 @@ check "no seat vanishes from Receipts too" \
 check "Receipts names the same seats as slots.tsv" \
   "grep -q '^| .good. |' '$R/report.md' && grep -q '^| .dead. |' '$R/report.md'"
 
+# ---- input provenance on every row (#37) -------------------------------------
+# ★ `prompt_bytes` is a SIZE. Two prompts that differ and happen to be the same
+# length are one row in the record, and CADRE_PROMPT_FILE replaces the brief
+# wholesale -- so the single input with the largest effect on a review was the
+# one the record described least. Three content hashes close it: the rendered
+# prompt, the adapter that ran, and the harness that dispatched.
+check "row carries a prompt hash"   "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*\t2\t[0-9a-f]{12}\t' '$R/slots.tsv'"
+check "row carries an adapter hash" "[ \$(cut -f10 '$R/slots.tsv' | grep -cE '^[0-9a-f]{12}\$') -eq 2 ]"
+check "row carries a harness hash"  "[ \$(cut -f11 '$R/slots.tsv' | grep -cE '^[0-9a-f]{12}\$') -eq 2 ]"
+# One panel dispatches one prompt from one harness, so those two columns have to
+# agree across seats. If they ever do not, the panel is not the comparison it
+# says it is, and that is the whole reason the fields exist.
+check "one prompt hash for the panel"  "[ \$(cut -f9  '$R/slots.tsv' | sort -u | wc -l) -eq 1 ]"
+check "one harness hash for the panel" "[ \$(cut -f11 '$R/slots.tsv' | sort -u | wc -l) -eq 1 ]"
+# ★ ...and the adapter column must NOT agree. Two different adapter files
+# produced these two rows; a hash that collapses them is hashing something else,
+# which is the failure a size-based field already had.
+check "adapter hash is per adapter"    "[ \$(cut -f10 '$R/slots.tsv' | sort -u | wc -l) -eq 2 ]"
+check "manifest names the harness too" "grep -qE '^harness:   [0-9a-f]{12}\$' '$R/manifest.txt'"
+check "the record carries the hashes"  "grep -qE '\"harness_sha\":\"[0-9a-f]{12}\"' '$R/runs.jsonl'"
+check "and the schema version"         "grep -q '\"v\":2' '$R/runs.jsonl'"
+
 # ---- record writer/reader units (#2) ----------------------------------------
 # ★ Hand-rolled JSON, so the escaping is the risk. Every one of these is a way a
 # single malformed line silently becomes a wrong FIELD rather than a parse
 # error -- which is worse than the prose-grepping it replaced, because a wrong
 # field looks measured.
+# ---- content_sha unit (#37) --------------------------------------------------
+CS=$(mktemp -d -p "$SANDBOX")
+printf 'alpha' > "$CS/a"; printf 'beta' > "$CS/b"
+check "sha: same bytes, same hash"   "[ \"\$(content_sha '$CS/a')\" = \"\$(content_sha '$CS/a')\" ]"
+check "sha: different bytes differ"  "[ \"\$(content_sha '$CS/a')\" != \"\$(content_sha '$CS/b')\" ]"
+check "sha: it is 12 hex chars"      "printf '%s' \"\$(content_sha '$CS/a')\" | grep -qE '^[0-9a-f]{12}\$'"
+# ★ Order is part of the identity, which is why harness_sha sorts its file list:
+# find's order is filesystem-dependent, so an unsorted input would hash the same
+# tree differently on two machines and manufacture a harness split.
+check "sha: order changes the hash"  "[ \"\$(content_sha '$CS/a' '$CS/b')\" != \"\$(content_sha '$CS/b' '$CS/a')\" ]"
+# ★ EMPTY, never a hash of whichever inputs happened to exist. A partial-set
+# hash compares EQUAL to another run that lost the same file for an unrelated
+# reason, so it reads as agreement where there is none.
+check "sha: a missing input is EMPTY" "[ -z \"\$(content_sha '$CS/a' '$CS/nope')\" ]"
+check "sha: no input at all is EMPTY" "[ -z \"\$(content_sha)\" ]"
+
 RJ=$(mktemp -d -p "$SANDBOX"); RL="$RJ/runs.jsonl"
 record_event "$RL" event=complete seat='codex:gpt-5.5' "secs#=12" "rc#=0"
 check "rec: seat with a colon survives" \
@@ -2018,7 +2056,7 @@ rm -f "$R/slots.tsv"
 OUT=$(run_cadre "$D" dataset "$D/dataset" 2>&1)
 check "aggregate walks the reviews" "[ -s '$D/dataset/slots.tsv' ]"
 check "it reconstructs the panel"   "grep -q reconstructed '$D/dataset/slots.tsv'"
-check "unknown measures stay empty" "grep -qP '\t[0-9]+\t\t\treconstructed\$' '$D/dataset/slots.tsv'"
+check "unknown measures stay empty" "grep -qP '\t[0-9]+\t\t\t\t\t\t\treconstructed\$' '$D/dataset/slots.tsv'"
 # ★ Explicitly: NOT zeroes. A reconstructed row has neither measurement, and
 # writing 0 would average like a real value and drag every mean toward the floor.
 check "never a fabricated sec zero" "! grep -qP '\t0\t\treconstructed\$' '$D/dataset/slots.tsv'"
@@ -2031,7 +2069,7 @@ mkdir -p "$D/state/reviews/ds-skip"
 printf 'ds-skip\tgood\tstub-good\tok\t100\t1\t100\nds-skip\tgood2\tstub-good2\tskipped\t0\t\t0\n' > "$D/state/reviews/ds-skip/slots.tsv"
 printf 'base-tree: aaaaaaaa11111111\nreviewed-tree: bbbbbbbb22222222\n' > "$D/state/reviews/ds-skip/manifest.txt"
 OUT=$(run_cadre "$D" dataset "$D/dataset" 2>&1)
-check "aggregate keeps skipped slot row" "grep -qP 'ds-skip\tgood2\t.*\tskipped\t0\t\t0\trecorded\$' '$D/dataset/slots.tsv'"
+check "aggregate keeps skipped slot row" "grep -qP 'ds-skip\tgood2\t.*\tskipped\t0\t\t0\t\t\t\t\trecorded\$' '$D/dataset/slots.tsv'"
 check "aggregate excludes skip from seats" "grep -qP 'ds-skip\t\S+\t1\t1\t0\t0\t0\t' '$D/dataset/panels.tsv'"
 
 RF="$D/receipt-fixtures"
@@ -2046,6 +2084,38 @@ printf 'oldrun\tlegacy\tlegacy\tok\t400\t5\n' > "$RF/old/slots.tsv"
 OUT=$(run_cadre "$D" receipts "$RF/old" 2>&1); RC=$?
 check "old receipts do not crash"    "[ '$RC' -eq 0 ]"
 check "old prompt spend is named"    "grep -q '1 rows predate prompt-byte capture; their prompt spend is not counted.' <<<\"\$OUT\""
+
+# ★ #20: ONE family, TWO slots.tsv schemas. `secs` changed meaning for a failed
+# seat -- it used to be blank, it is now the measured seconds -- and neither
+# value is wrong, so the per-schema totals are not wrong either. A single total
+# over both is the thing nobody can interpret. Nothing is dropped: the rows are
+# listed separately, which is both the refusal to average and the notice.
+mkdir -p "$RF/mixed"
+printf 'r1\tcodex:a\topenai\tok\t1024\t7\t2048\n' > "$RF/mixed/slots.tsv"
+printf 'r2\tcodex:a\topenai\tok\t1024\t9\t2048\t2\tdeadbeefcafe\taaaaaaaaaaaa\tbbbbbbbbbbbb\n' >> "$RF/mixed/slots.tsv"
+OUT=$(run_cadre "$D" receipts "$RF/mixed")
+check "mixed: one row per schema"    "[ \$(awk '\$1 == \"openai\"' <<<\"\$OUT\" | wc -l) -eq 2 ]"
+check "mixed: nothing is dropped"    "[ \$(awk '\$1 == \"openai\" { n += \$3 } END { print n+0 }' <<<\"\$OUT\") -eq 2 ]"
+# The number this whole issue exists to prevent: 7 + 9 printed as one SECS cell.
+check "mixed: the two secs never merge" "! awk '\$1 == \"openai\" && \$9 == 16 { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "mixed: an old row says unknown"  "awk '\$1 == \"openai\" && \$13 == \"?\" { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "mixed: a new row names its schema" "awk '\$1 == \"openai\" && \$13 == 2 { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "mixed: the boundary is said out loud" "grep -q 'Those rows are NOT comparable' <<<\"\$OUT\""
+check "mixed: pre-#19 panels still read"     "awk '\$1 == \"openai\" && \$13 == \"?\" && \$9 == 7 { f=1 } END { exit !f }' <<<\"\$OUT\""
+check "mixed: an unhashed row is counted"    "grep -q 'Harness: 1 row(s) name none' <<<\"\$OUT\""
+
+# ★ #37: a comparison spanning two harnesses is not like-for-like, and the
+# AGREEMENT case prints too. An absent warning is indistinguishable from a check
+# that never ran, and this line is the only place harness identity surfaces.
+mkdir -p "$RF/harness"
+printf 'r1\tc\topenai\tok\t10\t1\t10\t2\tpppppppppppp\taaaaaaaaaaaa\t111111111111\n' > "$RF/harness/slots.tsv"
+printf 'r2\tc\topenai\tok\t10\t1\t10\t2\tpppppppppppp\taaaaaaaaaaaa\t222222222222\n' >> "$RF/harness/slots.tsv"
+OUT=$(run_cadre "$D" receipts "$RF/harness")
+check "harness: a split is called out" "grep -q 'span 2 versions' <<<\"\$OUT\""
+check "harness: both are named"        "grep -q '111111111111, 222222222222' <<<\"\$OUT\""
+printf 'r3\tc\topenai\tok\t10\t1\t10\t2\tpppppppppppp\taaaaaaaaaaaa\t111111111111\n' > "$RF/harness/slots.tsv"
+OUT=$(run_cadre "$D" receipts "$RF/harness")
+check "harness: agreement is stated"   "grep -q 'every row ran against 111111111111' <<<\"\$OUT\""
 
 echo "== ★ settled-decisions ledger =="
 # ★ The loop-breaker. Cadre reviews once, but anything that WRAPS it re-raises


### PR DESCRIPTION
Closes #37. Closes #20.

Two halves of one gap: a row that does not say what produced it. `#37` is the
inputs, `#20` is the rule that filled the columns. They land together because
both add columns to `slots.tsv` and doing that twice is worse than once.

## #37 — content hashes for the prompt, the adapter, and the harness

Three new columns on every `slots.tsv` row and three new fields on every
`complete` record: `prompt_sha`, `adapter_sha`, `harness_sha`, 12 hex each.

- **`prompt_bytes` is a size.** Two prompts that differ and happen to be the
  same length were indistinguishable in the record, and `CADRE_PROMPT_FILE`
  replaces the brief wholesale — so the single input with the largest effect on
  a review was the one the record described least.
- **`adapter_sha` hashes BOTH files when both exist.** `agentcall` sources the
  shipped adapter and then the user override, so hashing only the override
  describes half of what ran. Same partial-override shape that once left a
  shipped `noprompt_` marker alive underneath an adapter that supported prompts.
- **`harness_sha`** covers `bin/agentcall`, `lib/common.sh`, `lib/run-review.sh`,
  `lib/run-pass.sh`, `lib/grade.sh` and `lib/prompts/*`. `bin/cadre` is
  deliberately out — folding the driver in would invalidate every stored
  comparison on any CLI edit. The manifest's existing
  `cadre:` line is a git short sha and says nothing while `lib/` is dirty —
  which is the normal state of the tree whenever any of this is being worked on,
  and exactly when a comparison is most likely to span an edit. A `harness:`
  line joins it in the manifest so a panel killed before `slots.tsv` was written
  still names its harness.

**Frozen at dispatch, not recomputed at completion.** The harness hash is
computed once before the first seat goes out; the per-seat pair is written to
`.sha-<slug>` beside `.len-<slug>`. Recomputing at completion would describe the
tree as it stands *after* a long panel, which is precisely the difference the
field exists to make visible — the checkable version of METHOD.md's refusal to
edit `lib/` mid-sweep.

**EMPTY, never zero and never faked**, matching the `prompt_bytes` precedent:
a reconstructed row, a promptless adapter that received no shared brief, or a
box with neither `sha256sum` nor `shasum`. `content_sha` also returns EMPTY if
*any* input is missing — a hash over the subset that happened to exist compares
EQUAL to a run that lost the same file for an unrelated reason, so it reads as
agreement where there is none. `harness_sha` sorts its file list, because
`find`'s order is filesystem-dependent and an unstable input order would
manufacture a harness split between two machines.

Never `cksum`. It is already used for `slug()`, where a collision costs a
filename; a 32-bit CRC collides often enough that "same hash" would stop meaning
"same bytes", which is the only property these fields are for.

`cadre receipts` states harness agreement **on both branches** — agreement and
disagreement. An absent warning is indistinguishable from a check that never
ran, and this line is the only place a comparison's harness identity surfaces.

## #20 — receipts cannot average across a schema change

Rows carry the schema version that wrote them (`v`, currently `2`), and
`cadre receipts` groups by **(family, SCHEMA)** instead of by family.

`#19` changed what `secs` means for a failed seat: blank before, measured
seconds now. Neither value is wrong, so neither per-schema total is wrong — one
total over both is. Splitting the row is the strongest available answer: there
is no unqualified number to misread, and a family listed twice is itself the
notice. Nothing is dropped, so pre-`#19` panels stay readable, which is the
other half of the ask.

A row with no version column prints `?`, never a default. Those rows straddle
the change and nothing on disk separates the halves after the fact.

`v` is a **constant** in the row writer, not a field read back from the record.
It describes the ROW, and this harness wrote every row below — including one for
a seat that left no completion event at all. Reading it from the record would
blank exactly the row whose provenance is in question.

```
FAMILY       RUNS SEATS   OK ...     SECS  PROMPT_KB  REVIEW_KB EST. TOKENS  SCHEMA
openai          1     1    1 ...        7        2.0        1.0         768       ?
openai          1     1    1 ...        9        2.0        1.0         768       2
anthropic       1     1    1 ...        4        1.0        0.9         475       2

Listed on more than one row, one per slots.tsv schema: openai.
Those rows are NOT comparable and were not added together. Schema ? predates the
column and spans the change to what a failed seat's SECS means.

Harness: every row that names one ran against bbbbbbbbbbbb.
Harness: 1 row(s) name none, so whether they match the rest is unknown.
```

## ⚠️ One correction to #20's own text

`#20`'s Notes say *"a `v` field is already written on every record line, so the
version that produced a row is recoverable for anything written after #19."*
**It is not.** There is no `v` anywhere in `record_event`'s callers on `main` —
checked before building. So the field had to be created here rather than
consumed, which is a scope increase over what the issue describes and the reason
`v` lands on `runs.jsonl` as well as on `slots.tsv`.

## Schema, and who reads it positionally

`slots.tsv` (panel):

    panel  slot  family  status  bytes  secs  prompt_bytes  v  prompt_sha  adapter_sha  harness_sha

Columns 1–7 are unchanged and both positional readers were checked:
`cmd_receipts` guards `NF < 5` / `NF < 7`, and `lib/aggregate.sh` re-projects
`$2..$7` explicitly. The dataset `slots.tsv` gains the same four columns before
`source`, and `aggregate.sh`'s own row reader was widened to match — only `$1`
and `$4` are used there, and both sit ahead of the first field that can be
empty, which matters because tab is IFS whitespace and a plain `read` collapses
the empty runs further right.

A panel written before these columns simply has no `$8..$11`; awk yields EMPTY
for each, which is the right answer and the one receipts groups on. Nothing
backfills them.

## Scope, named

Provenance, **not** tamper-proofing. The hashes are computed by the same tree
they describe, so anyone who can edit `lib/` can edit what gets hashed. What
they buy is that a comparison spanning an edit becomes visible instead of
silent. Written down as a non-goal in `docs/ASSURANCE_CASE.md` (plus claims 12
and 13) so the guarantee is not oversold, and documented per column in
`docs/DATASET.md`.

## Tests

`tests/review-smoke.sh` **1024 pass, 0 fail** (985 on `main`, 39 new).
`tests/engine-seam.sh` **37 pass, 0 fail**.

Eight existing assertions were end-anchored on the 7-column shape and now assert
the `v` column instead of `$` — they were updated, not relaxed.

New coverage, the ones that actually discriminate:

- `adapter hash is per adapter` — two different adapter files must NOT collapse
  to one hash; the prompt and harness columns must agree across seats in one
  panel.
- `sha: a missing input is EMPTY` and `sha: order changes the hash`.
- `mixed: the two secs never merge` — the exact number this issue exists to
  prevent, `7 + 9` printed as one SECS cell, asserted absent.
- `mixed: pre-#19 panels still read` — the old rows are present and correct, not
  excluded.
- `harness: a split is called out` / `harness: agreement is stated` — both
  branches of the harness check.


---

## Update — five defects found and fixed after the first push (`91cb2b5`)

A Codex read-only second opinion on this diff found five, all reproduced, none
caught by the 26 tests written with the feature. Full detail, with repros, is in
[the review comment](#issuecomment-5474015795). Summary:

| | Defect | Fix |
|---|---|---|
| 1 | `content_sha` returned `e3b0c44298fc` — the *stable* digest of nothing — when an input could not be read, so two failed runs compared EQUAL | `-r` check, `pipefail` in the substitution, empty digest refused |
| 2 | Concatenated bytes have no field boundary: `#a`+`x=1` and `#`+`ax=1` hashed identically | hash the per-file digests, fixed-width blocks |
| 3 | `adapter_sha` missed a foreign `zzz.sh` defining `run_<agent>()` — `agentcall` sources every `*.sh` into one namespace | membership = files that define anything for this agent |
| 4 | `bin/agentcall` was not in `HARNESS_FILES`, though it decides stdin-vs-argv delivery | added; `bin/cadre` pinned out |
| 5 | `receipts` read column 8 as a schema version, so an old dataset's `source` column split every family into schemas named `recorded`/`reconstructed` | column 8 is a version only when it reads as one |

⚠️ **Claim 12 in `docs/ASSURANCE_CASE.md` was false as written** by defect 1 —
it promised "EMPTY, never zero and never faked". Corrected in place, not
appended to.
