### PR TITLE
agy: retry the flaky close, and put the attempt count on the record

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,13 @@ Budget the wall-clock: on defaults a run that stays limited costs about three
 minutes before giving up. Each wait is printed, so it is not hung. On a tight
 free tier, lower `CADRE_RETRIES` or run one reviewer at a time.
 
+One adapter has a second, narrower retry. `agy`'s print stream sometimes ends
+`status=ERROR` with a complete review already written, minutes inside every
+clock. That is a transport flake, not a limit, so `agents.d/agy.sh` re-runs the
+same model up to `CADRE_AGY_RETRIES` times (default 3) and records the count on
+the run record as `adapter_attempts`. It never retries past cadre's timeout or agy's
+own, and a refusal (which arrives as `SUCCESS` text) is never retried.
+
 ## It won't leak your answers or your secrets
 
 If the key is "the bug the author fixed next," then the fix commit's subject line

--- a/agents.d/agy.sh
+++ b/agents.d/agy.sh
@@ -72,6 +72,11 @@ original closing sentence suppressed the brief's own verdict line.
 ⚠️ It wanders. Given a loose target it has read files outside the directory it
 was pointed at. Scope it with --add-dir and keep the prompt specific.
 
+★ Flaky close: the print stream sometimes ends status=ERROR with the full review
+already written. The adapter retries the same model up to CADRE_AGY_RETRIES (3)
+times, never past cadre's clock or agy's own; the count lands in runs.jsonl as
+adapter_attempts. Read adapter_attempts>1 as a transport retry, not a second review.
+
 Line attribution runs about one off (reported 860 lines for an 859-line file),
 so sanity-check its file:line citations before grading it on them.
 NOTES
@@ -111,12 +116,41 @@ run_agy() {
   # already generated and discarded. The outer `timeout` never fired, so this
   # read as a model failure rather than a clock. Align them, and leave the outer
   # one as the backstop for a CLI that hangs without honouring its own flag.
-  timeout -k 30 "$TIMEOUT" agy -p "$ptr" "${m[@]}" \
-    --add-dir "$dir" --add-dir "$pd" --print-timeout "${TIMEOUT}s" \
-    --dangerously-skip-permissions --output-format json >"$out" 2>/dev/null
-  rc=$?
+  #
+  # ★ And it FLAKES. The print stream intermittently ends status=ERROR ("timeout
+  # waiting for response") with a complete review already in .response, minutes
+  # inside both clocks. Measured twice: 2026-08-19 (ERROR at 185s, identical
+  # retry SUCCESS at 155s) and 2026-09-02 (ERROR at 425s, retry SUCCESS at
+  # 390s; 1 flake in 13 calls). Under runs=1 that flake zeroes the pass and
+  # `cadre run` aborts the whole sweep on it (exit 4), so an unattended agy
+  # sweep could not finish. Retry the SAME model on the SAME prompt when the run
+  # did not end SUCCESS, with two exclusions that keep a retry from masking
+  # something real: the outer clock fired (rc >= 124: cadre's timeout, a hang,
+  # not a flake), or agy's own clock did (the attempt ran out most of TIMEOUT,
+  # so another attempt just triples the wait). A refusal comes back as SUCCESS
+  # text and is never retried. Attempts are recorded over the meta channel and
+  # land in runs.jsonl as adapter_attempts, never on stderr: run-pass merges
+  # stderr into the review and a judge would read it.
+  local attempt=0 max="${CADRE_AGY_RETRIES:-3}" t0
+  # A knob that is not a whole number would print bash's arithmetic diagnostic
+  # INTO the review and never satisfy -ge; fall back to the default instead.
+  case "$max" in ''|*[!0-9]*) max=3 ;; esac
+  while :; do
+    attempt=$((attempt + 1)); t0=$SECONDS
+    timeout -k 30 "$TIMEOUT" agy -p "$ptr" "${m[@]}" \
+      --add-dir "$dir" --add-dir "$pd" --print-timeout "${TIMEOUT}s" \
+      --dangerously-skip-permissions --output-format json >"$out" 2>/dev/null
+    rc=$?
+    status=$(jq -r '.status // "MISSING"' "$out" 2>/dev/null)
+    [ "$status" = SUCCESS ] && break
+    [ "$rc" -ge 124 ] && break
+    [ $((SECONDS - t0)) -ge $((TIMEOUT * 9 / 10)) ] && break
+    [ "$attempt" -ge "$max" ] && break
+  done
+  # Generic key: run-pass / run-review copy it onto the complete record as
+  # adapter_attempts, beside the harness's own rate-limit `attempts`.
+  [ -n "${CADRE_RUN_META:-}" ] && printf 'attempts=%s\n' "$attempt" >> "$CADRE_RUN_META"
 
