### PR TITLE
Finish coverage reporting and verify mined bug/fix pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,24 @@ and a model grades measures agreement with the model, so you read the draft
 before the pass will register. The setup step needs a human. `cadre run` after
 it does not.
 
+`cadre setup ~/my-repo --verify` optionally runs each shortlisted fix's tests
+twice: once at the fix, then on a fresh copy with only its source changes
+reverted and its tests retained. `verified` means the first command passed and
+the second failed. Rows that cannot establish that stay `unverified` (or
+`no-test-cmd`); they are not dropped. Review the saved logs before accepting a
+key: a failure can still be environmental, and one green/red pair does not
+establish that a suite is free of flakes or that the blamed target introduced
+the bug.
+
+**Verification executes repository code on your machine, without a sandbox.**
+Test scripts can access your environment and network. It is off by default;
+`CADRE_VERIFY_PAIRS=1` also enables it. Both copies live temporarily under
+`CADRE_WORK`, outside the source repo and `CADRE_HOME`. Cadre does not install
+dependencies. Use `CADRE_TEST_CMD` to override the detected full-suite command
+and `CADRE_VERIFY_TIMEOUT` to change the 120-second limit per arm. Timeouts,
+signals, and command launch errors never count as proof. Commands, exit codes,
+logs, and the source-revert patch stay in `CADRE_HOME/verification/`.
+
 ## Where the answer key comes from
 
 Not from a model's opinion. From what the author actually fixed next.

