### PR TITLE
Tag every run with the change's dominant language; slice the gauntlet by it (#9)

### DIFF
--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -107,6 +107,26 @@ Most panels here have a unique `diff_id`. The one real cluster is four panels
 over `2cfcd0ba..25beedef`, covering five distinct reviewers, with `codex` and
 `grok` each run twice — which is the only repeatability signal in the set.
 
+## `language` — on the run record, observational only
+
+Every `dispatch` and `complete` event in `runs.jsonl` (panel and benchmark
+paths) carries `language`: the dominant language of the change, from an
+extension histogram over the files that changed between base and head in the
+checkout the reviewers saw (`detect_language` in `lib/common.sh`; docs, data
+and lock files are not counted). Deterministic — count desc, then name asc —
+so a tie always resolves the same way. EMPTY when nothing recognisable
+changed, never a guess. The panel manifest carries the same value on a
+`language:` line, blank in that case.
+
+A gauntlet report prints each pass's language and, **only when the graded
+passes span at least two recorded languages**, a `By language (observational)`
+table of blocking hits per language. Read the heading literally. Language and
+repo are confounded — nothing matched those passes for difficulty, and a row
+built from one repo measures that repo — so the table reflects the repos you
+happened to register, not cross-language ground truth. It exists so that
+per-language splits can fall out of ordinary BYO-repo use over time; it is
+not a benchmark claim, and no such claim should be quoted from it.
+
 ## Known blind spots
 
 1. **No ground truth.** Above. This is the big one.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -172,6 +172,49 @@ harness_sha() {
   content_sha "${files[@]}"
 }
 
+# Dominant language of a change, from an extension histogram over the files
+# that changed between <base> and <head> in <dir> (#9). Deterministic: count
+# desc, then name asc, so a tie always picks the same one. Docs, data and lock
+# files are NOT counted -- a change that edits one .ts file and six .md files
+# is a typescript change. EMPTY when nothing recognisable changed; never a
+# guess, because a per-language split downstream would treat a guess as a
+# measurement. Observational by construction: it names the repo people happened
+# to run on, not matched-difficulty ground truth (docs/DATASET.md).
+lang_of_path() {
+  case "${1##*/}" in
+    *.ts|*.tsx|*.mts|*.cts)        echo typescript ;;
+    *.js|*.jsx|*.mjs|*.cjs)        echo javascript ;;
+    *.py)                          echo python ;;
+    *.go)                          echo go ;;
+    *.rs)                          echo rust ;;
+    *.rb)                          echo ruby ;;
+    *.java)                        echo java ;;
+    *.kt|*.kts)                    echo kotlin ;;
+    *.swift)                       echo swift ;;
+    *.cs)                          echo csharp ;;
+    *.php)                         echo php ;;
+    *.scala)                       echo scala ;;
+    *.ex|*.exs)                    echo elixir ;;
+    *.dart)                        echo dart ;;
+    *.lua)                         echo lua ;;
+    *.sh|*.bash|*.zsh)             echo shell ;;
+    *.sql)                         echo sql ;;
+    *.c|*.h)                       echo c ;;
+    *.cc|*.cpp|*.cxx|*.hh|*.hpp)   echo cpp ;;
+    *.m|*.mm)                      echo objective-c ;;
+    *) ;;
+  esac
+}
+detect_language() {  # <dir> <base> <head> -> dominant language, or EMPTY
+  local dir="$1" base="$2" head="${3:-HEAD}"
+  [ -n "$base" ] || return 0
+  # -z: without it git C-quotes a name with non-ASCII or control characters,
+  # and the trailing quote hides the extension from lang_of_path.
+  git -C "$dir" diff -z --name-only "$base" "$head" 2>/dev/null \
+    | while IFS= read -r -d '' f; do lang_of_path "$f"; done \
+    | LC_ALL=C sort | uniq -c | LC_ALL=C sort -k1,1nr -k2,2 | awk 'NR == 1 { print $2 }'
+}
+
 # ★ slots.tsv schema version, stamped on every row THIS harness writes (#20).
 # It describes the ROW, not the run: what the columns mean and which rule
 # produced them. A row without it is not "version 1", it is UNKNOWN -- rows

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -396,6 +396,9 @@ remove that directory and re-run."
   local total_hit=0 total_items=0 unusable=0 suspect=0 extras_all="" graded_passes=0 reference_used=0
   local skipped="" nskipped=0 unquoted_defer=0
   local blocking_unresolved=0 total_unresolved=0 split_notes=""