-  status=$(jq -r '.status // "MISSING"' "$out" 2>/dev/null)
   text=$(jq -r '.response // ""' "$out" 2>/dev/null)
 
   if [ -n "$text" ] && [ "$status" = SUCCESS ]; then

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -266,6 +266,7 @@ for r in "${reviewers[@]}"; do
       "v#=$SLOTS_SCHEMA_V" prompt_sha="$prompt_sha" \
       adapter_sha="$(adapter_sha "$agent")" harness_sha="$HARNESS_SHA" \
       model="$(sed -n 's/^model=//p' "$f.part.meta" 2>/dev/null | tail -1)" \
+      "adapter_attempts#=$(sed -n 's/^attempts=//p' "$f.part.meta" 2>/dev/null | tail -1)" \
       language="$CHANGE_LANG" "ts#=$(date +%s)"
     # Same rule as the panel path: the declaration is consumed, the state lives
     # in runs.jsonl, and a stale .meta would classify the NEXT attempt at this

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -533,6 +533,7 @@ record_complete() {  # <slug> <spec> <state> [rc] [secs]
     adapter_sha="$(sed -n 2p "$shaf" 2>/dev/null)" \
     harness_sha="$HARNESS_SHA" \
     model="$(sed -n 's/^model=//p' "$OUT/$sl.md.part.meta" 2>/dev/null | tail -1)" \
+    "adapter_attempts#=$(sed -n 's/^attempts=//p' "$OUT/$sl.md.part.meta" 2>/dev/null | tail -1)" \
     language="$CHANGE_LANG" "ts#=$(date +%s)"
 }
 

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -948,6 +948,65 @@ check "and aligns agy's own timeout" "grep -q -- '--print-timeout \"\${TIMEOUT}s
 check "and parses status not stdout"  "grep -q \"jq -r '.status\" '$ROOT/agents.d/agy.sh'"
 check "and names its kind of nothing" "grep -q 'DID NOT COMPLETE' '$ROOT/agents.d/agy.sh'"
 check "and exits nonzero on truncation" "grep -q '_TRUNCATED, agy ended' '$ROOT/agents.d/agy.sh'"