--- a/bin/cadre
+++ b/bin/cadre
@@ -422,6 +422,7 @@ cmd_panel() {
 
   local rows=() passes=() invalid=() r line pass base judge spec rowid
   declare -A grade seen rowspec passitems firstv flip
+  declare -A filecov_sum filecov_runs
   for r in "${reports[@]}"; do
     spec=$(sed -n '1s/^# Gauntlet: `\(.*\)`$/\1/p' "$r"); [ -n "$spec" ] || continue
     # ★ An INVALID report measured nothing about the candidate. Its surviving
@@ -450,6 +451,15 @@ cmd_panel() {
         continue
       fi
       [ -n "$pass" ] || continue
+      # Same measured-run mean as the grade report. Older reports and empty
+      # denominators stay unavailable; absence is never fabricated as zero.
+      if [[ "$line" =~ ^-\ run\ [0-9]+\ coverage:\ ([0-9]+)/([0-9]+)\ changed\ files\ mentioned ]]; then
+        local covered_files=${BASH_REMATCH[1]} measured_files=${BASH_REMATCH[2]}
+        if [ "$measured_files" -gt 0 ] && [ "$covered_files" -le "$measured_files" ]; then
+          filecov_sum[$rowid,$pass]=$(( ${filecov_sum[$rowid,$pass]:-0} + 100 * covered_files / measured_files ))
+          filecov_runs[$rowid,$pass]=$(( ${filecov_runs[$rowid,$pass]:-0} + 1 ))
+        fi
+      fi
       local kv k v
       for kv in $(grep -oE '\bK[0-9]+=(HIT|DEFER|MISS)' <<<"$line"); do
         k=${kv%%=*}; v=${kv#*=}
@@ -500,18 +510,25 @@ cmd_panel() {
       echo "${pfx}pass $p"
       printf '%s%-44s' "$pfx" 'CANDIDATE'
       for ki in $(panel_items "$p"); do printf '%-8s' "$ki"; done
-      echo
+      echo 'FILES % (runs)'
       for s in "${rows[@]}"; do
         printf '%s%-44s' "$pfx" "$s"
         for ki in $(panel_items "$p"); do
           printf '%-8s' "${grade[$s,$p,$ki]:-.}${flip[$s,$p,$ki]:+*}"
         done
-        echo
+        if [ "${filecov_runs[$s,$p]:-0}" -gt 0 ]; then
+          echo "$((filecov_sum[$s,$p] / filecov_runs[$s,$p]))% (${filecov_runs[$s,$p]})"
+        else
+          echo '-'
+        fi
       done
       echo "$pfx"
     done
   }
   panel_matrix ''
+  echo 'FILES: mean changed-file mention coverage across measured runs; - is unavailable.'
+  echo 'Shared basenames are excluded. Mentions do not prove a file was reviewed.'
+  echo
 
   local gaps=() deferrers=() p ki s
   for p in "${passes[@]}"; do
@@ -571,6 +588,7 @@ cmd_panel() {
   echo
   echo "Pick the smallest set of rows that covers every column. Prefer a"
   echo "candidate that covers a column no one else does, even at a lower total."
+  echo "Weigh FILES alongside item hits; a high hit rate can still leave files unmentioned."
   echo "cadre does not choose for you."
 
   [ "$save" = 1 ] || return 0

--- a/bin/cadre
+++ b/bin/cadre
@@ -48,7 +48,8 @@ usage() {
 Code Review Cadre: benchmark AI code reviewers on YOUR repo, staff a panel,
 then run that panel on the code you are about to ship.
 
-  cadre setup <repo-dir> [limit]        mine (target, fix) commit pairs
+  cadre setup <repo-dir> [limit] [--verify]
+                                        mine pairs; optionally execute tests
   cadre make-pass <label> <repo-dir> <target-sha> <fix-sha>
                                         build the leak-controlled checkout and
                                         DRAFT an answer key for you to correct
@@ -198,12 +199,28 @@ cmd_passes() {
 }
 
 cmd_setup() {
-  local repo="${1:?usage: cadre setup <repo-dir> [limit]}" limit="${2:-200}"
-  [ -d "$repo/.git" ] || die "not a git repo: $repo"
+  local repo='' limit=200 have_limit=0 verify="${CADRE_VERIFY_PAIRS:-0}" arg
+  for arg in "$@"; do
+    case "$arg" in
+      --verify) verify=1 ;;
+      --*) die "unknown setup option: $arg" ;;
+      *) if [ -z "$repo" ]; then repo="$arg"
+         elif [ "$have_limit" -eq 0 ]; then limit="$arg"; have_limit=1
+         else die "usage: cadre setup <repo-dir> [limit] [--verify]"; fi ;;
+    esac
+  done
+  [ -n "$repo" ] || die "usage: cadre setup <repo-dir> [limit] [--verify]"
+  case "$limit" in ''|*[!0-9]*|0) die "setup limit must be a positive integer" ;; esac
+  git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || die "not a git repo: $repo"
+  repo=$(git -C "$repo" rev-parse --show-toplevel) || die "setup needs a working-tree repository"
+  if [ "$verify" = 1 ]; then
+    . "$CADRE_ROOT/lib/verify-pair.sh"
+    verify_pairs_check "$repo"
+  fi
   init_home
   local out="$CADRE_HOME/shortlist-$(basename "$(readlink -f "$repo")").tsv"
   echo "mining fix-commit pairs in $repo (last $limit fix-shaped commits)…"
-  "$CADRE_ROOT/lib/mine-fixes.sh" "$repo" "$limit" | tee "$out"
+  CADRE_VERIFY_PAIRS="$verify" "$CADRE_ROOT/lib/mine-fixes.sh" "$repo" "$limit" | tee "$out" || return $?
   echo
   # ★ Do not tell someone to "pick a row" from an empty table. The miner has
   # already explained on stderr WHICH filter emptied it; this only has to stop
@@ -220,9 +237,9 @@ EOF
   echo "saved: $out"
   cat <<EOF
 
-Each of the $rows row(s) is a candidate pass: the author broke something in
-target_sha and repaired it in fix_sha, WITH a test change proving the defect
-was real.
+Each of the $rows row(s) is a candidate pass with a source and test change.
+The verification column says whether tests passed at fix_sha and failed with
+its source changes reverted. Unverified rows remain candidates, not proven bugs.
 
 Pick a row where the fix is a behavioural repair you would have wanted a
 reviewer to catch, then:

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -15,6 +15,27 @@ Versions captured **2026-07-26** on the machine cadre was built on. `agentcall
 (`~/.local/state/cadre/agents.d/` here, per `lib/common.sh:18`) did not exist, so
 every row below is a shipped adapter with no local override in front of it.
 
+## Mining verification
+
+`cadre setup <repo-dir> [limit] [--verify]` mines candidates without executing
+code by default. `--verify` or `CADRE_VERIFY_PAIRS=1` enables the optional
+green-at-fix/red-with-source-reverted check. The shortlist TSV appends a
+`verification` column (`verified`, `unverified`, or `no-test-cmd`). Existing
+columns keep their positions. `CADRE_TEST_CMD` overrides detection;
+`CADRE_VERIFY_TIMEOUT` is a positive integer in seconds (default 120 per arm).
+
+Verification retains tests, configuration and other non-source files at the
+fix revision. Source means the miner's supported code extensions outside test
+paths, conventional Go/Python/Ruby/Java test filenames, and type declarations.
+This is file-level separation. Rust source containing `test` or `doctest` is
+left unverified because its assertions may be embedded in the source being
+reverted. Other embedded-test conventions are not detected; inspect the saved
+patch before treating the result as a test of the original assertion.
+It handles additions, deletions and renames by
+reversing their source-file patch. Separate fresh copies avoid generated-file
+contamination between arms. No dependencies are installed automatically.
+See the README execution warning before enabling this on a third-party repo.
+
 ## Roster
 
 | adapter | binary | version here | docs | changelog |

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -198,6 +198,30 @@ gets said plainly here rather than left for a reader to infer.
 
 `cadre panel` **generates hypotheses. It does not estimate decorrelation.**
 
+The `FILES % (runs)` cell shows each candidate's mean changed-file mention
+coverage for that pass, with the number of measured runs. Shared-basename
+ambiguity is excluded from the denominator; missing measurements and older
+reports show `-`. This is a separate signal to weigh beside item hits, not an
+automatic seating threshold. Mentioning a file does not prove it was reviewed.
+
+Grade reports also check supported `path:line`, `path:start-end`, and
+`path#Lstart-Lend` citations against that file's diff hunks (three context lines).
+Paths are matched literally, including spaces and regex punctuation. A basename
+unique across the old and new trees also works; shared basenames, unknown paths,
+unsupported citation syntax, binary changes, and missing diffs provide no position
+measurement. Supported paths start a line or follow whitespace, a backtick, or
+a quote; other wrapping is deliberately left unclassified. Paths containing
+tabs, newlines, double quotes, or backslashes are also unclassified. Renames are
+compared as deletion and addition so an old-path citation can still resolve.
+
+Any part of a cited range overlapping a hunk on either the old or new side is
+enough to avoid a drift flag, because these citations do not establish which
+side they mean. Zero-length sides contain no lines. An anchor outside all such
+hunks is **possible position drift**, not an invalid finding: unchanged code
+outside a hunk can be relevant. The check is advisory and never changes grades,
+DEFER gates, or the slot verdict. The denominator counts supported occurrences,
+not findings, and makes no claim that every citation was recognized.
+
 The defaults are two runs against a handful of key items. That is on the order of
 tens of binary outcomes — nowhere near enough to estimate co-failure structure,
 separate lineage effects from run-to-run variance, or put an interval on "covers

--- a/lib/anchor-scan.awk
+++ b/lib/anchor-scan.awk
@@ -1,0 +1,72 @@
+# Literal identity first, line syntax second. Never extract paths with a regex:
+# punctuation in real paths otherwise splits a citation into another file.
+BEGIN {
+    path = ENVIRON["CADRE_ANCHOR_PATH"]
+    basename = ENVIRON["CADRE_ANCHOR_BASENAME"]
+    nblockers = split(ENVIRON["CADRE_ANCHOR_BLOCKERS"], blockers, "\n")
+    n = split(ENVIRON["CADRE_ANCHOR_PATCH"], patch, "\n")
+    for (i = 1; i <= n; i++) {
+        if (patch[i] !~ /^@@ -[0-9]+(,[0-9]+)? \+[0-9]+(,[0-9]+)? @@/) continue
+        split(patch[i], fields, " ")
+        # An unlabelled citation may refer to either side. A zero-length side
+        # has NO lines; its insertion/deletion point must not count as a hunk.
+        for (j = 2; j <= 3; j++) {
+            count = split(substr(fields[j], 2), span, ",")
+            len = count == 1 ? 1 : span[2] + 0
+            if (len > 0) { starts[++hunks] = span[1] + 0; ends[hunks] = span[1] + len - 1 }
+        }
+    }
+}
+function scan(text, name,    pos,offset,before,tail,anchor,nums,count,first,last,k,overlap,after,blocked,start,ending) {
+    offset = 1
+    while ((pos = index(substr(text, offset), name)) > 0) {
+        pos += offset - 1
+        before = pos == 1 ? "" : substr(text, pos - 1, 1)
+        offset = pos + length(name)
+        # Deliberately narrow delimiters: a slash or filename punctuation is
+        # not a boundary. Unsupported wrapping is unavailable, not a guess.
+        if (before != "" && before !~ /[[:space:]`"']/) continue
+        if (before ~ /[`"']/ && pos > 2 && substr(text, pos - 2, 1) !~ /[[:space:]]/) continue
+        blocked = 0
+        for (k = 1; k <= nblockers; k++) {
+            start = offset - length(blockers[k])
+            if (length(blockers[k]) > length(name) && start > 0 &&
+                substr(text, start, length(blockers[k])) == blockers[k]) blocked = 1
+        }
+        if (blocked) continue
+        tail = substr(text, offset)
+        if (!match(tail, /^:[0-9]+(-[0-9]+)?/) && !match(tail, /^#L[0-9]+(-L?[0-9]+)?/)) continue
+        anchor = substr(tail, 1, RLENGTH)
+        ending = substr(tail, RLENGTH + 1)
+        # Whitelist endings: an unknown continuation (including Unicode range
+        # separators) must not turn an unsupported range into a point citation.
+        # Check the whole suffix up to whitespace, so ':2..30' or ':2,30'
+        # cannot slip through merely because the first character is prose punctuation.
+        for (k = 1; k <= length(ending); k++) {
+            after = substr(ending, k, 1)
+            if (after ~ /[[:space:]]/) break
+            if (!index("`\"'.,;!?)]}", after)) { blocked = 1; break }
+        }
+        if (blocked) continue
+        nums = anchor
+        gsub(/[:#L]/, "", nums)
+        count = split(nums, range, "-")
+        first = range[1] + 0; last = count == 1 ? first : range[2] + 0
+        if (first < 1 || last < first || !hunks) continue
+        # Any overlap is enough: checking only a range's start over-accuses.
+        overlap = 0
+        for (k = 1; k <= hunks; k++)
+            if (first <= ends[k] && last >= starts[k]) overlap = 1
+        checked++
+        if (!overlap) {
+            drift++
+            list = list (list == "" ? "" : ", ") path anchor
+        }
+    }
+}
+{
+    # Root paths that share a basename cannot identify a file either.
+    if (path != basename || unique == 1) scan($0, path)
+    if (unique == 1 && path != basename) scan($0, basename)
+}
+END { printf "%d\t%d\t%s\n", checked, drift, list }

--- a/lib/grade.sh
+++ b/lib/grade.sh
@@ -214,11 +214,6 @@ cost_per_hit() {
 #  - Empty denominator (no base, git failure, zero changed files) is "-", never
 #    0/0 -- same rule cost_per_hit follows: a number would be a claim the
 #    measurement does not support.
-# ★ DEFERRED (issue #5, criterion b): anchor/position-drift validation. A first
-# cut manufactured false drift four ways (substring file mis-attribution, an
-# anchor regex that fragments metachar paths, range anchors tested only at their
-# start, and pure-deletion files judged against another file's hunks). Left out
-# rather than shipped noisy; it is its own follow-up.
 # ★ NAMED NON-GOAL: mention detection is TEXT matching, not comprehension. A
 # reviewer can name a file without reviewing it. Coverage bounds attention from
 # below (never mentioned => never reviewed); it does not certify a read.
@@ -251,6 +246,44 @@ coverage_scan() {
       COV_UNCOVERED_LIST="${COV_UNCOVERED_LIST:+$COV_UNCOVERED_LIST, }$f"
     fi
   done <<< "$changed"
+}
+
+# Anchor checks deliberately use a separate, stricter matcher than mentions.
+# A substring may safely CREDIT attention; it cannot safely accuse drift.
+# Only literal full paths / unique basenames and supported line syntax count.
+# Per-file diffs avoid inferring file identity from quoted patch headers.
+anchor_scan() { # <review> <repo> <base> <sha>; sets ANCHOR_* (advisory only)
+  local review="$1" dir="$2" base="$3" sha="$4" paths treepaths oldtree f bn shares blockers patch result
+  ANCHOR_CHECKED=0 ANCHOR_DRIFT=0 ANCHOR_DRIFT_LIST=""
+  [ -n "$base" ] && [ -r "$review" ] || return 0
+  # Keep Git's C-quoted unusual paths out of this newline-based interface.
+  # Tabs/newlines/backslashes/quotes in names are unavailable, never drift.
+  paths=$(git -C "$dir" -c core.quotePath=false diff --name-only --no-renames "$base...$sha" 2>/dev/null) || return 0
+  oldtree=$(git -C "$dir" merge-base "$base" "$sha" 2>/dev/null) || return 0
+  treepaths=$(git -C "$dir" -c core.quotePath=false ls-tree -r --name-only "$oldtree" 2>/dev/null) || return 0
+  treepaths+=$'\n'$(git -C "$dir" -c core.quotePath=false ls-tree -r --name-only "$sha" 2>/dev/null) || return 0
+  treepaths=$(LC_ALL=C sort -u <<< "$treepaths")
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    case "$f" in *\\*|*\"*|*$'\t'*) continue ;; esac
+    bn=${f##*/}
+    shares=$(awk -v b="$bn" '{p=$0; sub(/.*\//,"",p); if(p==b)n++} END{print n+0}' <<< "$treepaths")
+    # A space/backtick/apostrophe can be filename text as well as a delimiter.
+    # Do not fragment a known longer name into this file's shorter citation.
+    blockers=$(awk -v f="$f" -v b="$bn" '
+      function suffix(s,t){return length(s)>length(t) && substr(s,length(s)-length(t)+1)==t}
+      {p=$0; sub(/.*\//,"",p); if(suffix($0,f) || suffix($0,b)) print; if(suffix(p,b)) print p}
+      ' <<< "$treepaths")
+    patch=$(git -C "$dir" diff --no-ext-diff --no-textconv --no-renames --unified=3 "$base...$sha" -- ":(literal)$f" 2>/dev/null) || continue
+    patch=$(awk '/^@@ /' <<< "$patch")
+    result=$(CADRE_ANCHOR_PATH="$f" CADRE_ANCHOR_BASENAME="$bn" CADRE_ANCHOR_PATCH="$patch" CADRE_ANCHOR_BLOCKERS="$blockers" \
+      awk -v unique="$shares" -f "$CADRE_ROOT/lib/anchor-scan.awk" "$review") || continue
+    local checked drift anchors
+    IFS=$'\t' read -r checked drift anchors <<< "$result"
+    ANCHOR_CHECKED=$((ANCHOR_CHECKED + checked))
+    ANCHOR_DRIFT=$((ANCHOR_DRIFT + drift))
+    [ -z "$anchors" ] || ANCHOR_DRIFT_LIST="${ANCHOR_DRIFT_LIST:+$ANCHOR_DRIFT_LIST, }$anchors"
+  done <<< "$paths"
 }
 
 # Which band a hit count falls in. Named so the range logic can ask the question
@@ -721,6 +754,14 @@ remove that directory and re-run."
         [ "$COV_UNCOVERED" -gt 0 ] && echo "  - never mentioned: $COV_UNCOVERED_LIST" >> "$report"
         passcov_runs=$((passcov_runs + 1))
         passcov_pctsum=$((passcov_pctsum + (100 * COV_COVERED / cov_denom)))
+      fi
+
+      anchor_scan "$rf" "$target" "$base" "$sha"
+      if [ "$ANCHOR_CHECKED" -gt 0 ]; then
+        echo "- run $n anchor positions: $ANCHOR_DRIFT/$ANCHOR_CHECKED outside diff hunks (possible position drift; advisory)" >> "$report"
+        [ "$ANCHOR_DRIFT" -eq 0 ] || echo "  - outside hunks: $ANCHOR_DRIFT_LIST" >> "$report"
+      else
+        echo "- run $n anchor positions: — (no supported anchors with resolvable text hunks)" >> "$report"
       fi
 
       # ---- grade this run with EVERY judge ------------------------------------

--- a/lib/mine-fixes.sh
+++ b/lib/mine-fixes.sh
@@ -7,14 +7,24 @@
 # is what makes A a plausible reviewable diff whose defect the author repaired
 # next. The two non-obvious filters below are argued in docs/METHOD.md §2.
 #
-# Usage: mine-fixes.sh <repo-dir> [max-fix-commits] [max-age-days]
+# Usage: mine-fixes.sh <repo-dir> [max-fix-commits] [max-age-days] [--verify]
 set -uo pipefail
 
 REPO="${1:?repo dir}"
 LIMIT="${2:-150}"
 MAXAGE="${3:-120}"
+VERIFY="${CADRE_VERIFY_PAIRS:-0}"
+[ "${4:-}" != --verify ] || VERIFY=1
+case "$VERIFY" in 0|1) ;; *) echo 'CADRE_VERIFY_PAIRS must be 0 or 1' >&2; exit 2 ;; esac
 
 git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1 || { echo "not a git repo: $REPO" >&2; exit 1; }
+REPO=$(git -C "$REPO" rev-parse --show-toplevel) || exit 1
+if [ "$VERIFY" = 1 ]; then
+  CADRE_ROOT="${CADRE_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+  . "$CADRE_ROOT/lib/common.sh"
+  . "$CADRE_ROOT/lib/verify-pair.sh"
+  verify_pairs_init "$REPO"
+fi
 
 # Fix-shaped commits, excluding merges and version bumps.
 # Reverts are dropped here, not left for the reader to spot: the "defect" is the
@@ -30,7 +40,7 @@ mapfile -t FIXES < <(
   | grep -viE 'tsc|type ?check|deno type|\bCI\b|failing test|flaky|satisfy .* types|jsdoc|comment' || true
 )
 
-printf 'fix_sha\ttarget_sha\tsrc\ttest\tshare\tage\tfix_subject\n'
+printf 'fix_sha\ttarget_sha\tsrc\ttest\tshare\tage\tfix_subject\tverification\n'
 
 # ★ Every filter below is a place the table can silently become empty. Without
 # a tally the output is a bare header and the reader cannot tell an empty repo
@@ -57,8 +67,8 @@ for line in "${FIXES[@]}"; do
          | grep -viE '(^|/)(tests?|__tests__|spec|e2e)/|\.(test|spec)\.|\.d\.ts$' -c) || nsrc=0
   [ "${nsrc:-0}" -ge 1 ] || { d_nosrc=$((d_nosrc + 1)); continue; }
 
-  # Require the fix to carry a test change too, the author proving the defect
-  # was real. This is the single strongest signal that the target is gradeable.
+  # A test change is a useful proxy, not proof that the test detects the defect.
+  # Optional execution verification below checks both directions.
   has_test=$(git -C "$REPO" diff --name-only "$B^" "$B" 2>/dev/null \
              | grep -ciE '(^|/)(tests?|__tests__|spec|e2e)/|\.(test|spec)\.') || has_test=0
   [ "${has_test:-0}" -ge 1 ] || { d_notest=$((d_notest + 1)); continue; }
@@ -100,7 +110,11 @@ for line in "${FIXES[@]}"; do
   [ "$age" -ge 0 ] && [ "$age" -le "$MAXAGE" ] || { d_age=$((d_age + 1)); continue; }
 
   n_kept=$((n_kept + 1))
-  printf '%s\t%s\t%s\t%s\t%s%%\t%s\t%s\n' "${B:0:9}" "${A:0:9}" "$nsrc" "$has_test" "$share" "$age" "$BS"
+  verification=unverified
+  if [ "$VERIFY" = 1 ]; then
+    verification=$(verify_pair "$REPO" "$B") || exit $?
+  fi
+  printf '%s\t%s\t%s\t%s\t%s%%\t%s\t%s\t%s\n' "${B:0:9}" "${A:0:9}" "$nsrc" "$has_test" "$share" "$age" "$BS" "$verification"
 done
 
 # ---- why the table is the size it is ------------------------------------

--- a/lib/verify-pair.sh
+++ b/lib/verify-pair.sh
@@ -1,0 +1,109 @@
+# Optional execution check for mined pairs. Sourced by mine-fixes.sh only when
+# explicitly enabled. This is a disposable working tree, NOT a sandbox.
+# shellcheck shell=bash
+
+verify_pairs_check() {
+  local repo="$1"
+  repo=$(git -C "$repo" rev-parse --show-toplevel) || die "verification needs a working-tree repository"
+  case "${CADRE_VERIFY_TIMEOUT:-120}" in
+    ''|*[!0-9]*|0) die "CADRE_VERIFY_TIMEOUT must be a positive integer (seconds)" ;;
+  esac
+  [ "${CADRE_VERIFY_TIMEOUT:-120}" -gt 0 ] 2>/dev/null || die "CADRE_VERIFY_TIMEOUT must be a positive integer (seconds)"
+  command -v timeout >/dev/null || die "pair verification needs GNU timeout"
+  case "$(readlink -m "$CADRE_WORK")/" in
+    "$(readlink -f "$repo")"/*) die "pair verification CADRE_WORK must be outside the source repo" ;;
+  esac
+}
+
+verify_pairs_init() {
+  verify_pairs_check "$1"
+  CADRE_WORK=$(readlink -m "$CADRE_WORK")
+  CADRE_HOME=$(readlink -m "$CADRE_HOME")
+  mkdir -p "$CADRE_WORK" "$CADRE_HOME/verification" || die "cannot create verification directories"
+  VERIFY_RECEIPTS=$(mktemp -d "$CADRE_HOME/verification/run-XXXXXXXX") || die "cannot create verification receipts"
+  echo "Executing repository tests (not sandboxed); receipts: $VERIFY_RECEIPTS" >&2
+}
+
+# detect_test_cmd supplies targeted examples for review prompts. Expand only
+# those known examples; an explicit CADRE_TEST_CMD is already executable text.
+verify_test_cmd() {
+  local cmd; cmd=$(detect_test_cmd "$1")
+  if [ -z "${CADRE_TEST_CMD:-}" ]; then
+    case "$cmd" in
+      'go test ./<pkg>') cmd='go test ./...' ;;
+      'cargo test <name>') cmd='cargo test' ;;
+      'pytest <path-to-test-file>') cmd='pytest' ;;
+      'npx vitest run <path-to-test-file>') cmd='npx --no-install vitest run' ;;
+      'npx jest <path-to-test-file>') cmd='npx --no-install jest' ;;
+    esac
+  fi
+  printf '%s' "$cmd"
+}
+
+verify_pair() (
+  # A subshell owns cleanup so interrupts cannot leave the execution tree
+  # behind or replace the miner's own traps. Logs survive in CADRE_HOME.
+  local repo="$1" fix="$2" dest receipt cmd f rc reason=checkout-error
+  local status=unverified fixed_rc='' reverted_rc='' paths=() inline_tests=0
+  receipt="$VERIFY_RECEIPTS/$fix"
+  mkdir -p "$receipt" || exit 2
+  dest=$(mktemp -d "$CADRE_WORK/verify-XXXXXXXX") || exit 2
+  trap 'rm -rf -- "$dest"' EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  # Each arm starts from a fresh archive: generated files or changed tests from
+  # the green run must not make the reverted run fail (or hide its failure).
+  if git -C "$repo" archive "$fix" | tar -x -C "$dest"; then
+    cmd=$(verify_test_cmd "$dest")
+    printf '%s\n' "$cmd" > "$receipt/command.txt"
+    if [ -z "$cmd" ]; then
+      status=no-test-cmd; reason=no-test-cmd
+    else
+      (cd "$dest" && timeout --kill-after=5 "${CADRE_VERIFY_TIMEOUT:-120}" bash -c "$cmd") > "$receipt/fixed.log" 2>&1
+      fixed_rc=$?
+      reason=fixed-not-green
+      if [ "$fixed_rc" -eq 0 ]; then
+        rm -rf -- "$dest"
+        mkdir -p "$dest"
+        if git -C "$repo" archive "$fix" | tar -x -C "$dest"; then
+          # Reverse source files only. --no-renames exposes both sides of a
+          # rename; NUL records and literal pathspecs keep unusual names intact.
+          while IFS= read -r -d '' f; do
+            case "$f" in *.ts|*.tsx|*.js|*.jsx|*.py|*.go|*.rs|*.java|*.rb) ;; *) continue ;; esac
+            case "${f##*/}" in
+              *_test.go|test_*.py|*_test.py|*_spec.rb|spec_*.rb|*_test.rb|test_*.rb|*Test.java|*Tests.java|Test*.java) continue ;;
+            esac
+            printf '%s\n' "$f" | grep -iE '(^|/)(tests?|__tests__|spec|e2e)/|\.(test|spec)\.|\.d\.ts$' >/dev/null && continue
+            # Rust commonly embeds unit tests in production files. Reverting
+            # the whole file would also revert its assertions and manufacture
+            # red/green evidence. Under-verify instead of attempting AST edits.
+            if [[ "$f" = *.rs ]] &&
+               { git -C "$repo" show "$fix:$f" 2>/dev/null || true; git -C "$repo" show "$fix^:$f" 2>/dev/null || true; } |
+               grep -E '(^|[^[:alnum:]_])(test|doctest)([^[:alnum:]_]|$)' >/dev/null; then
+              inline_tests=1
+            fi
+            paths+=(":(literal)$f")
+          done < <(git -C "$repo" diff --no-renames --name-only -z "$fix^" "$fix")
+          reason=source-revert-error
+          [ "$inline_tests" -eq 0 ] || reason=inline-tests-not-separated
+          if [ "$inline_tests" -eq 0 ] && [ "${#paths[@]}" -gt 0 ] &&
+             git -C "$repo" diff --binary --no-renames "$fix" "$fix^" -- "${paths[@]}" > "$receipt/source-revert.patch" &&
+             (cd "$dest" && GIT_CEILING_DIRECTORIES="$(dirname -- "$dest")" git apply --binary -- "$receipt/source-revert.patch") 2> "$receipt/revert.log"; then
+            (cd "$dest" && timeout --kill-after=5 "${CADRE_VERIFY_TIMEOUT:-120}" bash -c "$cmd") > "$receipt/reverted.log" 2>&1
+            reverted_rc=$?
+            reason=reverted-not-red
+            # timeout, launch errors, and signals do not establish a failing
+            # test. Ordinary nonzero suite exits are recorded for human audit.
+            if [ "$reverted_rc" -gt 0 ] && [ "$reverted_rc" -lt 124 ]; then
+              status=verified; reason=fixed-green-reverted-red
+            fi
+          fi
+        fi
+      fi
+    fi
+  fi
+  printf 'status\treason\tfixed_exit\treverted_exit\n%s\t%s\t%s\t%s\n' \
+    "$status" "$reason" "$fixed_rc" "$reverted_rc" > "$receipt/result.tsv"
+  printf '%s\n' "$status"
+)

--- a/tests/coverage-drift.sh
+++ b/tests/coverage-drift.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# No adapters, models, or network. Real Git diffs and synthetic saved reports.
+set -uo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+export CADRE_ROOT="$ROOT"
+. "$ROOT/lib/grade.sh"
+TMP=$(mktemp -d) || exit 1
+trap 'rm -rf "$TMP"' EXIT
+PASS=0 FAIL=0
+check() {
+  if "$@"; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); printf 'FAIL: %s\n' "$*"; fi
+}
+repo="$TMP/repo"
+mkdir -p "$repo/src/a" "$repo/src/b" "$repo/app/(group)/[id]" "$repo/unchanged"
+git -C "$repo" init -q
+git -C "$repo" config user.email test@example.invalid
+git -C "$repo" config user.name Test
+files=('src/a/index.ts' 'src/b/index.ts' 'src/unique.ts' 'src/myunique.ts'
+       'app/(group)/[id]/a+(x).ts' 'src/space name.ts' 'src/deleted.ts'
+       'src/other.ts' 'src/pure.ts' 'src/alias.ts' 'unchanged/alias.ts' 'src/rename.ts'
+       'name.ts' 'x).ts' 'src/apostrophe'"'"'name.ts')
+for f in "${files[@]}"; do seq 1 60 > "$repo/$f"; done
+printf '\0base\n' > "$repo/binary.dat"
+git -C "$repo" add -- .
+git -C "$repo" commit -qm base
+BASE=$(git -C "$repo" rev-parse HEAD)
+for f in "${files[@]}"; do
+  case "$f" in src/deleted.ts|src/pure.ts|src/rename.ts|unchanged/*) continue ;; esac
+  awk 'NR==30{$0="changed"} {print}' "$repo/$f" > "$TMP/edited"
+  cp "$TMP/edited" "$repo/$f"
+done
+rm "$repo/src/deleted.ts"
+# Pure deletion at line 50. The other.ts hunk is at 30; never borrow it.
+awk 'NR != 50' "$repo/src/pure.ts" > "$TMP/edited"
+cp "$TMP/edited" "$repo/src/pure.ts"
+printf 'new line\n' > "$repo/src/new.ts"
+printf '\0changed\n' > "$repo/binary.dat"
+mv "$repo/src/rename.ts" "$repo/src/renamed.ts"
+git -C "$repo" add -- .
+git -C "$repo" commit -qm change
+SHA=$(git -C "$repo" rev-parse HEAD)
+scan() {
+  printf '%s\n' "$1" > "$TMP/review"
+  anchor_scan "$TMP/review" "$repo" "$BASE" "$SHA"
+  check test "$ANCHOR_CHECKED" -eq "$2"
+  check test "$ANCHOR_DRIFT" -eq "$3"
+}
+
+scan 'src/unique.ts:30 src/unique.ts:2' 2 1
+check test "$ANCHOR_DRIFT_LIST" = 'src/unique.ts:2'
+scan 'src/myunique.ts:30' 1 0                    # no suffix unique.ts attribution
+scan 'unknown/src/unique.ts:900' 0 0           # no substring full-path attribution
+scan 'src/a/index.ts:30' 1 0                   # no sibling basename attribution
+scan 'index.ts:900 alias.ts:900' 0 0           # unchanged siblings also ambiguous
+scan 'unique.ts:900' 1 1
+scan 'app/(group)/[id]/a+(x).ts:30' 1 0
+scan 'a+(x).ts:30' 1 0
+scan 'src/space name.ts:30' 1 0
+scan 'space name.ts:30' 1 0                   # do not fragment into root name.ts
+scan "src/apostrophe'name.ts:30" 1 0
+scan 'src/unique.ts:2-30' 1 0                  # range starts outside, overlaps later
+scan 'src/unique.ts:2–30 src/unique.ts:2+30' 0 0 # unsupported ranges cannot become points
+scan 'src/unique.ts:2..30 src/unique.ts:2,30' 0 0
+scan 'src/unique.ts:1-2' 1 1
+scan 'src/unique.ts#L2-L30' 1 0
+scan 'src/unique.ts#L900-L901' 1 1
+scan 'src/unique.ts:27 src/unique.ts:33' 2 0    # the three context lines count
+scan 'src/deleted.ts:50' 1 0                   # old side exists, new side is empty
+scan 'src/deleted.ts:900 src/other.ts:30' 2 1
+scan 'src/pure.ts:50 src/pure.ts:30' 2 1        # per-file hunk isolation
+check test "$ANCHOR_DRIFT_LIST" = 'src/pure.ts:30'
+scan 'src/new.ts:1 src/new.ts:2' 2 1
+scan 'src/rename.ts:30 src/renamed.ts:30' 2 0   # renames are deletion + addition
+scan 'src/new.ts:0 src/new.ts:4-2 src/new.ts:1:99' 0 0
+scan 'binary.dat:900 missing.ts:900 localhost:3000 node:18' 0 0
+scan 'src/unique.ts:30foo src/unique.ts:30-unknown' 0 0
+printf 'src/unique.ts:900\n' > "$TMP/review"
+anchor_scan "$TMP/review" "$repo" '' "$SHA"
+check test "$ANCHOR_CHECKED" -eq 0
+anchor_scan "$TMP/review" "$repo" invalid-ref "$SHA"
+check test "$ANCHOR_CHECKED" -eq 0
+anchor_scan "$TMP/review" "$repo" "$SHA" "$SHA"
+check test "$ANCHOR_CHECKED" -eq 0
+
+# A side with zero length contains no position. Exercise exact hunk headers
+# independently of context expansion in Git, including a deletion at EOF.
+printf 'src/deleted.ts:50 src/deleted.ts:1\n' > "$TMP/review"
+OUT=$(CADRE_ANCHOR_PATH=src/deleted.ts CADRE_ANCHOR_BASENAME=deleted.ts \
+      CADRE_ANCHOR_PATCH='@@ -50 +0,0 @@' awk -v unique=1 -f "$ROOT/lib/anchor-scan.awk" "$TMP/review")
+check test "$OUT" = $'2\t1\tsrc/deleted.ts:1'
+
+# Panel means per-run ratios, not pooled files, and keeps observations separate.
+mkdir -p "$TMP/home"
+cat > "$TMP/home/report-one-by-j1.md" <<'EOF'
+# Gauntlet: `one`
+## alpha
+- run 1 coverage: 1/2 changed files mentioned
+- run 1: K1=HIT
+- run 2 coverage: 4/4 changed files mentioned
+- run 2: K1=HIT
+## beta
+- run 1 coverage: — (all 2 changed file(s) ambiguous by shared basename)
+- run 1: K1=MISS
+## Verdict: SEAT: can review alone
+EOF
+cat > "$TMP/home/report-one-by-j2.md" <<'EOF'
+# Gauntlet: `one`
+## alpha
+- run 1 coverage: 0/2 changed files mentioned
+- run 1: K1=MISS
+## Verdict: DO NOT SLOT
+EOF
+cat > "$TMP/home/report-old.md" <<'EOF'
+# Gauntlet: `old`
+## alpha
+- run 1: K1=HIT
+## Verdict: SEAT: can review alone
+EOF
+cat > "$TMP/home/report-invalid.md" <<'EOF'
+# Gauntlet: `leaked`
+## alpha
+- run 1 coverage: 9/9 changed files mentioned
+- run 1: K1=HIT
+## Verdict: INVALID, leaked key
+EOF
+OUT=$(CADRE_HOME="$TMP/home" "$ROOT/bin/cadre" panel --save)
+check grep -qF 'FILES % (runs)' <<< "$OUT"
+check grep -qE '^one.*judge: j1.*HIT.*75% \(2\)$' <<< "$OUT"
+check grep -qE '^one.*judge: j2.*MISS.*0% \(1\)$' <<< "$OUT"
+check grep -qE '^old +HIT +-$' <<< "$OUT"
+check grep -qE '^one.*judge: j1.*MISS.*-$' <<< "$OUT"
+check grep -qF 'Weigh FILES alongside item hits' <<< "$OUT"
+check grep -qE '^# +one.*judge: j1.*75% \(2\)$' "$TMP/home/roster"
+check test "$(grep -c '99%\|100%' <<< "$OUT")" -eq 0
+
+# Exercise the real grade report path with deterministic judges. No reviewer
+# runs, no provider calls; drift must remain advisory even at a 100% hit rate.
+export CADRE_HOME="$TMP/grade-home" CADRE_WORK="$TMP/work" CADRE_JUDGE='j1,j2'
+. "$ROOT/lib/common.sh"
+mkdir -p "$CADRE_HOME/alpha"
+PASSES="$CADRE_HOME/passes.conf"
+printf 'alpha|%s|%s|%s|key.md\n' "$SHA" "$repo" "$BASE" > "$PASSES"
+cat > "$CADRE_HOME/key.md" <<'EOF'
+#### K1 blocking - the changed operation drops an important write
+details
+#### K2 blocking - the authentication response exposes a private token
+details
+EOF
+sl=$(slug one)
+printf '**blocking** src/unique.ts:900 — dropped write and leaked token\nVerdict: blocking\n' > "$CADRE_HOME/alpha/$sl-run1.md"
+grade_one() {
+  printf '%s\n' '{"items":{"K1":"HIT","K2":"HIT"},"quotes":{"K1":"dropped write","K2":"leaked token"},"extras":[]}' > "$3"
+}
+run_gauntlet one 1 1 > "$TMP/grade-output" 2>&1
+grade_rc=$?
+check test "$grade_rc" -eq 0
+[ "$grade_rc" -eq 0 ] || cat "$TMP/grade-output"
+report="$CADRE_HOME/report-$sl-by-$(slug j1,j2).md"
+check grep -qF 'run 1 anchor positions: 1/1 outside diff hunks' "$report"
+check grep -qF 'outside hunks: src/unique.ts:900' "$report"
+check grep -qF '## Verdict: SEAT: can review alone' "$report"
+check grep -qF 'K1=HIT' "$report"
+check grep -qF 'run 1 coverage:' "$report"
+# Suspected key leaks skip both coverage and anchor measurement.
+cp "$CADRE_HOME/key.md" "$CADRE_HOME/alpha/$sl-run1.md"
+printf '\nsrc/unique.ts:900\nVerdict: blocking\n' >> "$CADRE_HOME/alpha/$sl-run1.md"
+run_gauntlet one 1 1 > "$TMP/leaked-output" 2>&1
+check grep -q 'SUSPECT' "$report"
+check test "$(grep -c 'anchor positions:' "$report")" -eq 0
+
+printf '%s passed; %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/verify-pairs.sh
+++ b/tests/verify-pairs.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Offline execution fixtures: prove both arms, and prove the caller stays intact.
+set -uo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf -- "$TMP"' EXIT
+export CADRE_ROOT="$ROOT" CADRE_HOME="$TMP/state" CADRE_WORK="$TMP/work"
+export CADRE_TEST_CMD='bash test/check.sh' CADRE_VERIFY_TIMEOUT=2
+unset CADRE_VERIFY_PAIRS
+PASS=0 FAIL=0
+check() { if eval "$2"; then PASS=$((PASS+1)); echo "ok $1"; else FAIL=$((FAIL+1)); echo "FAIL $1"; fi; }
+S="$TMP/source"
+mkdir -p "$S/test"
+git -C "$S" init -q
+git -C "$S" config user.name Test
+git -C "$S" config user.email test@example.invalid
+printf 'bad\n' > "$S/value [x].js"
+git -C "$S" add .
+git -C "$S" commit -qm 'feat: initial value'
+printf 'good\n' > "$S/value [x].js"
+printf '#!/bin/bash\ngrep -qx good "value [x].js"\n' > "$S/test/check.sh"
+git -C "$S" add .
+git -C "$S" commit -qm 'fix: return the right value'
+FIX=$(git -C "$S" rev-parse HEAD)
+# Dirty/untracked caller data must survive every execution.
+printf 'user edit\n' > "$S/value [x].js"
+printf 'keep\n' > "$S/untracked"
+BEFORE=$(git -C "$S" status --porcelain)
+OUT=$("$ROOT/bin/cadre" setup "$S" 20 2>&1)
+check 'default labels candidate unverified' "grep -q 'unverified' '$CADRE_HOME/shortlist-source.tsv'"
+check 'default does not execute or create receipts' "[ ! -d '$CADRE_HOME/verification' ]"
+OUT=$("$ROOT/bin/cadre" setup "$S" 20 --verify 2>&1)
+check 'actual source regression is verified' "tail -1 '$CADRE_HOME/shortlist-source.tsv' | grep -q $'\tverified$'"
+check 'source index and worktree untouched' '[ "$BEFORE" = "$(git -C "$S" status --porcelain)" ]'
+check 'source HEAD unchanged' '[ "$FIX" = "$(git -C "$S" rev-parse HEAD)" ]'
+check 'execution trees cleaned' '[ -z "$(ls -A "$CADRE_WORK")" ]'
+check 'both exit codes recorded' "cat '$CADRE_HOME'/verification/*/'$FIX'/result.tsv | grep -q $'verified\tfixed-green-reverted-red\t0\t1'"
+check 'fixed tests retained on reverted source' "cat '$CADRE_HOME'/verification/*/'$FIX'/source-revert.patch | grep -q 'value' && ! cat '$CADRE_HOME'/verification/*/'$FIX'/source-revert.patch | grep -q 'test/check'"
+
+run_with() {
+  CADRE_TEST_CMD="$1" CADRE_VERIFY_PAIRS=1 "$ROOT/lib/mine-fixes.sh" "$S" 20 > "$TMP/table" 2> "$TMP/log"
+}
+run_with 'true'
+check 'a test that passes both arms is unverified' "tail -1 '$TMP/table' | grep -q $'\tunverified$'"
+run_with 'false'
+check 'a test that fails at the fix is unverified' "tail -1 '$TMP/table' | grep -q $'\tunverified$'"
+run_with 'if grep -qx good "value [x].js"; then exit 0; else sleep 10; fi'
+check 'reverted timeout is unverified' "tail -1 '$TMP/table' | grep -q $'\tunverified$'"
+run_with 'sleep 10'
+check 'fixed timeout is unverified' "tail -1 '$TMP/table' | grep -q $'\tunverified$'"
+run_with 'if grep -qx good "value [x].js"; then exit 0; else exit 127; fi'
+check 'command launch error is unverified' "tail -1 '$TMP/table' | grep -q $'\tunverified$'"
+run_with ''
+check 'unknown test runner has own status' "tail -1 '$TMP/table' | grep -q $'\tno-test-cmd$'"
+run_with 'if [ -e generated ]; then exit 1; fi; touch generated; true'
+check 'each arm starts clean' "tail -1 '$TMP/table' | grep -q $'\tunverified$'"
+OUT=$(CADRE_WORK="$CADRE_HOME/nested" "$ROOT/bin/cadre" setup "$S" --verify 2>&1); RC=$?
+check 'refuses execution inside answer-key tree' '[ "$RC" -ne 0 ]'
+OUT=$(CADRE_WORK="$S/work" "$ROOT/bin/cadre" setup "$S" --verify 2>&1); RC=$?
+check 'refuses execution inside user repo' '[ "$RC" -ne 0 ]'
+OUT=$(CADRE_WORK="$S/work" "$ROOT/bin/cadre" setup "$S/test" --verify 2>&1); RC=$?
+check 'subdirectory input cannot bypass source-root guard' '[ "$RC" -ne 0 ] && [ ! -d "$S/work" ]'
+mkdir -p "$TMP/relative"
+OUT=$(cd "$TMP/relative" && CADRE_HOME=state CADRE_WORK=work "$ROOT/bin/cadre" setup "$S" --verify 2>&1); RC=$?
+check 'relative state and work directories resolve before execution' '[ "$RC" -eq 0 ] && tail -1 "$TMP/relative/state/shortlist-source.tsv" | grep -q $'"'"'\tverified$'"'"''
+OUT=$(CADRE_VERIFY_TIMEOUT=no "$ROOT/bin/cadre" setup "$S" --verify 2>&1); RC=$?
+check 'invalid timeout propagates setup failure' '[ "$RC" -ne 0 ]'
+OUT=$(CADRE_VERIFY_TIMEOUT=00 "$ROOT/bin/cadre" setup "$S" --verify 2>&1); RC=$?
+check 'zero-padded zero cannot disable timeout' '[ "$RC" -ne 0 ]'
+OUT=$("$ROOT/bin/cadre" setup "$S" --typo 2>&1); RC=$?
+check 'unknown setup flags fail' '[ "$RC" -ne 0 ]'
+. "$ROOT/lib/common.sh"
+. "$ROOT/lib/verify-pair.sh"
+export CADRE_TEST_CMD='bash test/check.sh'
+VERIFY_RECEIPTS="$TMP/receipts"
+mkdir -p "$VERIFY_RECEIPTS"
+for shape in add delete rename; do
+  R="$TMP/$shape"
+  mkdir -p "$R/test"
+  git -C "$R" init -q
+  git -C "$R" config user.name Test
+  git -C "$R" config user.email test@example.invalid
+  printf 'old\n' > "$R/old.js"
+  git -C "$R" add .
+  git -C "$R" commit -qm initial
+  case "$shape" in
+    add) printf 'new\n' > "$R/new.js"; printf '[ -f new.js ]\n' > "$R/test/check.sh" ;;
+    delete) rm "$R/old.js"; printf '[ ! -e old.js ]\n' > "$R/test/check.sh" ;;
+    rename) mv "$R/old.js" "$R/new.js"; printf '[ -f new.js ] && [ ! -e old.js ]\n' > "$R/test/check.sh" ;;
+  esac
+  git -C "$R" add .
+  git -C "$R" commit -qm "fix: $shape source"
+  V=$(verify_pair "$R" "$(git -C "$R" rev-parse HEAD)")
+  check "$shape source patch is reversible without reverting test" '[ "$V" = verified ]'
+done
+R="$TMP/inline-rust"
+mkdir -p "$R/tests"
+git -C "$R" init -q
+git -C "$R" config user.name Test
+git -C "$R" config user.email test@example.invalid
+printf 'pub fn value() -> u8 { 0 }\n#[test]\nfn example() { assert_eq!(value(), 1); }\n' > "$R/lib.rs"
+git -C "$R" add .
+git -C "$R" commit -qm initial
+printf 'pub fn value() -> u8 { 0 }\n#[test]\nfn example() { assert_eq!(value(), 0); }\n' > "$R/lib.rs"
+printf 'updated\n' > "$R/tests/README.md"
+git -C "$R" add .
+git -C "$R" commit -qm 'fix: change assertion only'
+V=$(CADRE_TEST_CMD='grep -q "value(), 0" lib.rs' verify_pair "$R" "$(git -C "$R" rev-parse HEAD)")
+check 'embedded Rust test edits cannot prove a source defect' '[ "$V" = unverified ]'
+mv "$R/lib.rs" "$R/new.rs"
+git -C "$R" add .
+git -C "$R" commit -qm 'fix: relocate inline test'
+V=$(CADRE_TEST_CMD='grep -q "value(), 0" new.rs' verify_pair "$R" "$(git -C "$R" rev-parse HEAD)")
+check 'new Rust test file cannot bypass inline-test guard' '[ "$V" = unverified ]'
+# CADRE_WORK may itself be inside a different git repo. Applying from a nested
+# path must not silently skip the patch while reporting success.
+git -C "$CADRE_WORK" init -q
+V=$(verify_pair "$TMP/rename" "$(git -C "$TMP/rename" rev-parse HEAD)")
+check 'work under unrelated repo still applies source patch' '[ "$V" = verified ]'
+for testname in value_test.go test_value.py value_test.py value_spec.rb spec_value.rb value_test.rb test_value.rb ValueTest.java ValueTests.java TestValue.java; do
+  R="$TMP/conventional-$testname"
+  mkdir -p "$R/test"
+  git -C "$R" init -q
+  git -C "$R" config user.name Test
+  git -C "$R" config user.email test@example.invalid
+  printf 'good\n' > "$R/value.js"
+  printf 'old\n' > "$R/$testname"
+  git -C "$R" add .
+  git -C "$R" commit -qm initial
+  printf 'good\n// cosmetic change\n' > "$R/value.js"
+  printf 'new\n' > "$R/$testname"
+  printf 'grep -qx new "%s"\n' "$testname" > "$R/test/check.sh"
+  git -C "$R" add .
+  git -C "$R" commit -qm 'fix: update test expectation'
+  V=$(verify_pair "$R" "$(git -C "$R" rev-parse HEAD)")
+  check "$testname is retained, never reverted as source" '[ "$V" = unverified ]'
+done
+mkdir -p "$TMP/detect"
+touch "$TMP/detect/go.mod"
+unset CADRE_TEST_CMD
+check 'targeted detector placeholder becomes full suite' '[ "$(verify_test_cmd "$TMP/detect")" = "go test ./..." ]'
+rm "$TMP/detect/go.mod"
+printf '{"devDependencies":{"vitest":"*"}}\n' > "$TMP/detect/package.json"
+check 'detected JS runner cannot implicitly install' '[ "$(verify_test_cmd "$TMP/detect")" = "npx --no-install vitest run" ]'
+export CADRE_TEST_CMD='custom < input'
+check 'explicit test command stays literal' '[ "$(verify_test_cmd "$TMP/detect")" = "custom < input" ]'
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Finish the remaining coverage checks and add execution evidence for mined bug/fix pairs.

- `cadre panel` shows changed-file mention coverage per pass. Grade reports flag supported citations outside that file's diff hunks as possible position drift. Ambiguous paths and unsupported ranges stay unmeasured; these checks never change grades or seat verdicts.
- `cadre setup <repo> --verify` runs tests on a fix and on a fresh copy with its source changes reverted. Candidates carry `verified`, `unverified`, or `no-test-cmd`, with commands, logs and exit codes retained. Verification is off by default, bounded by a timeout, and executes repository code without a sandbox. The docs state that boundary and the limits of file-based source/test separation.

Validation: the full smoke suite passes 1125 checks; 41 pair-verification checks, 74 coverage checks, and 37 engine-seam checks also pass. The smoke run used an empty HOME so shell startup could not replace test stubs with installed CLIs, plus CADRE_RETRY_WAIT=1 for fixture retries. Independent review findings were fixed and covered by regressions, including conventional test filenames, embedded Rust tests, repository subdirectory inputs, relative state paths, and unsupported citation ranges.

Closes #5
Closes #30

Automated review status: CodeRabbit skipped review under its repository policy. Kilo failed with “The model output limit was reached” and posted no findings. Neither is counted as a completed review; the independent code review and local validation above are the review evidence for this head.