+  # Per-pass blocking tallies keyed by the pass's recorded language (#9), for
+  # the observational slice at the end. One TSV line per graded pass.
+  local lang_rows="" pass_lang="" pass_bhit=0 pass_btotal=0 pass_bunres=0
   # CLEAN passes are counted apart from the keyed score all the way through:
   # they share no denominator with it and must not share a column either.
   local clean_passes=0 clean_fp=0 clean_labels="" clean_extras=""
@@ -582,6 +585,25 @@ remove that directory and re-run."
     # inference from filenames, and the two must not be confused for each other.
     local pass_record="$CADRE_HOME/$label/runs.jsonl" pass_runs=""
     pass_runs=$(record_rows "$pass_record" complete slug run state rc secs)
+    # ★ Read from the RECORD, never re-detected here: the dispatch layer saw the
+    # checkout the reviewers saw. A pass with no record, or one written before
+    # the field, says so rather than getting a value invented at grade time.
+    # ★ The LAST completion's value, not the last non-empty one: a slot can be
+    # re-dispatched, and an older event's language must not outlive a newer
+    # event that recorded none. Two nothings, told apart: a record whose last
+    # completion carries the field EMPTY detected nothing (docs-only change);
+    # a record with no field at all predates it, or there is no record.
+    local pass_lang_field=""
+    pass_lang=$(record_rows "$pass_record" complete language | tail -1)
+    grep '"event":"complete"' "$pass_record" 2>/dev/null | tail -1 | grep -q '"language":' && pass_lang_field=1
+    pass_bhit=0; pass_btotal=0; pass_bunres=0
+    if [ -n "$pass_lang" ]; then
+      { echo "Language: \`$pass_lang\` (dominant, by changed files; observational)"; echo; } >> "$report"
+    elif [ -n "$pass_lang_field" ]; then
+      { echo "Language: none detected (no recognisable source file changed)"; echo; } >> "$report"
+    else
+      { echo "Language: not recorded"; echo; } >> "$report"
+    fi
     local n
     for n in $(seq 1 "$runs"); do
       local rf="$CADRE_HOME/$label/$sl-run$n.md"
@@ -831,9 +853,9 @@ remove that directory and re-run."
         [ "$v" = HIT ]        && total_hit=$((total_hit + 1))
         [ "$v" = UNRESOLVED ] && total_unresolved=$((total_unresolved + 1))
         if [ "$sev" = blocking ]; then
-          blocking_total=$((blocking_total + 1))
-          [ "$v" = HIT ]        && blocking_hit=$((blocking_hit + 1))
-          [ "$v" = UNRESOLVED ] && blocking_unresolved=$((blocking_unresolved + 1))
+          blocking_total=$((blocking_total + 1)); pass_btotal=$((pass_btotal + 1))
+          [ "$v" = HIT ]        && { blocking_hit=$((blocking_hit + 1)); pass_bhit=$((pass_bhit + 1)); }
+          [ "$v" = UNRESOLVED ] && { blocking_unresolved=$((blocking_unresolved + 1)); pass_bunres=$((pass_bunres + 1)); }
           # ★ A DEFER disqualifies outright, so it must carry the sentence that
           # earned it. An unquoted DEFER cannot be re-checked by anyone, and
           # this harness's graders have split one item in three -- letting a
@@ -983,6 +1005,11 @@ remove that directory and re-run."
         skipped="$skipped- $label: ran, but produced no usable review at all"$'\n'
         measurement_failed=1
       fi