+# ★ agy FLAKES: the print stream ends status=ERROR with the review already in
+# .response, minutes inside both clocks (measured 2026-08-19 and 2026-09-02).
+# Under runs=1 that zeroed the pass and `cadre run` aborted the sweep (exit 4).
+# The adapter now retries the same model. Driven end-to-end against a fake agy
+# so the loop's exclusions are tested as behaviour, not pinned as text.
+AF="$SANDBOX/agyfake"; mkdir -p "$AF/bin"
+cat > "$AF/bin/agy" <<'FAKE'
+#!/bin/sh
+# Flaky agy: ERROR until call number $AGYFAKE_OK, SUCCESS from then on. An
+# AGYFAKE_SLEEP that outlives the caller's clock stands in for a real hang.
+c=$(cat "$AGYFAKE_COUNT" 2>/dev/null || echo 0); c=$((c + 1)); echo "$c" > "$AGYFAKE_COUNT"
+[ -n "${AGYFAKE_SLEEP:-}" ] && sleep "$AGYFAKE_SLEEP"
+if [ "$c" -lt "${AGYFAKE_OK:-1}" ]; then
+  echo "{\"status\":\"ERROR\",\"response\":\"partial review $c\"}"
+else
+  echo '{"status":"SUCCESS","response":"full review"}'
+fi
+FAKE
+chmod +x "$AF/bin/agy"
+# run_agy with the adapter's variable contract set the way agentcall sets it.
+agyfake() {  # $1 = AGYFAKE_OK, $2 = TIMEOUT, rest = extra env
+  rm -f "$AF/n" "$AF/meta"
+  env -i PATH="$AF/bin:$PATH" HOME="$HOME" AGYFAKE_COUNT="$AF/n" AGYFAKE_OK="$1" "${@:3}" \
+    bash -c "TIMEOUT=$2; DRY=; dir='$AF'; model=''; prompt='review this'; CADRE_RUN_META='$AF/meta'
+             source '$ROOT/agents.d/agy.sh'; run_agy; echo \"rc=\$?\"" > "$AF/out" 2>&1 < /dev/null
+  # ★ </dev/null is not decoration. GNU timeout runs its child in a background
+  # process group, and with this suite's inherited stdin the fake never ran at
+  # all: every case sat out the full clock and filed "DID NOT COMPLETE". The
+  # real path is immune (agentcall's stdin is the prompt file, at EOF).
+}
+# ★ The review is compared WHOLE, not grepped: a stale attempt-1 line surviving
+# in $out, or a retry note on stderr, would both be invisible to a positive grep.
+agyfake 2 60
+check "agy retry: flake then SUCCESS is a clean pass"  "[ \"\$(cat '$AF/out')\" = \$'full review\\nrc=0' ]"
+check "agy retry: took exactly two attempts"           "[ \"\$(cat '$AF/n')\" = 2 ]"
+check "agy retry: attempts recorded in run meta"       "grep -qx 'attempts=2' '$AF/meta'"
+agyfake 1 60
+check "agy retry: SUCCESS first time = one call"       "[ \"\$(cat '$AF/n')\" = 1 ] && grep -qx 'attempts=1' '$AF/meta'"
+agyfake 9 60
+check "agy retry: gives up after CADRE_AGY_RETRIES (3)" "[ \"\$(cat '$AF/n')\" = 3 ]"
+check "agy retry: and the LAST partial is kept, marked" "[ \"\$(cat '$AF/out')\" = \$'partial review 3\\n\\n_TRUNCATED, agy ended with status=ERROR (exit 0); this review is INCOMPLETE, not a clean pass._\\nrc=1' ]"
+agyfake 9 60 CADRE_AGY_RETRIES=1
+check "agy retry: CADRE_AGY_RETRIES=1 disables it"     "[ \"\$(cat '$AF/n')\" = 1 ]"
+agyfake 9 60 CADRE_AGY_RETRIES=0
+check "agy retry: CADRE_AGY_RETRIES=0 is one call too" "[ \"\$(cat '$AF/n')\" = 1 ]"
+# A knob that is not a number falls back to the default and prints NOTHING
+# into the review (bash's arithmetic error would otherwise land there).
+agyfake 2 60 CADRE_AGY_RETRIES=lots
+check "agy retry: a non-numeric knob = default, silent" "[ \"\$(cat '$AF/n')\" = 2 ] && [ \"\$(cat '$AF/out')\" = \$'full review\\nrc=0' ]"
+# The outer clock firing is a hang, not a flake: no retry, and the nothing is named.
+agyfake 2 1 AGYFAKE_SLEEP=5
+check "agy retry: cadre's timeout is NOT retried"      "[ \"\$(cat '$AF/n')\" = 1 ] && grep -q 'DID NOT COMPLETE, agy hit the 1s timeout' '$AF/out'"
+# agy's OWN clock firing looks like ERROR inside the outer timeout. An attempt
+# that used most of TIMEOUT (here 2.5s of 3, past the 90% line) is not retried
+# either, or one slow pass would run three times the budget.
+agyfake 9 3 AGYFAKE_SLEEP=2.5
+check "agy retry: an attempt that ate the clock is NOT retried" "[ \"\$(cat '$AF/n')\" = 1 ] && grep -q '_TRUNCATED, agy ended with status=ERROR' '$AF/out'"
+check "agy retry: loop is env-tunable"                 "grep -q 'CADRE_AGY_RETRIES:-3' '$ROOT/agents.d/agy.sh'"
+check "agy retry: run-pass copies the count onto the record" "grep -q 'adapter_attempts#=' '$ROOT/lib/run-pass.sh'"
 # ⚠️ ro is UNENFORCED here and the adapter must keep saying so. --mode plan does NOT
 # block writes (measured: it created the file anyway), and skip-permissions is
 # mandatory for it to read at all. Containment is cadre's disposable checkout, not
