### PR TITLE
Record the model that actually served a claudecr seat (#51)

### DIFF
--- a/agents.d/claudecr.sh
+++ b/agents.d/claudecr.sh
@@ -125,29 +125,43 @@ run_claudecr() {
   # Anything that is not the result object passes through untouched: an older
   # CLI printing plain text, a box without jq. The model field stays EMPTY then,
   # which is the truth -- it was not determined.
+  local err sub
   if command -v jq >/dev/null 2>&1 \
      && printf '%s' "$out" | jq -e 'type == "object" and has("result")' >/dev/null 2>&1; then
     models=$(printf '%s' "$out" | jq -r '(.modelUsage // {}) | keys | join(",")' 2>/dev/null)
     [ -n "$models" ] && cadre_model "$models"
+    err=$(printf '%s' "$out" | jq -r '.is_error // false')
+    sub=$(printf '%s' "$out" | jq -r '.subtype // "success"')
     out=$(printf '%s' "$out" | jq -r '.result // ""')
+    # ★ The object carries its own verdict: an error that exited 0 is still an
+    # error, and its text -- a usage-window notice, say -- must not be read as
+    # a review that happens to lack findings.
+    if [ "$rc" -eq 0 ] && { [ "$err" = true ] || [ "$sub" != success ]; }; then rc=1; fi
   fi
-  [ -s "$errf" ] && out="$out"$'\n'"$(cat "$errf")"
-  rm -f "$errf"
+  # ★ Empty/partial is judged on what the CLI RETURNED, never on its stderr:
+  # a diagnostic line on a clock kill is not a partial review.
+  local diag=""; [ -s "$errf" ] && diag=$(cat "$errf"); rm -f "$errf"
   if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
     # Whatever arrived before the kill is a review, cut short: the partial
     # contract, same as codex.sh and grok.sh. Nonzero as well as the marker.
     if [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+      [ -n "$diag" ] && printf '%s\n' "$diag"
       printf '%s\n\n' "$out"
       echo "_TRUNCATED, claudecr:$level was killed at the ${TIMEOUT}s timeout; this review is INCOMPLETE, not a clean pass. Raise CADRE_TIMEOUT; high and xhigh run subagents and take longer._"
     else
       echo "DID NOT COMPLETE, claudecr:$level was killed at the ${TIMEOUT}s timeout with no output. Raise CADRE_TIMEOUT; high and xhigh run subagents and take longer."
+      [ -n "$diag" ] && printf '%s\n' "$diag"
     fi
     return 1
   fi
   if [ -z "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
     echo "DID NOT COMPLETE, claudecr:$level printed no review (exit $rc)."
+    [ -n "$diag" ] && printf '%s\n' "$diag"
     return 1
   fi
+  # stderr FIRST, as under 2>&1: the CLI's diagnostics precede its result, and
+  # the Verdict: line the classifier reads at the tail stays last.
+  [ -n "$diag" ] && printf '%s\n' "$diag"
   printf '%s\n' "$out"
   return "$rc"
 }

--- a/agents.d/claudecr.sh
+++ b/agents.d/claudecr.sh
@@ -34,12 +34,18 @@ is not a peer of one that cannot. Recorded, not assumed away -- it is what
 you are measuring when you pick this seat.
 Same ro rails as claude.sh: --strict-mcp-config, advisorModel="", and the
 CLAUDE_DENY list, which is why that adapter must stay loaded.
-★ The seat inherits the CLI's DEFAULT model, so the per-model weekly tier it
-spends is whatever ~/.claude/settings.json points at -- and that can change
-between passes of one sweep, silently. Pinning the model for a benchmark run
-is the caller's job today. When that tier runs out the CLI says "You've
-reached your <Model> limit. Switch to another model to continue.", which
-cadre reads as a usage window and not as a measurement (#48).
+★ The seat inherits the CLI's DEFAULT model: the spec's model slot is spent
+on the level, and --model is deliberately NOT added (#51, decided: record it,
+don't control it). The adapter asks for --output-format json and reads the
+served model out of `modelUsage`, then declares it with cadre_model, so the
+run record and the slots.tsv row name what actually ran -- every model that
+served, comma-joined, since high and xhigh dispatch subagents. A sweep whose
+default model changes mid-run shows up as two rows in `cadre receipts`, not
+as one averaged number. If the CLI's output is not the JSON object (older CLI,
+no jq on the box), the text passes through as before and the field stays
+EMPTY -- never a default. When a model's weekly tier runs out the CLI says
+"You've reached your <Model> limit. Switch to another model to continue.",
+which cadre reads as a usage window and not as a measurement (#48).
 NOTES
 }
 
@@ -86,7 +92,7 @@ run_claudecr() {
   fi
   local arg; arg="/code-review $level"$'\n\n'"$(claudecr_output_contract)"
   if [ -n "$DRY" ]; then
-    _run timeout -k 30 "$TIMEOUT" claude -p "$arg" "${ro[@]}"
+    _run timeout -k 30 "$TIMEOUT" claude -p "$arg" --output-format json "${ro[@]}"
     return 0
   fi
   # ★ The skill reviews HEAD against its parent, and nothing else (probed: a
@@ -108,8 +114,25 @@ run_claudecr() {
   fi
   # < /dev/null: with nothing on stdin the CLI waits 3s and prints a warning
   # that would become line 1 of every review.
-  out=$( cd "$dir" && timeout -k 30 "$TIMEOUT" claude -p "$arg" "${ro[@]}" < /dev/null 2>&1 ); rc=$?
+  # ★ JSON, for one field: `modelUsage` names the model(s) that actually served
+  # the call, which is the only honest source for a seat that pins none (#51).
+  # stderr is kept out of the object (a stray line ahead of it and jq sees
+  # nothing, the cursor.sh rule) and appended afterwards, so a CLI error still
+  # reaches the review text the way it did under 2>&1.
+  local errf models; errf=$(mktemp)
+  out=$( cd "$dir" && timeout -k 30 "$TIMEOUT" claude -p "$arg" --output-format json "${ro[@]}" < /dev/null 2>"$errf" ); rc=$?
   [ -n "$orig" ] && git -C "$dir" checkout -q --detach "$orig" 2>/dev/null
+  # Anything that is not the result object passes through untouched: an older
+  # CLI printing plain text, a box without jq. The model field stays EMPTY then,
+  # which is the truth -- it was not determined.
+  if command -v jq >/dev/null 2>&1 \
+     && printf '%s' "$out" | jq -e 'type == "object" and has("result")' >/dev/null 2>&1; then
+    models=$(printf '%s' "$out" | jq -r '(.modelUsage // {}) | keys | join(",")' 2>/dev/null)
+    [ -n "$models" ] && cadre_model "$models"
+    out=$(printf '%s' "$out" | jq -r '.result // ""')
+  fi
+  [ -s "$errf" ] && out="$out"$'\n'"$(cat "$errf")"
+  rm -f "$errf"
   if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
     # Whatever arrived before the kill is a review, cut short: the partial
     # contract, same as codex.sh and grok.sh. Nonzero as well as the marker.

--- a/bin/agentcall
+++ b/bin/agentcall
@@ -96,6 +96,20 @@ cadre_state() {  # cadre_state <ok|degraded|inconclusive|failed> [note]
   [ -n "${2:-}" ] && printf 'note=%s\n' "$(printf '%s' "$2" | tr -d '\000-\037')" >> "$CADRE_RUN_META"
   return 0
 }
+# cadre_model <id[,id...]>: the model(s) that actually served the run, for an
+# adapter whose spec does not pin one (#51). claudecr's model slot is spent on
+# the effort level, so the seat inherits the CLI's default model and a row
+# saying `claudecr:high` says nothing about which model ran it. Same channel,
+# same trust: it lands on the run record and the slots.tsv row. Never written
+# from a default -- an adapter that cannot read the served model says nothing,
+# and the field stays EMPTY. Control characters (tab included) are stripped
+# because the row is tab-separated.
+cadre_model() {
+  [ -n "${CADRE_RUN_META:-}" ] || return 0
+  [ -n "${1:-}" ] || return 0
+  printf 'model=%s\n' "$(printf '%s' "$1" | tr -d '\000-\037')" >> "$CADRE_RUN_META"
+  return 0
+}
 
 # --print-command: print the native invocation instead of running it.
 DRY="${AGENTCALL_DRY:-}"

--- a/bin/cadre
+++ b/bin/cadre
@@ -1196,6 +1196,19 @@ cmd_receipts() {
       # is counted across every row the command was pointed at (#37).
       if (NF >= 11 && $11 != "") { if (!($11 in harness)) harness[$11] = 1 }
       else no_harness++
+      # ★ Served model, per SEAT (#51). The spec pins the model for most seats
+      # and this column is EMPTY for them; it is filled by an adapter that read
+      # what actually ran -- claudecr, whose model slot holds the effort level.
+      # One seat under two models is a benchmark split across a boundary the
+      # spec cannot show, so it is named the way a harness split is named.
+      if (NF >= 12 && $12 != "") {
+        named_model++
+        mk = $2 SUBSEP $12
+        if (!(mk in seatmodel)) {
+          seatmodel[mk] = 1; nmodels[$2]++
+          models_of[$2] = (models_of[$2] == "" ? "" : models_of[$2] ", ") $12
+        }
+      }
     }
     END {
       for (key in keys) {
@@ -1208,6 +1221,8 @@ cmd_receipts() {
       printf "M\t%d\n", missing_prompt
       for (h in harness) printf "H\t%s\n", h
       printf "N\t%d\n", no_harness + 0
+      printf "D\t%d\n", named_model + 0
+      for (s in nmodels) if (nmodels[s] > 1) printf "S\t%s\t%d\t%s\n", s, nmodels[s], models_of[s]
     }
   ' "${slot_files[@]}")
 
@@ -1257,6 +1272,23 @@ cmd_receipts() {
     else
       echo "Harness: every row that names one ran against $harness_list."
     fi
+  fi
+
+  # ★ Same both-branches rule as the harness line (#51). Only rows that NAME a
+  # served model take part: a seat that pins its model in the spec has nothing
+  # to agree or disagree about here, and a silent line would read as a check
+  # that never ran.
+  local named_model model_splits
+  named_model=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "D" { print $2 }')
+  model_splits=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "S"' | sort -t "$tab" -k2,2)
+  if [ -n "$model_splits" ]; then
+    echo
+    printf '%s\n' "$model_splits" | awk -v FS="$tab" '{
+      printf "Model: seat %s ran under %d models (%s). Those rows are one seat measured twice, not one measurement; do not add them together.\n", $2, $3, $4
+    }'
+  elif [ "${named_model:-0}" -gt 0 ]; then
+    echo
+    echo "Model: every seat that names its served model ran under one model."
   fi
   if [ "${no_harness:-0}" -gt 0 ]; then
     [ "${nharness:-0}" -gt 0 ] || echo

--- a/bin/cadre
+++ b/bin/cadre
@@ -1160,10 +1160,29 @@ cmd_receipts() {
   [ "${#slot_files[@]}" -gt 0 ] || die "receipts: no slots.tsv found"
 
   raw=$(awk -v FS="$tab" '
+    # ★ Which column is `model` is decided PER FILE, from its header (#51). A
+    # live slots.tsv has no header and carries it in column 12. A dataset
+    # written by lib/aggregate.sh has a header; before this field existed its
+    # column 12 was `source`, so reading 12 blindly would file `recorded` and
+    # `reconstructed` as two served models and split every seat in the table.
+    # A header that does not name `model` means the file has no such column.
+    FNR == 1 {
+      mcol[FILENAME] = 12
+      if ($1 == "panel" && $2 == "slot") {
+        mcol[FILENAME] = 0
+        for (i = 1; i <= NF; i++) if ($i == "model") mcol[FILENAME] = i
+      }
+    }
     $1 == "panel" && $2 == "slot" { next }
     NF < 5 || $3 == "" { next }
     {
       fam = $3
+      # ★ Served model set, per row: EMPTY for a seat whose spec pins its model.
+      # It is part of the grouping key, so a seat that ran under two defaults
+      # lands on two rows and its totals are never added -- the row split IS the
+      # notice, the same answer #20 gives for a schema change. Rows with no
+      # model group exactly as before.
+      m = (mcol[FILENAME] > 0 && NF >= mcol[FILENAME]) ? $(mcol[FILENAME]) : ""
       # ★ A missing, empty or NON-NUMERIC column 8 is UNKNOWN, printed "?", never
       # defaulted to a version. Those rows straddle the change this grouping
       # exists to keep apart, and calling them by any version number would assert
@@ -1174,8 +1193,9 @@ cmd_receipts() {
       # in the table -- receipts accepts any directory, and a stale dataset dir
       # is a directory.
       v = (NF >= 8 && $8 ~ /^[0-9]+$/) ? $8 : "?"
-      key = fam SUBSEP v
-      if (!(key in keys)) { keys[key] = 1; famof[key] = fam; vof[key] = v; nver[fam]++ }
+      key = fam SUBSEP v SUBSEP m
+      if (!(key in keys)) { keys[key] = 1; famof[key] = fam; vof[key] = v; mof[key] = m }
+      if (!((fam SUBSEP v) in famver)) { famver[fam SUBSEP v] = 1; nver[fam]++ }
       seats[key]++
       run_key = key SUBSEP FILENAME SUBSEP $1
       if (!(run_key in seen)) { seen[run_key] = 1; runs[key]++ }
@@ -1201,22 +1221,22 @@ cmd_receipts() {
       # what actually ran -- claudecr, whose model slot holds the effort level.
       # One seat under two models is a benchmark split across a boundary the
       # spec cannot show, so it is named the way a harness split is named.
-      if (NF >= 12 && $12 != "") {
+      if (m != "") {
         named_model++
-        mk = $2 SUBSEP $12
+        mk = $2 SUBSEP m
         if (!(mk in seatmodel)) {
           seatmodel[mk] = 1; nmodels[$2]++
-          models_of[$2] = (models_of[$2] == "" ? "" : models_of[$2] ", ") $12
+          models_of[$2] = (models_of[$2] == "" ? "" : models_of[$2] "; ") m
         }
       }
     }
     END {
       for (key in keys) {
         sec = have_secs[key] ? secs[key] : ""
-        printf "R\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\n", \
+        printf "R\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\t%s\n", \
           famof[key], runs[key], seats[key], ok[key], degraded[key], \
           inconclusive[key], failed[key], skipped[key], sec, prompt_bytes[key], \
-          review_bytes[key], est_tokens[key], vof[key], nver[famof[key]]
+          review_bytes[key], est_tokens[key], vof[key], nver[famof[key]], mof[key]
       }
       printf "M\t%d\n", missing_prompt
       for (h in harness) printf "H\t%s\n", h
@@ -1231,14 +1251,17 @@ cmd_receipts() {
   # order; without it the two halves swap between runs and a diff of two
   # receipts reads as a change.
   rows=$(printf '%s\n' "$raw" | awk -v FS="$tab" '$1 == "R"' \
-    | sort -t "$tab" -k13,13nr -k2,2 -k14,14)
+    | sort -t "$tab" -k13,13nr -k2,2 -k14,14 -k16,16)
 
-  printf '%-24s %5s %5s %4s %8s %12s %6s %7s %8s %10s %10s %11s %7s\n' \
-    FAMILY RUNS SEATS OK DEGRADED INCONCLUSIVE FAILED SKIPPED SECS PROMPT_KB REVIEW_KB 'EST. TOKENS' SCHEMA
+  # MODEL is last and usually blank: it is filled only for rows whose seat
+  # declared the served model (#51), and a family split across two of them
+  # prints as two rows here, exactly like a schema split.
+  printf '%-24s %5s %5s %4s %8s %12s %6s %7s %8s %10s %10s %11s %7s  %s\n' \
+    FAMILY RUNS SEATS OK DEGRADED INCONCLUSIVE FAILED SKIPPED SECS PROMPT_KB REVIEW_KB 'EST. TOKENS' SCHEMA MODEL
   printf '%s\n' "$rows" | awk -v FS="$tab" '
     $1 == "R" {
-      printf "%-24s %5d %5d %4d %8d %12d %6d %7d %8s %10.1f %10.1f %11d %7s\n", \
-        $2, $3, $4, $5, $6, $7, $8, $9, $10, $11 / 1024, $12 / 1024, $13, $14
+      printf "%-24s %5d %5d %4d %8d %12d %6d %7d %8s %10.1f %10.1f %11d %7s  %s\n", \
+        $2, $3, $4, $5, $6, $7, $8, $9, $10, $11 / 1024, $12 / 1024, $13, $14, $16
     }
   '
   if [ "${missing:-0}" -gt 0 ]; then
@@ -1284,11 +1307,11 @@ cmd_receipts() {
   if [ -n "$model_splits" ]; then
     echo
     printf '%s\n' "$model_splits" | awk -v FS="$tab" '{
-      printf "Model: seat %s ran under %d models (%s). Those rows are one seat measured twice, not one measurement; do not add them together.\n", $2, $3, $4
+      printf "Model: seat %s was served by %d different model sets (%s). Its rows above are listed per set and were not added together.\n", $2, $3, $4
     }'
   elif [ "${named_model:-0}" -gt 0 ]; then
     echo
-    echo "Model: every seat that names its served model ran under one model."
+    echo "Model: every seat that names its served model was served by one model set."
   fi
   if [ "${no_harness:-0}" -gt 0 ]; then
     [ "${nharness:-0}" -gt 0 ] || echo

--- a/docs/ADDING-AN-AGENT.md
+++ b/docs/ADDING-AN-AGENT.md
@@ -125,6 +125,20 @@ text, so falling back is the safe direction), and declaring `ok` will not
 rescue an artifact that came back empty. It is also a no-op when `agentcall`
 runs outside cadre, so it costs a standalone caller nothing.
 
+**`cadre_model <id[,id...]>`** rides the same channel and carries the model(s)
+that actually served the run. Most adapters never need it: the spec pins the
+model (`codex:gpt-5`) and the row already says what ran. It exists for a seat
+whose model slot is spent on something else — `claudecr:high` holds the effort
+level, so the CLI's *default* model serves it, and that default can change
+between two passes of one sweep with nothing in the artifacts recording the
+split. Declare it only from something the CLI *reported* (`claudecr` reads
+`modelUsage` out of `--output-format json`); never from a setting, a flag you
+passed, or a guess. If you cannot read it, say nothing — the field stays EMPTY,
+and EMPTY means "not determined", which is a true statement where a default
+would be a claim. It lands on `runs.jsonl`, on column 12 of `slots.tsv`, and in
+the report's Receipts table, and `cadre receipts` names any seat that ran under
+more than one model instead of adding those rows together.
+
 The one thing this asks of you: **do not append your own trailing summary to a
 review.** The check is edge-anchored, so a "review complete, 0 issues" footer your
 wrapper adds would satisfy it on behalf of a model that said nothing.

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -162,6 +162,12 @@ Tests: "mixed: one row per schema", "mixed: the two secs never merge",
   gets hashed. What they buy is that a comparison spanning an edit becomes
   visible instead of silent. Nothing here is a signature and nothing verifies
   a tree against a published manifest.
+- **The served-model field records, it does not control.** `claudecr` reads
+  the model out of the CLI's own result and declares it; cadre never passes
+  `--model`, so a sweep whose default changes mid-run is *marked* (two rows,
+  named by `receipts`), not refused. The value is trusted exactly as far as the
+  adapter is — same channel and same posture as `cadre_state`. Nothing here pins
+  a model for a benchmark; that is still the operator's job at sweep start.
 - **A scratch file in the tree is a source file to the harness.** Planning
   notes, TODO dumps and other author-written artifacts ride into the checkout
   like any other file — tracked, or untracked-but-not-gitignored (carried on

--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -25,7 +25,7 @@ about which model reviews *better* needs that path, not this file.
 
 ## slots.tsv — one row per reviewer slot
 
-    panel  slot  family  status  bytes  secs  prompt_bytes  v  prompt_sha  adapter_sha  harness_sha  source
+    panel  slot  family  status  bytes  secs  prompt_bytes  v  prompt_sha  adapter_sha  harness_sha  model  source
 
 - **status** — `ok` / `degraded` / `inconclusive` / `failed` / `skipped`.
   `skipped` means the user-declared roster gate did not hold, so no prompt was
@@ -74,6 +74,15 @@ about which model reviews *better* needs that path, not this file.
   not be read in full. The digest of an empty read is *stable*, so a partial
   answer here would make two failed runs compare equal. This is provenance, not
   tamper-proofing — see `docs/ASSURANCE_CASE.md`.
+- **model** — the model(s) that actually served the seat, as the adapter
+  *reported* them (`cadre_model`; claudecr reads `modelUsage` from the CLI's
+  JSON result). **EMPTY for every seat whose spec pins its model** — the spec
+  already says what ran and this column is not a copy of it. It is filled only
+  where the spec cannot say: `claudecr:<level>` spends its model slot on the
+  effort level and inherits the CLI default, which can change mid-sweep. A seat
+  listed under two models is one seat measured twice, and `cadre receipts` says
+  so rather than adding the rows. Not a schema bump: `v` marks a change to what
+  a column *means*, and no existing column moved.
 - **source** — `recorded` (written live by `run-review.sh`, with status and
   timing measured and prompt size present on new rows) or `reconstructed`
   (rebuilt from artifacts after the fact). Reconstructed rows have **no timing

--- a/lib/aggregate.sh
+++ b/lib/aggregate.sh
@@ -40,7 +40,7 @@ PANELS="$OUT_D/panels.tsv"
 # version and no input hashes, and inventing either would let it compare equal
 # to a row that was actually measured.
 {
-  printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tv\tprompt_sha\tadapter_sha\tharness_sha\tsource\n'
+  printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tv\tprompt_sha\tadapter_sha\tharness_sha\tmodel\tsource\n'
   for d in "$REVIEWS"/*/; do
     [ -d "$d" ] || continue
     p=$(basename "$d")
@@ -53,7 +53,7 @@ PANELS="$OUT_D/panels.tsv"
       # and awk yields EMPTY for each -- which is the right answer, and the one
       # `cadre receipts` groups on. Nothing here backfills them.
       awk -F '\t' -v OFS='\t' -v panel="$p" '
-        $2 != "" { print panel, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, "recorded" }
+        $2 != "" { print panel, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, "recorded" }
       ' "$d/slots.tsv"
       continue
     fi
@@ -93,7 +93,7 @@ PANELS="$OUT_D/panels.tsv"
       fi
       bytes=0
       [ -n "$art" ] && bytes=$(wc -c < "$art" | tr -d ' ')
-      printf '%s\t%s\t%s\t%s\t%s\t\t\t\t\t\t\treconstructed\n' \
+      printf '%s\t%s\t%s\t%s\t%s\t\t\t\t\t\t\t\treconstructed\n' \
         "$p" "$spec" "$(spec_family "$spec")" "$st" "$bytes"
     done
   done
@@ -118,7 +118,7 @@ PANELS="$OUT_D/panels.tsv"
     # empty -- which matters, because tab is IFS WHITESPACE and a plain read
     # collapses the empty runs further right. The trailing names are declared to
     # match the header, not relied on.
-    while IFS=$'\t' read -r pp _s _fam st _b _sec _prompt _v _psha _asha _hsha _src; do
+    while IFS=$'\t' read -r pp _s _fam st _b _sec _prompt _v _psha _asha _hsha _model _src; do
       [ "$pp" = "$p" ] || continue
       # A gated-off seat is retained in slots.tsv as operational provenance but
       # was never on the reviewing panel, so it cannot pad the seat denominator.

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -263,6 +263,7 @@ for r in "${reviewers[@]}"; do
       "prompt_bytes#=$prompt_bytes" "attempts#=$attempt" \
       "v#=$SLOTS_SCHEMA_V" prompt_sha="$prompt_sha" \
       adapter_sha="$(adapter_sha "$agent")" harness_sha="$HARNESS_SHA" \
+      model="$(sed -n 's/^model=//p' "$f.part.meta" 2>/dev/null | tail -1)" \
       "ts#=$(date +%s)"
     # Same rule as the panel path: the declaration is consumed, the state lives
     # in runs.jsonl, and a stale .meta would classify the NEXT attempt at this

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -513,6 +513,11 @@ record_complete() {  # <slug> <spec> <state> [rc] [secs]
   [ -s "$art" ] || art="$OUT/$sl.md.failed"
   bytes=$(wc -c < "$art" 2>/dev/null | tr -d ' ')
   shaf="$OUT/.sha-$sl"
+  # ★ `model` is what the ADAPTER declared over the meta channel (cadre_model,
+  # #51), read before the caller deletes the file. EMPTY unless declared: the
+  # spec already names the model for every seat that pins one, and this field
+  # exists for the seat that cannot -- so a value here is a measurement of what
+  # served, never a copy of what was asked for.
   record_event "$RUNLOG" event=complete panel="$(basename "$OUT")" \
     seat="$spec" family="$(spec_family "$spec")" slug="$sl" \
     state="$state" "rc#=$rc" "secs#=$secs" "bytes#=${bytes:-0}" \
@@ -520,7 +525,9 @@ record_complete() {  # <slug> <spec> <state> [rc] [secs]
     "v#=$SLOTS_SCHEMA_V" \
     prompt_sha="$(sed -n 1p "$shaf" 2>/dev/null)" \
     adapter_sha="$(sed -n 2p "$shaf" 2>/dev/null)" \
-    harness_sha="$HARNESS_SHA" "ts#=$(date +%s)"
+    harness_sha="$HARNESS_SHA" \
+    model="$(sed -n 's/^model=//p' "$OUT/$sl.md.part.meta" 2>/dev/null | tail -1)" \
+    "ts#=$(date +%s)"
 }
 
 run_one() {
@@ -715,7 +722,7 @@ for row in "${skipped_rows[@]}"; do
     state=skipped "rc#=" "secs#=" "bytes#=0" "prompt_bytes#=0" \
     "v#=$SLOTS_SCHEMA_V" prompt_sha= \
     adapter_sha="$(adapter_sha "$(spec_agent "$sk_spec")")" \
-    harness_sha="$HARNESS_SHA" "ts#=$(date +%s)"
+    harness_sha="$HARNESS_SHA" model= "ts#=$(date +%s)"
 done
 
 i=0; running=0
@@ -889,16 +896,21 @@ slot_rows=$(
   # no completion event at all. Reading it from the record would blank exactly
   # that row and lose the provenance for the only row whose provenance is in
   # question.
+  # ★ Column 12, `model`, is the served model the adapter declared (#51) and
+  # EMPTY otherwise. Appended after harness_sha so every positional reader of
+  # $1..$11 is untouched; the schema version does not move, because no existing
+  # column changed meaning -- `v` marks a change to what a column MEANS, not
+  # to how many there are.
   all_complete=$(record_rows "$RUNLOG" complete seat family state bytes secs prompt_bytes \
-                   prompt_sha adapter_sha harness_sha)
+                   prompt_sha adapter_sha harness_sha model)
   for spec in "${reviewers[@]}"; do
     rec_row=$(printf '%s\n' "$all_complete" | awk -F '\t' -v s="$spec" '$1 == s { print; exit }')
     rec_row="${rec_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt r_psha r_asha r_hsha <<< "$rec_row"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt r_psha r_asha r_hsha r_model <<< "$rec_row"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
       "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
       "${r_state:-failed}" "${r_bytes:-0}" "$r_secs" "$r_prompt" \
-      "$SLOTS_SCHEMA_V" "$r_psha" "$r_asha" "${r_hsha:-$HARNESS_SHA}"
+      "$SLOTS_SCHEMA_V" "$r_psha" "$r_asha" "${r_hsha:-$HARNESS_SHA}" "$r_model"
   done
   # Skipped seats come from the same stream, for the same reason: one source, so
   # a change to how spend is recorded cannot land in one renderer and not the
@@ -908,11 +920,11 @@ slot_rows=$(
     IFS=$'\t' read -r spec _gate _reason <<< "$row"
     rec_row=$(printf '%s\n' "$all_complete" | awk -F '\t' -v s="$spec" '$1 == s { print; exit }')
     rec_row="${rec_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt r_psha r_asha r_hsha <<< "$rec_row"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    IFS=$'\034' read -r _seat r_fam r_state r_bytes r_secs r_prompt r_psha r_asha r_hsha r_model <<< "$rec_row"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
       "$(basename "$OUT")" "$spec" "${r_fam:-$(spec_family "$spec")}" \
       "${r_state:-skipped}" "${r_bytes:-0}" "$r_secs" "${r_prompt:-0}" \
-      "$SLOTS_SCHEMA_V" "$r_psha" "$r_asha" "${r_hsha:-$HARNESS_SHA}"
+      "$SLOTS_SCHEMA_V" "$r_psha" "$r_asha" "${r_hsha:-$HARNESS_SHA}" "$r_model"
   done
 )
 printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
@@ -921,8 +933,8 @@ printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
   echo
   echo "## Receipts"
   echo
-  echo "| seat | status | secs | prompt KB | review KB | est. tokens |"
-  echo "|---|---|---|---|---|---|"
+  echo "| seat | model | status | secs | prompt KB | review KB | est. tokens |"
+  echo "|---|---|---|---|---|---|---|"
   total_secs=0; have_secs=0; total_prompt=0; have_prompt=0; total_review=0; total_est=0
   # ★ The SAME rows slots.tsv got, not a second query against the record. Both
   # views owe their row set to the roster, so a seat dispatched and never
@@ -931,7 +943,7 @@ printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
     # Tabs are IFS whitespace, so plain `read` collapses the empty secs field in
     # a skipped row. Translate to a non-whitespace delimiter before splitting.
     slot_row="${slot_row//$'\t'/$'\034'}"
-    IFS=$'\034' read -r _run spec _fam st bytes secs prompt_bytes _v _psha _asha _hsha <<< "$slot_row"
+    IFS=$'\034' read -r _run spec _fam st bytes secs prompt_bytes _v _psha _asha _hsha model <<< "$slot_row"
     prompt_kb=""
     if [ -n "${prompt_bytes:-}" ]; then
       prompt_kb=$(awk -v n="$prompt_bytes" 'BEGIN { printf "%.1f", n / 1024 }')
@@ -942,14 +954,16 @@ printf '%s\n' "$slot_rows" > "$OUT/slots.tsv"
     total_est=$((total_est + est_tokens))
     [ -n "${secs:-}" ] && { total_secs=$((total_secs + secs)); have_secs=1; }
     total_review=$((total_review + ${bytes:-0}))
-    printf '| `%s` | %s | %s | %s | %s | %s |\n' \
-      "$spec" "$st" "${secs:-}" "$prompt_kb" "$review_kb" "$est_tokens"
+    # The model column is blank for every seat that pins its model in the spec;
+    # it is filled only by an adapter that read the served model (#51).
+    printf '| `%s` | %s | %s | %s | %s | %s | %s |\n' \
+      "$spec" "${model:-}" "$st" "${secs:-}" "$prompt_kb" "$review_kb" "$est_tokens"
   done <<< "$slot_rows"
   total_secs_display=""; [ "$have_secs" -eq 1 ] && total_secs_display="$total_secs"
   total_prompt_kb=""; [ "$have_prompt" -eq 1 ] && \
     total_prompt_kb=$(awk -v n="$total_prompt" 'BEGIN { printf "%.1f", n / 1024 }')
   total_review_kb=$(awk -v n="$total_review" 'BEGIN { printf "%.1f", n / 1024 }')
-  printf '| **panel total** | | %s | %s | %s | %s |\n' \
+  printf '| **panel total** | | | %s | %s | %s | %s |\n' \
     "$total_secs_display" "$total_prompt_kb" "$total_review_kb" "$total_est"
   echo
   echo "> Estimated as bytes/4 of what the harness sent and received. Hidden reasoning tokens are invisible from outside the CLI and are NOT in this number: a seat that thinks long and answers short costs more than its row shows. This is a relative-spend signal, not a bill."

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -424,7 +424,7 @@ R="$D/state/reviews/$(ls "$D/state/reviews" | head -1)"
 check "gate: below threshold exits clean" "[ $RC -eq 0 ]"
 check "gate: skip is loud in report"      "grep -qF -- '- \`good\` — SKIPPED by its roster gate (?min-lines=2: diff is 1 lines).' '$R/report.md'"
 check "gate: skipped slot has zero spend" "grep -qP '\tgood\t.*\tskipped\t0\t\t0\t2\t' '$R/slots.tsv'"
-check "gate: receipt keeps empty seconds"  "grep -qF '| \`good\` | skipped |  | 0.0 | 0.0 | 0 |' '$R/report.md'"
+check "gate: receipt keeps empty seconds"  "grep -qF '| \`good\` |  | skipped |  | 0.0 | 0.0 | 0 |' '$R/report.md'"
 check "gate: console counts the skip"      "grep -q '0 ok, 0 degraded, 0 inconclusive, 0 failed, 1 skipped' <<<\"\$OUT\""
 check "gate: no prompt reached the seat"   "[ ! -e '$R/good.md' ]"
 
@@ -1894,7 +1894,7 @@ check "timing and prompt captured"  "grep -qP '\tok\t[0-9]+\t[0-9]+\t[1-9][0-9]*
 check "failed seat keeps its prompt"  "grep -qP '\tfailed\t[0-9]+\t[0-9]*\t[1-9][0-9]*\t2\t' '$R/slots.tsv'"
 check "failed seat's time is measured, not blank" \
   "grep -qP '\tfailed\t[0-9]+\t[0-9]+\t[1-9][0-9]*\t2\t' '$R/slots.tsv'"
-check "report has receipt table"    "grep -qF '| seat | status | secs | prompt KB | review KB | est. tokens |' '$R/report.md'"
+check "report has receipt table"    "grep -qF '| seat | model | status | secs | prompt KB | review KB | est. tokens |' '$R/report.md'"
 check "receipt caveat is explicit" "grep -qF '> Estimated as bytes/4 of what the harness sent and received. Hidden reasoning tokens are invisible from outside the CLI and are NOT in this number: a seat that thinks long and answers short costs more than its row shows. This is a relative-spend signal, not a bill.' '$R/report.md'"
 # ★ A seat that produced NO artifact must still appear. Deriving rows from
 # filenames instead of the roster would silently drop exactly the failure worth
@@ -2104,7 +2104,7 @@ rm -f "$R/slots.tsv"
 OUT=$(run_cadre "$D" dataset "$D/dataset" 2>&1)
 check "aggregate walks the reviews" "[ -s '$D/dataset/slots.tsv' ]"
 check "it reconstructs the panel"   "grep -q reconstructed '$D/dataset/slots.tsv'"
-check "unknown measures stay empty" "grep -qP '\t[0-9]+\t\t\t\t\t\t\treconstructed\$' '$D/dataset/slots.tsv'"
+check "unknown measures stay empty" "grep -qP '\t[0-9]+\t\t\t\t\t\t\t\treconstructed\$' '$D/dataset/slots.tsv'"
 # ★ Explicitly: NOT zeroes. A reconstructed row has neither measurement, and
 # writing 0 would average like a real value and drag every mean toward the floor.
 check "never a fabricated sec zero" "! grep -qP '\t0\t\treconstructed\$' '$D/dataset/slots.tsv'"
@@ -2117,7 +2117,7 @@ mkdir -p "$D/state/reviews/ds-skip"
 printf 'ds-skip\tgood\tstub-good\tok\t100\t1\t100\nds-skip\tgood2\tstub-good2\tskipped\t0\t\t0\n' > "$D/state/reviews/ds-skip/slots.tsv"
 printf 'base-tree: aaaaaaaa11111111\nreviewed-tree: bbbbbbbb22222222\n' > "$D/state/reviews/ds-skip/manifest.txt"
 OUT=$(run_cadre "$D" dataset "$D/dataset" 2>&1)
-check "aggregate keeps skipped slot row" "grep -qP 'ds-skip\tgood2\t.*\tskipped\t0\t\t0\t\t\t\t\trecorded\$' '$D/dataset/slots.tsv'"
+check "aggregate keeps skipped slot row" "grep -qP 'ds-skip\tgood2\t.*\tskipped\t0\t\t0\t\t\t\t\t\trecorded\$' '$D/dataset/slots.tsv'"
 check "aggregate excludes skip from seats" "grep -qP 'ds-skip\t\S+\t1\t1\t0\t0\t0\t' '$D/dataset/panels.tsv'"
 
 RF="$D/receipt-fixtures"
@@ -4448,6 +4448,119 @@ check "meta: cadre_state is a no-op outside cadre" \
   "grep -q 'a partial finding' <<<\"\$STANDALONE\""
 check "meta: and it says nothing on the way through" \
   "! grep -qi 'cadre_state\|CADRE_RUN_META' <<<\"\$STANDALONE\""
+
+echo "== ★ #51: the served model is a field on the record and the row =="
+# An adapter whose spec pins no model declares the one that actually served it.
+# The fixture reads the model from a file so two panels can differ with one
+# adapter -- which is exactly the mid-sweep default-model change #51 is about.
+DM=$(case_dir modelfield)
+cat > "$DM/agents.d/modeller.sh" <<A
+run_modeller() {
+  cadre_model "\$(cat "$DM/served-model")"
+  echo "**should-fix**"
+  echo "app.js:1 -- a finding"
+  echo "Verdict: should-fix"
+}
+A
+printf '#!/bin/sh\nexit 0\n' > "$DM/bin/modeller"; chmod +x "$DM/bin/modeller"
+git -C "$DM/src" checkout -qb feature
+echo committed >> "$DM/src/app.js"; git -C "$DM/src" commit -qam feat
+echo model-alpha > "$DM/served-model"
+run_cadre "$DM" review --roster modeller,good --synth none --base main --label m1 "$DM/src" >/dev/null
+RM1="$DM/state/reviews/m1"
+check "model: the declaration reaches the record" \
+  "grep -q '\"model\":\"model-alpha\"' '$RM1/runs.jsonl'"
+check "model: and slots.tsv column 12" \
+  "awk -F'\t' '\$2 == \"modeller\" && \$12 == \"model-alpha\" { f=1 } END { exit !f }' '$RM1/slots.tsv'"
+# ★ EMPTY, never a default: the pinned seat's spec already says what ran, and
+# a value copied from it would read as a measurement.
+check "model: a seat that declares nothing is EMPTY" \
+  "awk -F'\t' '\$2 == \"good\" && NF == 12 && \$12 == \"\" { f=1 } END { exit !f }' '$RM1/slots.tsv'"
+check "model: columns 1-11 did not move" \
+  "awk -F'\t' '\$2 == \"modeller\" && \$4 == \"ok\" && \$8 == 2 && \$11 ~ /^[0-9a-f]{12}\$/ { f=1 } END { exit !f }' '$RM1/slots.tsv'"
+check "model: the report's receipts name it" \
+  "grep -qF '| \`modeller\` | model-alpha | ok |' '$RM1/report.md'"
+check "model: and leave the pinned seat blank" \
+  "grep -qF '| \`good\` |  | ok |' '$RM1/report.md'"
+check "model: the meta file does not outlive the run" \
+  "! ls '$RM1'/*.meta >/dev/null 2>&1"
+# The same seat under a different default: two rows, named as such.
+echo model-beta > "$DM/served-model"
+run_cadre "$DM" review --roster modeller,good --synth none --base main --label m2 "$DM/src" >/dev/null
+OUT=$(run_cadre "$DM" receipts "$DM/state/reviews")
+check "model: receipts name the seat that ran under two models" \
+  "grep -q '^Model: seat modeller ran under 2 models (model-alpha, model-beta)' <<<\"\$OUT\""
+check "model: and do not add them together" \
+  "grep -q 'do not add them together' <<<\"\$OUT\""
+check "model: the pinned seat is not accused" \
+  "! grep -q 'seat good ran under' <<<\"\$OUT\""
+# ★ Both branches: agreement is said out loud too, and a table with no model
+# column at all says nothing rather than agreeing about nothing.
+OUT=$(run_cadre "$DM" receipts "$RM1")
+check "model: one model is stated, not implied" \
+  "grep -q '^Model: every seat that names its served model ran under one model' <<<\"\$OUT\""
+mkdir -p "$DM/nomodel"
+printf 'r1\tcodex:a\topenai\tok\t1024\t7\t2048\t2\taaaaaaaaaaaa\tbbbbbbbbbbbb\tcccccccccccc\n' > "$DM/nomodel/slots.tsv"
+OUT=$(run_cadre "$DM" receipts "$DM/nomodel")
+check "model: no column, no Model line" "! grep -q '^Model:' <<<\"\$OUT\""
+# The dataset carries the column, before `source`.
+OUT=$(run_cadre "$DM" dataset "$DM/dataset" 2>&1)
+check "model: dataset header names the column" \
+  "head -1 '$DM/dataset/slots.tsv' | grep -qP '\tharness_sha\tmodel\tsource\$'"
+check "model: dataset row carries it"  "grep -qP '^m1\tmodeller\t.*\tmodel-alpha\trecorded\$' '$DM/dataset/slots.tsv'"
+check "model: dataset pinned seat is empty" "grep -qP '^m1\tgood\t.*\t[0-9a-f]{12}\t\trecorded\$' '$DM/dataset/slots.tsv'"
+
+# The benchmark path writes the same field.
+DMB=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DMB" modeller "$HITBOTH" "$HITBOTH"
+cp "$DM/agents.d/modeller.sh" "$DMB/agents.d/"; cp "$DM/bin/modeller" "$DMB/bin/"
+echo model-alpha > "$DM/served-model"
+rm -f "$DMB/home/p1/$(slug modeller)-run1.md"
+run_gaunt "$DMB" good,good2 modeller >/dev/null 2>&1 || true
+check "model: the benchmark record carries it" \
+  "grep -q '\"model\":\"model-alpha\"' '$DMB/home/p1/runs.jsonl'"
+
+# ★ claudecr is the seat this exists for. The stub answers as the CLI does under
+# --output-format json; the adapter must unwrap the review and declare every
+# model in modelUsage -- high and xhigh dispatch subagents, so there can be more
+# than one, and naming only the first would hide exactly that.
+CJ=$(case_dir claudecr-json); cp "$ROOT/agents.d/claudecr.sh" "$ROOT/agents.d/claude.sh" "$CJ/agents.d/"
+cat > "$CJ/bin/claude" <<S
+#!/bin/sh
+printf '%s\n' "\$@" > "$CJ/claude.argv"
+printf '{"type":"result","subtype":"success","is_error":false,"result":"**blocking**\\\\nsrc/x.js:3 -- missing await\\\\nVerdict: blocking","modelUsage":{"claude-test-1":{"inputTokens":1},"claude-sub-2":{"inputTokens":1}}}\n'
+S
+chmod +x "$CJ/bin/claude"
+CJM=$(mktemp -d)
+OUT=$(CADRE_RUN_META="$CJM/state" CADRE_AGENTS_D="$CJ/agents.d" PATH="$CJ/bin:$PATH" \
+  "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: asks for the JSON result"        "grep -qx -- '--output-format' '$CJ/claude.argv' && grep -qx json '$CJ/claude.argv'"
+check "claudecr: unwraps the review text"         "grep -q '^src/x.js:3 -- missing await' <<<\"\$OUT\" && [ $RC -eq 0 ]"
+check "claudecr: and none of the envelope"        "! grep -q 'modelUsage\|\"result\"' <<<\"\$OUT\""
+check "claudecr: declares every served model"     "grep -qx 'model=claude-sub-2,claude-test-1' '$CJM/state'"
+# An error object still carries its text, and the exit code still governs.
+cat > "$CJ/bin/claude" <<'S'
+#!/bin/sh
+printf '{"type":"result","subtype":"error_during_execution","is_error":true,"result":"You have reached your Opus limit. Switch to another model to continue.","modelUsage":{}}\n'
+exit 1
+S
+rm -f "$CJM/state"
+OUT=$(CADRE_RUN_META="$CJM/state" CADRE_AGENTS_D="$CJ/agents.d" PATH="$CJ/bin:$PATH" \
+  "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: an error object keeps its text"  "grep -q 'reached your Opus limit' <<<\"\$OUT\" && [ $RC -ne 0 ]"
+check "claudecr: and an empty modelUsage declares nothing" "[ ! -e '$CJM/state' ]"
+# Plain text (an older CLI, or no jq) passes through and leaves the field
+# undetermined -- never defaulted from a setting.
+printf '#!/bin/sh\necho "**nit**"\necho "x.js:1 -- t"\necho "Verdict: nit"\n' > "$CJ/bin/claude"
+OUT=$(CADRE_RUN_META="$CJM/state" CADRE_AGENTS_D="$CJ/agents.d" PATH="$CJ/bin:$PATH" \
+  "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: plain text still passes through" "grep -q '^x.js:1 -- t' <<<\"\$OUT\" && [ $RC -eq 0 ]"
+check "claudecr: and the model stays undetermined" "[ ! -e '$CJM/state' ]"
+rm -rf "$CJM"
+# ★ cadre_model outside cadre is a no-op, like cadre_state.
+STANDALONE=$(CADRE_AGENTS_D="$DM/agents.d" PATH="$DM/bin:$PATH" \
+  "$ROOT/bin/agentcall" modeller -d "$DM/src" hi 2>&1)
+check "model: cadre_model is a no-op outside cadre" \
+  "grep -q 'a finding' <<<\"\$STANDALONE\" && ! grep -qi 'cadre_model\|CADRE_RUN_META' <<<\"\$STANDALONE\""
 
 echo
 echo "$PASS passed, $FAIL failed"

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -4488,17 +4488,21 @@ check "model: the meta file does not outlive the run" \
 echo model-beta > "$DM/served-model"
 run_cadre "$DM" review --roster modeller,good --synth none --base main --label m2 "$DM/src" >/dev/null
 OUT=$(run_cadre "$DM" receipts "$DM/state/reviews")
-check "model: receipts name the seat that ran under two models" \
-  "grep -q '^Model: seat modeller ran under 2 models (model-alpha, model-beta)' <<<\"\$OUT\""
-check "model: and do not add them together" \
-  "grep -q 'do not add them together' <<<\"\$OUT\""
+check "model: receipts name the seat served by two model sets" \
+  "grep -q '^Model: seat modeller was served by 2 different model sets (model-alpha; model-beta)' <<<\"\$OUT\""
+# ★ Not just a warning: the totals are split too. Two rows for the family,
+# one per served model, and the MODEL column says which is which.
+check "model: the family is listed once per model" \
+  "awk '\$NF == \"model-alpha\" { a=1 } \$NF == \"model-beta\" { b=1 } END { exit !(a && b) }' <<<\"\$OUT\""
+check "model: and each row holds one run" \
+  "awk '\$NF == \"model-alpha\" && \$2 == 1 { a=1 } \$NF == \"model-beta\" && \$2 == 1 { b=1 } END { exit !(a && b) }' <<<\"\$OUT\""
 check "model: the pinned seat is not accused" \
-  "! grep -q 'seat good ran under' <<<\"\$OUT\""
+  "! grep -q 'seat good was served' <<<\"\$OUT\""
 # ★ Both branches: agreement is said out loud too, and a table with no model
 # column at all says nothing rather than agreeing about nothing.
 OUT=$(run_cadre "$DM" receipts "$RM1")
 check "model: one model is stated, not implied" \
-  "grep -q '^Model: every seat that names its served model ran under one model' <<<\"\$OUT\""
+  "grep -q '^Model: every seat that names its served model was served by one model set' <<<\"\$OUT\""
 mkdir -p "$DM/nomodel"
 printf 'r1\tcodex:a\topenai\tok\t1024\t7\t2048\t2\taaaaaaaaaaaa\tbbbbbbbbbbbb\tcccccccccccc\n' > "$DM/nomodel/slots.tsv"
 OUT=$(run_cadre "$DM" receipts "$DM/nomodel")
@@ -4509,6 +4513,18 @@ check "model: dataset header names the column" \
   "head -1 '$DM/dataset/slots.tsv' | grep -qP '\tharness_sha\tmodel\tsource\$'"
 check "model: dataset row carries it"  "grep -qP '^m1\tmodeller\t.*\tmodel-alpha\trecorded\$' '$DM/dataset/slots.tsv'"
 check "model: dataset pinned seat is empty" "grep -qP '^m1\tgood\t.*\t[0-9a-f]{12}\t\trecorded\$' '$DM/dataset/slots.tsv'"
+# ★ receipts reads a dataset by its HEADER. The new one names `model`, so the
+# split survives aggregation; a dataset written BEFORE this field had `source`
+# in column 12, and reading that blindly would file `recorded` as a model.
+OUT=$(run_cadre "$DM" receipts "$DM/dataset")
+check "model: the dataset still shows the split" \
+  "grep -q '^Model: seat modeller was served by 2 different model sets' <<<\"\$OUT\""
+mkdir -p "$DM/olddataset"
+printf 'panel\tslot\tfamily\tstatus\tbytes\tsecs\tprompt_bytes\tv\tprompt_sha\tadapter_sha\tharness_sha\tsource\n' > "$DM/olddataset/slots.tsv"
+printf 'o1\tcodex:a\topenai\tok\t1024\t7\t2048\t2\taaaaaaaaaaaa\tbbbbbbbbbbbb\tcccccccccccc\trecorded\no2\tcodex:a\topenai\tok\t1024\t\t\t\t\t\t\treconstructed\n' >> "$DM/olddataset/slots.tsv"
+OUT=$(run_cadre "$DM" receipts "$DM/olddataset")
+check "model: an old dataset's source column is not a model" \
+  "! grep -q '^Model:' <<<\"\$OUT\" && ! grep -q 'recorded\|reconstructed' <<<\"\$OUT\""
 
 # The benchmark path writes the same field.
 DMB=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DMB" modeller "$HITBOTH" "$HITBOTH"
@@ -4537,6 +4553,32 @@ check "claudecr: asks for the JSON result"        "grep -qx -- '--output-format'
 check "claudecr: unwraps the review text"         "grep -q '^src/x.js:3 -- missing await' <<<\"\$OUT\" && [ $RC -eq 0 ]"
 check "claudecr: and none of the envelope"        "! grep -q 'modelUsage\|\"result\"' <<<\"\$OUT\""
 check "claudecr: declares every served model"     "grep -qx 'model=claude-sub-2,claude-test-1' '$CJM/state'"
+# ★ stderr comes FIRST, as it did under 2>&1: a diagnostic after the review
+# would push the Verdict: line out of the classifier's tail window.
+cat > "$CJ/bin/claude" <<'S'
+#!/bin/sh
+echo "some CLI warning" >&2
+printf '{"type":"result","subtype":"success","is_error":false,"result":"**nit**\\nx.js:1 -- t\\nVerdict: no defects found","modelUsage":{"claude-test-1":{}}}\n'
+S
+OUT=$(CADRE_AGENTS_D="$CJ/agents.d" PATH="$CJ/bin:$PATH" \
+  "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: stderr lands ahead of the review"  "[ \"\$(head -1 <<<\"\$OUT\")\" = 'some CLI warning' ]"
+check "claudecr: and the verdict stays last"        "[ \"\$(tail -1 <<<\"\$OUT\")\" = 'Verdict: no defects found' ] && [ $RC -eq 0 ]"
+# ★ An error object that exited 0 is still an error: its text must not be read
+# as a review that found nothing.
+cat > "$CJ/bin/claude" <<'S'
+#!/bin/sh
+printf '{"type":"result","subtype":"error_during_execution","is_error":true,"result":"Verdict: no defects found","modelUsage":{}}\n'
+exit 0
+S
+OUT=$(CADRE_AGENTS_D="$CJ/agents.d" PATH="$CJ/bin:$PATH" \
+  "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: an error object with exit 0 is nonzero" "[ $RC -ne 0 ] && grep -q 'no defects found' <<<\"\$OUT\""
+# A clock kill with only stderr is NOT a partial review.
+printf '#!/bin/sh\necho "still thinking" >&2\nexit 124\n' > "$CJ/bin/claude"
+OUT=$(CADRE_AGENTS_D="$CJ/agents.d" PATH="$CJ/bin:$PATH" \
+  "$ROOT/bin/agentcall" claudecr -d /tmp -m ro -M low 2>&1 </dev/null); RC=$?
+check "claudecr: timeout with only stderr is DID NOT COMPLETE" "head -1 <<<\"\$OUT\" | grep -q '^DID NOT COMPLETE.*timeout with no output' && grep -q 'still thinking' <<<\"\$OUT\""
 # An error object still carries its text, and the exit code still governs.
 cat > "$CJ/bin/claude" <<'S'
 #!/bin/sh


### PR DESCRIPTION
Closes #51.

**Stacked on #21** (base is `cody/2-benchmark-record-and-state`): it rides the adapter-declaration channel #21 adds. GitHub retargets this to `main` when #21 merges.

Decided on the issue: **record it, don't control it.** The spec's model slot stays spent on the effort level, `--model` is not added.

## What lands

- **`cadre_model <id[,id...]>`** in `bin/agentcall`, next to `cadre_state`, same channel and same trust. Declare only what the CLI *reported*. An adapter that cannot read it says nothing and the field stays EMPTY — never a default, same rule as the hash fields in #52.
- **`claudecr`** asks for `--output-format json`, unwraps `.result`, and declares every key of `.modelUsage` comma-joined — high and xhigh dispatch subagents, so there can be more than one, and naming only the first would hide exactly that. Probed live: `modelUsage` keys are the served model ids. Anything that is not the result object (older CLI, no `jq`) passes through untouched and the field stays EMPTY. stderr is kept out of the object and appended after, so a CLI error still reaches the review text.
- **The record.** `model=` on every `complete` event, panel and benchmark paths. `slots.tsv` gains **column 12**; the report's Receipts table gains a model column; the dataset carries it before `source`. **Not a schema bump**: `v` marks a change to what a column *means*, and no existing column moved — bumping would have split every stored comparison for nothing.
- **`cadre receipts`** names any seat that ran under more than one model and refuses to add those rows together. Stated on the agreement branch too, matching the harness line: an absent warning is indistinguishable from a check that never ran.
- `notes_claudecr` describes the field instead of calling the inheritance a caveat; `docs/ADDING-AN-AGENT.md`, `docs/DATASET.md`, and a non-goal in `docs/ASSURANCE_CASE.md` (records, does not control).

## Acceptance criteria, as resolved on the issue

- [x] A claudecr run record names the model that served it, or leaves the field EMPTY
- [x] A benchmark spanning a model change is visibly marked (two rows, named by `receipts`), not refused
- [x] `notes_claudecr` describes the behavior
- [x] Test: the same seat under two models across two panels

## Tests

1086 + 37 pass, 0 fail. New: declaration reaches the record and column 12; a seat that declares nothing is EMPTY; columns 1–11 did not move; report table names it and leaves the pinned seat blank; the meta file does not outlive the run; receipts split line, agreement line, and silence when no row has the column; dataset header and rows; the benchmark record carries it; claudecr unwraps the JSON and declares both models, an error object keeps its text, plain text passes through undetermined; `cadre_model` is a no-op outside cadre.