+    fi
+    # Only a pass that scored something joins the slice; a pass that graded
+    # nothing has no denominator to lend to a language.
+    if [ "$pass_usable" -gt 0 ]; then
+      lang_rows="$lang_rows${pass_lang:-unknown}	$label	$pass_bhit	$pass_btotal	$pass_bunres"$'\n'
     fi
     echo >> "$report"
   done < "$CADRE_HOME/passes.conf"
@@ -1186,6 +1213,37 @@ ambiguous. Tighten the key and re-grade. Do not pick a judge."
   # report already knows how to call out.
   if [ "$nskipped" -gt 0 ] || { [ -n "$scoped" ] && [ "$nfiltered" -gt 0 ]; }; then
     partial_note=" (partial denominator)"
+  fi
+
+  # ★ The per-language slice (#9): rendered only when the graded passes span at
+  # least TWO recorded languages, silent otherwise -- one language is not a
+  # split, and a section that says so would read as a finding. Labelled
+  # observational on the line the numbers sit on, because language and repo are
+  # confounded here: nothing matched these passes for difficulty, and a row
+  # built from one repo says nothing about the language. Passes with no
+  # recorded language are listed, not folded into a guess.
+  local nlangs
+  nlangs=$(printf '%s' "$lang_rows" | awk -F '\t' '$1 != "unknown" && !seen[$1]++ { n++ } END { print n + 0 }')
+  if [ "${nlangs:-0}" -ge 2 ]; then
+    {
+      echo "## By language (observational)"
+      echo
+      echo "The passes you registered happen to span these languages. This is NOT a"
+      echo "cross-language benchmark: language and repo are confounded, difficulty is"
+      echo "unmatched, and a row built from one repo measures that repo. Blocking items"
+      echo "only; UNRESOLVED scores nothing either way."
+      echo
+      echo "| language | passes | blocking hit | blocking total | unresolved |"
+      echo "|---|---|---|---|---|"
+      printf '%s' "$lang_rows" | awk -F '\t' '
+        { p[$1]++; h[$1] += $3; t[$1] += $4; u[$1] += $5 }
+        END {
+          for (l in p) if (l != "unknown") printf "%s\t%d\t%d\t%d\t%d\n", l, p[l], h[l], t[l], u[l]
+        }' | LC_ALL=C sort | awk -F '\t' '{ printf "| `%s` | %d | %d | %d | %d |\n", $1, $2, $3, $4, $5 }'
+      printf '%s' "$lang_rows" | awk -F '\t' '$1 == "unknown" { n++ }
+        END { if (n) printf "| none detected / not recorded | %d | - | - | - |\n", n }'
+      echo
+    } >> "$report"
   fi
 
   {

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -80,6 +80,8 @@ PROMPT="$OUT/prompt.txt"
 # panel path. Recomputing per run would describe the tree as it stands after a
 # long pass, which is exactly the difference the field exists to make visible.
 HARNESS_SHA=$(harness_sha)
+# Once per pass, from the checkout the reviewers see (#9). EMPTY is a value.
+CHANGE_LANG=$(detect_language "$CHECKOUT" "$BASE" HEAD)
 if [ -n "${CADRE_PROMPT_FILE:-}" ]; then
   cp "$CADRE_PROMPT_FILE" "$PROMPT"
 else
@@ -141,7 +143,7 @@ for r in "${reviewers[@]}"; do
     # was dispatched. Same guarantee, same shape, as the panel path.
     record_event "$RUNLOG" event=dispatch pass="$label" \
       seat="$r" family="$(spec_family "$r")" slug="$(slug "$r")" "run#=$n" \
-      "prompt_bytes#=$prompt_bytes" "ts#=$start"
+      "prompt_bytes#=$prompt_bytes" language="$CHANGE_LANG" "ts#=$start"
     # ★ .failed and .inconclusive, never .partial. Deleting .partial here threw
     # away real findings the moment a retry produced nothing -- the previous
     # attempt's partial review was the only copy, and this feature exists
@@ -264,7 +266,7 @@ for r in "${reviewers[@]}"; do
       "v#=$SLOTS_SCHEMA_V" prompt_sha="$prompt_sha" \
       adapter_sha="$(adapter_sha "$agent")" harness_sha="$HARNESS_SHA" \
       model="$(sed -n 's/^model=//p' "$f.part.meta" 2>/dev/null | tail -1)" \
-      "ts#=$(date +%s)"
+      language="$CHANGE_LANG" "ts#=$(date +%s)"
     # Same rule as the panel path: the declaration is consumed, the state lives
     # in runs.jsonl, and a stale .meta would classify the NEXT attempt at this
     # slot by this one's field.

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -418,6 +418,9 @@ fi
 # made checkable instead of asked for.
 HARNESS_SHA=$(harness_sha)
 PROMPT_SHA=$(content_sha "$PROMPT")
+# Dominant language of the change, from the checkout itself (#9). In target
+# mode the base is the empty tree, so this is the whole target.
+CHANGE_LANG=$(detect_language "$TPL" "$BASE" HEAD)
 
 # ★ Capability preflight BEFORE any paid call. A seat whose adapter (or model)
 # has declared it cannot do this job is skipped loudly, not dispatched. Same
@@ -465,6 +468,9 @@ unset _kept _spec _block _decl _reason
   echo "base-tree: $btree"
   echo "reviewed-tree: $(git -C "$TPL" rev-parse HEAD^{tree} 2>/dev/null || echo unknown)"
   echo "roster:    ${reviewers[*]}"
+  # Blank when nothing recognisable changed -- the same EMPTY the record carries,
+  # not a stand-in word that would read as a detected value.
+  echo "language:  $CHANGE_LANG"
   # Provenance for the one non-model input. A report saying the suite passed is
   # only checkable if the manifest names the command that was run.
   # tr, because the manifest is one field per line and a multi-line command
@@ -527,7 +533,7 @@ record_complete() {  # <slug> <spec> <state> [rc] [secs]
     adapter_sha="$(sed -n 2p "$shaf" 2>/dev/null)" \
     harness_sha="$HARNESS_SHA" \
     model="$(sed -n 's/^model=//p' "$OUT/$sl.md.part.meta" 2>/dev/null | tail -1)" \
-    "ts#=$(date +%s)"
+    language="$CHANGE_LANG" "ts#=$(date +%s)"
 }
 
 run_one() {
@@ -557,7 +563,7 @@ run_one() {
   # `complete`, so a dispatch with no completion IS the signal that a seat was
   # cut off mid-flight -- not a gap to be guessed at later.
   record_event "$RUNLOG" event=dispatch panel="$(basename "$OUT")" \
-    seat="$spec" family="$(spec_family "$spec")" slug="$sl" "ts#=$(date +%s)"
+    seat="$spec" family="$(spec_family "$spec")" slug="$sl" language="$CHANGE_LANG" "ts#=$(date +%s)"
   # ★ A roster member that is not installed is a FAILURE, not a skip. run-pass
   # prints "skipping" and moves on, which in a live review is indistinguishable
   # from a reviewer that ran and found nothing.
@@ -722,7 +728,7 @@ for row in "${skipped_rows[@]}"; do
     state=skipped "rc#=" "secs#=" "bytes#=0" "prompt_bytes#=0" \
     "v#=$SLOTS_SCHEMA_V" prompt_sha= \
     adapter_sha="$(adapter_sha "$(spec_agent "$sk_spec")")" \
-    harness_sha="$HARNESS_SHA" model= "ts#=$(date +%s)"
+    harness_sha="$HARNESS_SHA" model= language="$CHANGE_LANG" "ts#=$(date +%s)"
 done
 
 i=0; running=0

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -4604,6 +4604,102 @@ STANDALONE=$(CADRE_AGENTS_D="$DM/agents.d" PATH="$DM/bin:$PATH" \
 check "model: cadre_model is a no-op outside cadre" \
   "grep -q 'a finding' <<<\"\$STANDALONE\" && ! grep -qi 'cadre_model\|CADRE_RUN_META' <<<\"\$STANDALONE\""
 
+echo "== ★ #9: language on the run record, observational slice in the report =="
+# Deterministic detection: count desc, then name asc; docs never count; EMPTY
+# when nothing recognisable changed.
+DLG=$(mktemp -d -p "$SANDBOX"); new_repo "$DLG/r"
+LB=$(git -C "$DLG/r" rev-parse HEAD)
+printf 'x\n' > "$DLG/r/a.py"; printf 'x\n' > "$DLG/r/b.py"; printf 'x\n' > "$DLG/r/c.js"
+printf 'x\n' > "$DLG/r/d.md"; printf 'x\n' > "$DLG/r/e.md"; printf 'x\n' > "$DLG/r/f.md"
+git -C "$DLG/r" add -A; git -C "$DLG/r" commit -qm langs
+LANGF="bash -c 'source \"$ROOT/lib/common.sh\"; detect_language \"\$1\" \"\$2\" HEAD' _"
+check "lang: the dominant code language wins, docs do not count" \
+  "[ \"\$($LANGF '$DLG/r' '$LB')\" = python ]"
+git -C "$DLG/r" checkout -q "$LB" 2>/dev/null; git -C "$DLG/r" checkout -q -B tie
+printf 'x\n' > "$DLG/r/x.rs"; printf 'x\n' > "$DLG/r/y.go"
+git -C "$DLG/r" add -A; git -C "$DLG/r" commit -qm tie
+check "lang: a tie resolves by name, the same way every time" \
+  "[ \"\$($LANGF '$DLG/r' '$LB')\" = go ]"
+git -C "$DLG/r" checkout -q "$LB" 2>/dev/null; git -C "$DLG/r" checkout -q -B docsonly
+printf 'x\n' > "$DLG/r/README.md"; git -C "$DLG/r" add -A; git -C "$DLG/r" commit -qm docs
+check "lang: nothing recognisable is EMPTY, not a guess" \
+  "[ -z \"\$($LANGF '$DLG/r' '$LB')\" ]"
+check "lang: no base is EMPTY too" "[ -z \"\$($LANGF '$DLG/r' '')\" ]"
+# A name git would C-quote without -z: the extension must still be seen.
+git -C "$DLG/r" checkout -q "$LB" 2>/dev/null; git -C "$DLG/r" checkout -q -B unicode
+printf 'x\n' > "$DLG/r/café.py"; git -C "$DLG/r" add -A; git -C "$DLG/r" commit -qm unicode
+check "lang: a non-ASCII filename still counts" "[ \"\$($LANGF '$DLG/r' '$LB')\" = python ]"
+
+# The panel path stamps it on the manifest and on every record line.
+DLP=$(case_dir langpanel)
+git -C "$DLP/src" checkout -qb feature; echo more >> "$DLP/src/app.js"; git -C "$DLP/src" commit -qam feat
+run_cadre "$DLP" review --roster good --synth none --base main --label lp "$DLP/src" >/dev/null
+RLP="$DLP/state/reviews/lp"
+check "lang: the manifest names it"            "grep -q '^language:  javascript$' '$RLP/manifest.txt'"
+check "lang: the dispatch event carries it"    "grep '\"event\":\"dispatch\"' '$RLP/runs.jsonl' | grep -q '\"language\":\"javascript\"'"
+check "lang: the complete event carries it"    "grep '\"event\":\"complete\"' '$RLP/runs.jsonl' | grep -q '\"language\":\"javascript\"'"
+
+# The benchmark path: two passes in two languages, each with a real base so
+# the checkout has a change to classify. The slice appears; a single-language
+# sweep prints no slice at all.
+# `finder`, not `terse`: terse deliberately returns no review, so a pass that
+# actually runs it is unusable and lends nothing to the slice.
+DL2=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DL2" finder "$HITBOTH" "$HITBOTH"
+SLT=$(slug finder); JA=$(slug good); JB=$(slug good2)
+echo change >> "$DL2/checkout/app.js"; git -C "$DL2/checkout" commit -qam change
+S1=$(git -C "$DL2/checkout" rev-parse HEAD); B1=$(git -C "$DL2/checkout" rev-parse HEAD~1)
+new_repo "$DL2/checkout2"; printf 'print(1)\n' > "$DL2/checkout2/main.py"
+git -C "$DL2/checkout2" add -A; git -C "$DL2/checkout2" commit -qm py
+S2=$(git -C "$DL2/checkout2" rev-parse HEAD); B2=$(git -C "$DL2/checkout2" rev-parse HEAD~1)
+mkdir -p "$DL2/home/p2"
+printf '%s\n' "$HITBOTH" > "$DL2/home/p2/$SLT-run1.by-$JA.grade.json"
+printf '%s\n' "$HITBOTH" > "$DL2/home/p2/$SLT-run1.by-$JB.grade.json"
+{ printf 'p1|%s|%s|%s|%s\n' "$S1" "$DL2/checkout" "$B1" "$DL2/home/k.md"
+  printf 'p2|%s|%s|%s|%s\n' "$S2" "$DL2/checkout2" "$B2" "$DL2/home/k.md"
+} > "$DL2/home/passes.conf"
+rm -f "$DL2/home/p1/$SLT-run1.md"                 # make both passes actually run
+run_gaunt_all "$DL2" good,good2 finder >/dev/null 2>&1 || true
+RL2=$(ls "$DL2/home"/report-*.md | head -1)
+check "lang: each pass names its language"     "grep -q 'Language: \`javascript\`' '$RL2' && grep -q 'Language: \`python\`' '$RL2'"
+check "lang: the slice renders across two languages" "grep -q '^## By language (observational)' '$RL2'"
+check "lang: one row per language, blocking items only" \
+  "grep -qF '| \`javascript\` | 1 | 2 | 2 | 0 |' '$RL2' && grep -qF '| \`python\` | 1 | 2 | 2 | 0 |' '$RL2'"
+check "lang: and it says what it is not"       "grep -q 'NOT a' '$RL2' && grep -q 'confounded' '$RL2'"
+# A docs-only pass detects nothing, is said so, and is listed apart in the
+# slice rather than folded into a language.
+new_repo "$DL2/checkout3"; printf 'notes\n' > "$DL2/checkout3/NOTES.md"
+git -C "$DL2/checkout3" add -A; git -C "$DL2/checkout3" commit -qm docs
+S3=$(git -C "$DL2/checkout3" rev-parse HEAD); B3=$(git -C "$DL2/checkout3" rev-parse HEAD~1)
+mkdir -p "$DL2/home/p3"
+printf '%s\n' "$HITBOTH" > "$DL2/home/p3/$SLT-run1.by-$JA.grade.json"
+printf '%s\n' "$HITBOTH" > "$DL2/home/p3/$SLT-run1.by-$JB.grade.json"
+printf 'p3|%s|%s|%s|%s\n' "$S3" "$DL2/checkout3" "$B3" "$DL2/home/k.md" >> "$DL2/home/passes.conf"
+run_gaunt_all "$DL2" good,good2 finder >/dev/null 2>&1 || true
+RL2=$(ls -t "$DL2/home"/report-*.md | head -1)
+check "lang: a docs-only change reads 'none detected'" "grep -q '^Language: none detected' '$RL2'"
+check "lang: and is listed apart in the slice" "grep -qF '| none detected / not recorded | 1 | - | - | - |' '$RL2'"
+# ★ The LAST completion decides. An older event naming a language must not
+# outlive a newer one that recorded none.
+printf '{"event":"complete","pass":"p3","seat":"finder","slug":"%s","run":1,"state":"ok","language":"javascript"}\n{"event":"complete","pass":"p3","seat":"finder","slug":"%s","run":1,"state":"ok","language":""}\n' "$SLT" "$SLT" > "$DL2/home/p3/runs.jsonl"
+CADRE_HOME="$DL2/home" CADRE_WORK="$DL2/work" CADRE_AGENTS_D="$DL2/agents.d" CADRE_JUDGE=good,good2 PATH="$DL2/bin:$PATH" \
+  "$ROOT/bin/cadre" grade finder 1 p3 >/dev/null 2>&1 || true
+RL3=$(ls -t "$DL2/home"/report-*-only-p3-*.md | head -1)
+check "lang: a stale earlier value is not resurrected" "grep -q '^Language: none detected' '$RL3' && ! grep -q 'Language: \`javascript\`' '$RL3'"
+# Exactly ONE recorded language is not a split: no slice.
+DL1=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DL1" finder "$HITBOTH" "$HITBOTH"
+echo change >> "$DL1/checkout/app.js"; git -C "$DL1/checkout" commit -qam change
+S4=$(git -C "$DL1/checkout" rev-parse HEAD); B4=$(git -C "$DL1/checkout" rev-parse HEAD~1)
+printf 'p1|%s|%s|%s|%s\n' "$S4" "$DL1/checkout" "$B4" "$DL1/home/k.md" > "$DL1/home/passes.conf"
+rm -f "$DL1/home/p1/$SLT-run1.md"
+run_gaunt_all "$DL1" good,good2 finder >/dev/null 2>&1 || true
+RL1=$(ls "$DL1/home"/report-*.md | head -1)
+check "lang: one recorded language renders no slice" "grep -q 'Language: \`javascript\`' '$RL1' && ! grep -q 'By language' '$RL1'"
+# And a pass with no record at all says so.
+DL0=$(mktemp -d -p "$SANDBOX"); gauntlet_case "$DL0" terse "$HITBOTH" "$HITBOTH"
+run_gaunt "$DL0" good,good2 terse >/dev/null 2>&1 || true
+RL0=$(ls "$DL0/home"/report-*.md | head -1)
+check "lang: no record reads 'not recorded'"   "grep -q '^Language: not recorded' '$RL0'"
+
 echo
 echo "$PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #9.

The nearly-free version the issue asks for: tag every run with the language of what was reviewed, and let per-language splits fall out of ordinary BYO-repo use — without claiming a cross-language benchmark.

## What lands

- **`detect_language <dir> <base> <head>`** in `lib/common.sh`: an extension histogram over the files that changed between base and head in the checkout the reviewers saw. Deterministic — count desc, then name asc, so a tie resolves the same way every time. Docs, data and lock files do not count (one `.ts` and six `.md` is a typescript change). **EMPTY when nothing recognisable changed, never a guess.**
- **Both dispatch layers stamp it.** `language=` on every `dispatch` and `complete` event in `runs.jsonl`, panel and benchmark paths; the panel manifest carries it on a `language:` line, blank when EMPTY. Not a `slots.tsv` column — this is a fact about the change, not about a seat.
- **The gauntlet report** prints each pass's language, read from the **record**, never re-detected at grade time (the dispatch layer saw the checkout the reviewers saw; a pass with no record reads `Language: not recorded`). **Only when the graded passes span at least two recorded languages** does a `## By language (observational)` table render: passes, blocking hit, blocking total, unresolved, per language, with passes lacking a record listed as *not recorded* rather than folded into a guess. One language renders no section at all.
- The section's own text says what it is not: language and repo are confounded, difficulty is unmatched, and a row built from one repo measures that repo.

Field name and shape match the `pass.language` string sketched in #1's telemetry payload.

## Acceptance criteria

- [x] Run record carries `language`, populated by the dispatch layer
- [x] Detection is deterministic and tested (dominant wins over docs; a tie resolves by name; docs-only is EMPTY; no base is EMPTY)
- [x] Report renders a per-language split only when ≥2 languages exist; silent otherwise
- [x] Wording calls the split observational and disclaims cross-language claims
- [x] Shape matches #1's `pass.language`

## Tests

1106 + 37 pass, 0 fail. New: four detection cases; the panel manifest and both record events carry it; a two-language two-pass gauntlet renders the slice with one row per language and blocking items only; a single-pass gauntlet with no record reads *not recorded* and renders no slice.