@@ -4484,6 +4543,24 @@ check "model: and leave the pinned seat blank" \
   "grep -qF '| \`good\` |  | ok |' '$RM1/report.md'"
 check "model: the meta file does not outlive the run" \
   "! ls '$RM1'/*.meta >/dev/null 2>&1"
+# ★ Same channel, second key: an adapter that had to retry its CLI (agy.sh)
+# declares attempts=N and the record carries it as adapter_attempts, beside the
+# harness's own rate-limit `attempts`. A seat that declares nothing reads null.
+cat > "$DM/agents.d/retrier.sh" <<A
+run_retrier() {
+  [ -n "\${CADRE_RUN_META:-}" ] && printf 'attempts=2\n' >> "\$CADRE_RUN_META"
+  echo "**should-fix**"
+  echo "app.js:1 -- a finding"
+  echo "Verdict: should-fix"
+}
+A
+printf '#!/bin/sh\nexit 0\n' > "$DM/bin/retrier"; chmod +x "$DM/bin/retrier"
+run_cadre "$DM" review --roster retrier,good --synth none --base main --label m1r "$DM/src" >/dev/null
+RM1R="$DM/state/reviews/m1r"
+check "attempts: the adapter's count reaches the record" \
+  "grep -q '\"seat\":\"retrier\".*\"adapter_attempts\":2' '$RM1R/runs.jsonl'"
+check "attempts: a seat that declares none is null, not 0" \
+  "grep -q '\"seat\":\"good\".*\"adapter_attempts\":null' '$RM1R/runs.jsonl'"
 # The same seat under a different default: two rows, named as such.
 echo model-beta > "$DM/served-model"
 run_cadre "$DM" review --roster modeller,good --synth none --base main --label m2 "$DM/src" >/dev/null


### PR DESCRIPTION
## What

`agy`'s print stream intermittently ends `status=ERROR` ("timeout waiting for response") with a complete review already in `.response`, minutes inside both clocks. Measured 2026-08-19 (ERROR at 185s, identical retry SUCCESS at 155s) and again 2026-09-02 (ERROR at 425s, retry SUCCESS at 390s; 1 flake in 13 calls). Under `runs=1` that zeroed the pass and `cadre run` aborted the sweep on exit 4, so an unattended agy sweep could not finish.

`agents.d/agy.sh` now re-runs the same model on the same prompt when the run did not end SUCCESS, up to `CADRE_AGY_RETRIES` (default 3). Two exclusions keep a retry from masking something real:

- the outer `timeout` fired (`rc >= 124`): a hang, not a flake
- the attempt used 90% of `TIMEOUT`: agy's own `--print-timeout` is aligned to it, so another attempt only triples the wait

A refusal arrives as SUCCESS text and is never retried. When every attempt fails the last partial is still emitted with the `_TRUNCATED` marker, so `.partial` handling downstream is unchanged.

## Where the count goes

Not stderr: `run-pass` merges it into the review and a judge would read it. The adapter writes `attempts=N` over the meta channel and both dispatch paths (`lib/run-pass.sh`, `lib/run-review.sh`) copy it onto the complete record as `adapter_attempts`, beside the harness's own rate-limit `attempts`. A seat that declares nothing reads `null`.

## Tests

`tests/review-smoke.sh`: 15 new checks. `run_agy` is driven end to end against a fake `agy` on PATH (ERROR until call N, then SUCCESS; optional sleep for the clock cases). The review is compared whole, not grepped, so a stale attempt-1 line or a stderr note would fail it. Each exclusion has a case (outer timeout, ate-the-clock, `CADRE_AGY_RETRIES` = 1 / 0 / non-numeric). The record field is checked through a real `cadre review` with a stub adapter. Suite: 1125 passed, 0 failed.

Codex reviewed the first cut as lead reviewer; its four should-fix items (knob validation, count not reaching the record, untested elapsed guard, grep-permissive assertions) are all addressed here.