### PR TITLE
Add optional Pi SDK reviewer and matched review corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /report-*.md
 /shortlist-*.tsv
 *.grade.json
+/integrations/pi-review/node_modules/

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ one you are paying for twice under different branding.
 
 ## Quick start
 
+For the optional Pi SDK reviewer and its frozen comparison corpus, see
+[Pi review adapter and matched evaluation](docs/PI-REVIEW.md).
+
 ```bash
 git clone https://github.com/VibeCodyH/code-review-cadre ~/code-review-cadre
 export PATH="$HOME/code-review-cadre/bin:$PATH"

--- a/agents.d/pireview.sh
+++ b/agents.d/pireview.sh
@@ -1,0 +1,59 @@
+# Optional Pi SDK reviewer. Install integrations/pi-review with npm ci first.
+bin_pireview() {
+  if [ -f "$CADRE_ROOT/integrations/pi-review/node_modules/@earendil-works/pi-coding-agent/package.json" ]; then
+    echo node
+  else
+    echo cadre-pi-review-not-installed
+  fi
+}
+
+cannot_pireview() { printf '%s\n' role:judge role:synth; }
+
+notes_pireview() {
+  cat <<'NOTES'
+Review-specific Pi SDK adapter; requires Node 22.19+ and npm ci in
+integrations/pi-review. Explicit provider/model required. Saves structured
+findings, tool execution events, and a result beside the Markdown review.
+Uses configured Pi providers/auth, with extensions, skills and context files
+disabled. Same coding tools as stock Pi, including bash: use a disposable
+checkout; this is not a filesystem sandbox. Judge and synthesis unsupported.
+CADRE_PI_THINKING defaults off. Artifacts default to CADRE_HOME/pi-review;
+CADRE_PI_REVIEW_ARTIFACTS overrides that directory. Never overwrite a run.
+NOTES
+}
+
+run_pireview() {
+  local script="$CADRE_ROOT/integrations/pi-review/cli.mjs" store run out rc state note
+  [ -n "$model" ] || { echo 'DID NOT RUN, misconfigured: pireview requires provider/model'; return 1; }
+  case "$TIMEOUT" in ''|*[!0-9]*) echo 'DID NOT RUN, misconfigured: pireview needs an integer CADRE_TIMEOUT'; return 1 ;; esac
+  if [ -n "$DRY" ]; then
+    _run node "$script" --cwd "$dir" --model "$model" --out '<new-artifact-directory>' \
+      --thinking "${CADRE_PI_THINKING:-off}" --timeout "$TIMEOUT"
+    return 0
+  fi
+  store="${CADRE_PI_REVIEW_ARTIFACTS:-$CADRE_HOME/pi-review}"
+  mkdir -p "$store" || return 1
+  run=$(mktemp -d "$store/run.XXXXXXXX") || return 1
+  out="$run/review"
+  # Keep bookkeeping paths out of the model's environment. Same uid is not isolation.
+  export -n CADRE_PI_REVIEW_ARTIFACTS 2>/dev/null || true
+  printf '%s' "$prompt" | PI_OFFLINE=1 PI_TELEMETRY=0 \
+    timeout -k 5 "$((TIMEOUT + 10))" node "$script" --cwd "$dir" --model "$model" \
+      --out "$out" --thinking "${CADRE_PI_THINKING:-off}" --timeout "$TIMEOUT" > "$run/stdout.txt" 2> "$run/stderr.txt"
+  rc=$?
+  state=$(jq -r '.status // empty' "$out/result.json" 2>/dev/null) || state=""
+  note="pi-review artifacts: $out"
+  if [ "$state" = ok ] && [ "$rc" -eq 0 ] && [ -s "$out/review.md" ]; then
+    cat "$out/review.md"
+    cadre_state ok "$note"
+    return 0
+  fi
+  if [ "$state" = degraded ] && [ -s "$out/review.md" ]; then
+    cat "$out/review.md"
+    cadre_state degraded "$note"
+    return 1
+  fi
+  echo "DID NOT COMPLETE, pireview failed (exit $rc); artifacts: $out"
+  cadre_state failed "$note"
+  return 1
+}

--- a/docs/PI-REVIEW.md
+++ b/docs/PI-REVIEW.md
@@ -83,6 +83,13 @@ node evals/review-v1/verify-corpus.mjs
 
 Then run the development comparison against an explicitly configured model:
 
+The comparison requires Linux and `bwrap` (Bubblewrap), with working mount
+namespaces. Each arm gets a private `/tmp`, with only its current checkout,
+configuration, and output directory made visible there. This prevents a
+reproduction from importing another attempt's temporary files. The runner checks
+this support before dispatching a model; it does not fall back to a shared `/tmp`.
+The standalone SDK adapter does not require Bubblewrap.
+
 ```sh
 node evals/review-v1/compare.mjs --model provider/model --out /path/to/new-results
 ```
@@ -100,11 +107,14 @@ same enabled coding tools and effective thinking setting. Unsupported thinking
 settings are rejected before either arm runs. Alternating arm order reduces a
 consistent first-run cache advantage; it does not eliminate server-load effects.
 
+The private temporary directory is not a host filesystem sandbox. Other host
+paths and network access remain available to the tools.
+
 The intervention is the submission and receipt tools with their instructions, plus the
 CLI-to-SDK lifecycle change. A difference cannot be attributed to any one of
 those changes without a later experiment.
 
-The runner checks the corpus and execution-code fingerprints before every arm.
+The runner checks the corpus and execution-code fingerprints before and after every arm.
 Changed code stops the comparison. It preserves failed observations, validates
 observed model identity, and marks tracked checkout mutations invalid. Untracked
 reproduction files are allowed. `report.md` links both reviews, while `runs.jsonl`

--- a/docs/PI-REVIEW.md
+++ b/docs/PI-REVIEW.md
@@ -13,7 +13,7 @@ From the Cadre repository:
 
 ```sh
 npm ci --prefix integrations/pi-review
-agentcall pireview -d /path/to/disposable-checkout -M provider/model < review-prompt.md
+./bin/agentcall pireview -d /path/to/disposable-checkout -M provider/model < review-prompt.md
 ```
 
 Configure the provider and credentials in Pi first. An explicit model is required;
@@ -24,7 +24,7 @@ accepts `minimal`, `low`, `medium`, `high`, or `xhigh` when the model supports i
 To put it on a Cadre panel:
 
 ```sh
-cadre review --roster pireview:provider/model --synth none
+./bin/cadre review --roster pireview:provider/model --synth none
 ```
 
 Cadre supplies the disposable checkout in this path. The adapter uses Pi's normal
@@ -84,10 +84,11 @@ node evals/review-v1/verify-corpus.mjs
 Then run the development comparison against an explicitly configured model:
 
 The comparison requires Linux and `bwrap` (Bubblewrap), with working mount
-namespaces. Each arm gets a private `/tmp`, with only its current checkout,
+namespaces. Each arm gets a private `/tmp` and standard `/dev`, with only its current checkout,
 configuration, and output directory made visible there. This prevents a
 reproduction from importing another attempt's temporary files. The runner checks
-this support before dispatching a model; it does not fall back to a shared `/tmp`.
+this support, including nested Bash/Git execution, before dispatching a model;
+it does not fall back to a shared `/tmp`.
 The standalone SDK adapter does not require Bubblewrap.
 
 ```sh

--- a/docs/PI-REVIEW.md
+++ b/docs/PI-REVIEW.md
@@ -1,0 +1,160 @@
+# Pi review adapter and matched evaluation
+
+`pireview` adds a structured review submission tool to Pi 0.84.4. It keeps the
+reviewer's findings and execution records so a formatting failure, an interrupted
+run, and a completed clean review have different outcomes.
+
+This is an optional integration. Existing Cadre adapters need no Node dependency.
+The SDK package requires Node 22.19 or newer.
+
+## Try the adapter
+
+From the Cadre repository:
+
+```sh
+npm ci --prefix integrations/pi-review
+agentcall pireview -d /path/to/disposable-checkout -M provider/model < review-prompt.md
+```
+
+Configure the provider and credentials in Pi first. An explicit model is required;
+the adapter refuses a model fallback. `CADRE_PI_THINKING` defaults to `off` and
+accepts `minimal`, `low`, `medium`, `high`, or `xhigh` when the model supports it.
+`CADRE_TIMEOUT` sets the review deadline in seconds.
+
+To put it on a Cadre panel:
+
+```sh
+cadre review --roster pireview:provider/model --synth none
+```
+
+Cadre supplies the disposable checkout in this path. The adapter uses Pi's normal
+`read`, `bash`, `edit`, and `write` tools plus `submit_review` and
+`execution_receipts`. Bash can access the
+host filesystem. A disposable checkout and disabled resource discovery are NOT
+a sandbox. Use only repositories and model providers you already trust with the
+available tools and source.
+
+User/project extensions, skills, context files, prompt templates, and themes are
+disabled. Compaction and automatic model retries are disabled for this first
+slice. Configured provider model parameters still apply. Large reviews that need
+compaction are outside this slice's evaluation.
+
+The adapter is reviewer-only. It cannot serve as a keyed judge or synthesizer.
+
+## What survives a run
+
+Artifacts go under `$CADRE_HOME/pi-review/run.*/review/` by default.
+`CADRE_PI_REVIEW_ARTIFACTS` overrides the parent directory. The adapter's state
+note records the location in `runs.jsonl` as `adapter_note`. Each run gets a new directory; existing output is
+never overwritten.
+
+- `result.json`: submitted findings, completion state, model identity, settings
+  and code fingerprints, usage reported by Pi, and tool-call outcomes.
+- `events.jsonl`: ordered tool calls/results and assistant lifecycle events.
+  SDK reasoning deltas are not retained as full text.
+- `review.md`: the submitted findings rendered for Cadre.
+
+A finding includes its original title, severity, path/line, trigger, consequence,
+and evidence. Locations must exist in the reviewed checkout; citations to deleted
+files or base-only lines are not supported yet. An `executed` claim must name a recorded bash call that actually
+exited. A failing reproduction can qualify. A tool call merely starting, timing
+out, or being denied cannot. That check proves execution occurred; it does not
+prove the command tested the claim correctly.
+
+The reviewer calls `execution_receipts` to retrieve the actual command IDs and
+exit outcomes before citing executed evidence. IDs are not inferred from prose.
+
+Only a valid, completed `submit_review` can produce `ok`. Prose that says a review
+is clean does not count as a submission. An explicit empty submission is allowed.
+A provider failure, timeout, or duplicate submission cannot leave a clean
+success. Accepted findings survive those failures as degraded output.
+
+Artifacts contain review text, commands, and source excerpts. Keep them as private
+as the repository being reviewed. The adapter does not serialize credentials or
+provider configuration into its event log. Tools can still print sensitive data.
+
+## Compare against stock Pi
+
+First verify the eight synthetic cases without calling a model:
+
+```sh
+node evals/review-v1/verify-corpus.mjs
+```
+
+Then run the development comparison against an explicitly configured model:
+
+```sh
+node evals/review-v1/compare.mjs --model provider/model --out /path/to/new-results
+```
+
+The default is two repetitions of six development cases, or 24 reviewer calls.
+Each has a 180-second deadline. Set `--runs`, `--timeout`, or `--thinking` explicitly
+to change those controls. `--case tenant-scope-buggy --runs 1` runs a two-call
+protocol smoke test. `--agent-dir DIR` selects the source Pi configuration.
+
+The baseline launches the pinned package's actual Pi CLI in JSON mode. The other
+arm launches the SDK integration. Both receive the same common brief and byte
+identical Git trees. Their scratch paths contain no case or buggy/fixed labels.
+They use fresh sessions and copies of the same provider configuration, with the
+same enabled coding tools and effective thinking setting. Unsupported thinking
+settings are rejected before either arm runs. Alternating arm order reduces a
+consistent first-run cache advantage; it does not eliminate server-load effects.
+
+The intervention is the submission and receipt tools with their instructions, plus the
+CLI-to-SDK lifecycle change. A difference cannot be attributed to any one of
+those changes without a later experiment.
+
+The runner checks the corpus and execution-code fingerprints before every arm.
+Changed code stops the comparison. It preserves failed observations, validates
+observed model identity, and marks tracked checkout mutations invalid. Untracked
+reproduction files are allowed. `report.md` links both reviews, while `runs.jsonl`
+records dispatches and completions. Stock JSON mode's exit code is insufficient:
+the runner also checks the final assistant stop reason and event completion.
+
+The temporary credential copies and checkouts are removed when the comparison
+exits normally or throws. A forcibly killed process can leave private temporary
+files behind. Results belong outside the Cadre worktree and are never committed
+automatically.
+
+## What the corpus establishes
+
+The four original scenarios cover a cross-tenant update, cleanup after partial
+failure, a non-atomic revision check, and a vacuous regression test. Each has a
+buggy and repaired counterpart with the same behavioral oracle. The verifier
+requires an explicit assertion failure on the buggy tree and success on its
+repair. Crashes, import errors, launch failures, and timeouts cannot count as
+proof of the defect. Every corpus file has a SHA-256 entry in the manifest.
+
+The vacuous-test pair is held out from default runs. Use `--split holdout` only
+after freezing the implementation; `--split all` includes both groups. The
+holdout is visible source, so it is a tuning convention, not a secret dataset.
+
+These are small synthetic development cases. Their keys are provisional guidance
+backed by the specific behavioral checks. They are not independently adjudicated
+production defects, and a repaired case is not proof that every possible finding
+on that code is false. Scores here must not determine a production roster.
+
+`ok` means the arm delivered usable output. The report does not turn that into a
+quality score. `adjudication.template.json` leaves grades blank for a separate
+read of the findings against the oracle and surrounding code. Keep that reader's
+identity and method explicit. Preserve the original review as evidence and judge
+out-of-key findings separately.
+
+## Offline checks
+
+After installing the optional SDK dependency:
+
+```sh
+node --test integrations/pi-review/review.test.mjs evals/review-v1/corpus.test.mjs evals/review-v1/compare.test.mjs
+bash tests/pi-review.sh
+bash tests/review-smoke.sh
+bash tests/engine-seam.sh
+```
+
+The SDK tests include its real tool loop with a fake model stream. None of these
+checks make a provider request. Live comparisons are separate from CI.
+
+This slice builds on [context A/B evaluation (#8)](https://github.com/VibeCodyH/code-review-cadre/issues/8)
+and [grading provenance (#39)](https://github.com/VibeCodyH/code-review-cadre/issues/39).
+Repeated-seat production panels and independent judge calibration remain separate
+work.

--- a/evals/review-v1/compare.mjs
+++ b/evals/review-v1/compare.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync, appendFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { verifyCorpus } from './verify-corpus.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '../..');
+const integration = join(root, 'integrations/pi-review');
+export const settings = { compaction: { enabled: false }, retry: { enabled: false } };
+const digest = value => createHash('sha256').update(value).digest('hex');
+const json = path => JSON.parse(readFileSync(path, 'utf8'));
+const save = (path, value) => writeFileSync(path, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 });
+
+export function parseArgs(args) {
+  const options = { runs: 2, split: 'development', thinking: 'off', timeout: 180 };
+  const names = new Set(['model', 'out', 'runs', 'split', 'thinking', 'timeout', 'case', 'agent-dir']);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--help') return { help: true };
+    const key = args[i].replace(/^--/, '');
+    if (!args[i].startsWith('--') || !names.has(key) || !args[i + 1] || args[i + 1].startsWith('--')) throw Error(`Unknown or incomplete option: ${args[i]}`);
+    options[key] = args[++i];
+  }
+  if (!options.model?.includes('/') || !options.out) throw Error('--model provider/model and --out NEW_DIRECTORY are required');
+  for (const name of ['runs', 'timeout']) {
+    options[name] = Number(options[name]);
+    if (!Number.isInteger(options[name]) || options[name] < 1 || options[name] > (name === 'runs' ? 10 : 3600)) throw Error(`Invalid --${name}`);
+  }
+  if (!['development', 'holdout', 'all'].includes(options.split)) throw Error('Invalid --split');
+  if (!['off', 'minimal', 'low', 'medium', 'high', 'xhigh'].includes(options.thinking)) throw Error('Invalid --thinking');
+  return options;
+}
+
+function stockVerdict(review) {
+  const verdicts = new Set();
+  let fence;
+  for (const raw of review.split('\n')) {
+    if (/^(?: {4}|\t)/.test(raw)) continue; // Markdown indented code.
+    const line = raw.trim();
+    if (line.startsWith('>')) continue;
+    const marker = /^(`{3,}|~{3,})(.*)$/.exec(line);
+    if (marker) {
+      if (!fence) fence = marker[1];
+      else if (marker[1][0] === fence[0] && marker[1].length >= fence.length && !marker[2].trim()) fence = undefined;
+      continue;
+    }
+    if (fence) continue;
+    const match = line.replace(/\*\*|__/g, '').match(/^Verdict:\s*(blocking|should-fix|no defects found)\s*$/i);
+    if (match) verdicts.add(match[1].toLowerCase());
+  }
+  return verdicts.size === 1 ? [...verdicts][0] : null;
+}
+
+export function parseStock(text, exitCode, timedOut = false) {
+  const events = [];
+  let malformed = false;
+  for (const line of text.split('\n').filter(Boolean)) {
+    try { events.push(JSON.parse(line)); } catch { malformed = true; }
+  }
+  const messages = events.filter(e => e.type === 'message_end' && e.message?.role === 'assistant').map(e => e.message);
+  const last = messages.at(-1);
+  const review = (last?.content ?? []).filter(c => c.type === 'text').map(c => c.text).join('\n');
+  const completed = events.some(e => e.type === 'agent_end');
+  const failure = timedOut || exitCode !== 0 || malformed || !completed || last?.stopReason !== 'stop';
+  const verdict = stockVerdict(review);
+  return {
+    status: failure ? (review.trim() ? 'degraded' : 'failed') : (verdict ? 'ok' : 'inconclusive'),
+    reason: timedOut ? 'timeout' : malformed ? 'invalid event stream' : last?.stopReason ?? 'no final assistant message',
+    review, verdict, model: last?.model ?? null, provider: last?.provider ?? null,
+    usage: sumUsage(messages),
+    tool_calls: events.filter(e => e.type === 'tool_execution_start').length,
+  };
+}
+
+function sumUsage(messages) {
+  const usage = messages.map(m => m.usage).filter(Boolean);
+  if (!usage.length) return null;
+  const sum = key => usage.every(u => typeof u[key] === 'number') ? usage.reduce((n, u) => n + u[key], 0) : null;
+  return Object.fromEntries(['input', 'output', 'cacheRead', 'cacheWrite', 'totalTokens'].map(k => [k, sum(k)]));
+}
+
+function git(cwd, args) {
+  const result = spawnSync('git', ['-c', 'core.hooksPath=/dev/null', '-c', 'init.templateDir=', '-C', cwd, ...args], {
+    encoding: 'utf8', timeout: 15000,
+    env: { ...process.env, GIT_CONFIG_NOSYSTEM: '1', GIT_CONFIG_GLOBAL: '/dev/null', GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z', GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z' },
+  });
+  if (result.status !== 0) throw Error(`git ${args[0]} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+export function prepareCheckout(corpus, item, cwd) {
+  cpSync(join(corpus, item.base), cwd, { recursive: true });
+  git(cwd, ['init', '-q']);
+  git(cwd, ['config', 'user.name', 'Cadre fixture']);
+  git(cwd, ['config', 'user.email', 'fixture@example.invalid']);
+  git(cwd, ['add', '--all']);
+  git(cwd, ['commit', '-qm', 'Base']);
+  git(cwd, ['tag', 'BASE']);
+  for (const file of readdirSync(cwd)) if (file !== '.git') rmSync(join(cwd, file), { recursive: true, force: true });
+  cpSync(join(corpus, item.target), cwd, { recursive: true });
+  git(cwd, ['add', '--all']);
+  git(cwd, ['commit', '--allow-empty', '-qm', 'Change under review']);
+  return { base_tree: git(cwd, ['rev-parse', 'BASE^{tree}']), reviewed_tree: git(cwd, ['rev-parse', 'HEAD^{tree}']) };
+}
+
+function softwareHashes() {
+  const paths = ['evals/review-v1/compare.mjs', 'evals/review-v1/prompt.md', 'evals/review-v1/verify-corpus.mjs'];
+  for (const file of readdirSync(integration).sort()) if (/\.(mjs|json)$/.test(file) && !file.endsWith('.test.mjs')) paths.push(`integrations/pi-review/${file}`);
+  return Object.fromEntries(paths.sort().map(p => [p, digest(readFileSync(join(root, p)))]));
+}
+
+export async function preflightModel(pkgDir, agentDir, requested, thinking) {
+  const sdk = await import(pathToFileURL(join(pkgDir, 'dist/index.js')));
+  const runtime = await sdk.ModelRuntime.create({
+    authPath: join(agentDir, 'auth.json'), modelsPath: join(agentDir, 'models.json'),
+    modelsStorePath: join(agentDir, 'models-cache.json'), allowModelNetwork: false,
+    refreshOnCreate: false, signal: AbortSignal.timeout(10000),
+  });
+  const slash = requested.indexOf('/');
+  const model = runtime.getModel(requested.slice(0, slash), requested.slice(slash + 1));
+  if (!model || `${model.provider}/${model.id}` !== requested) throw Error('Requested model is unavailable; no arms were dispatched');
+  const settingsManager = sdk.SettingsManager.inMemory(settings);
+  const loader = new sdk.DefaultResourceLoader({ cwd: agentDir, agentDir, settingsManager,
+    noExtensions: true, noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true,
+  });
+  await loader.reload();
+  const { session } = await sdk.createAgentSession({ cwd: agentDir, agentDir, model, modelRuntime: runtime,
+    thinkingLevel: thinking, tools: [], resourceLoader: loader, settingsManager,
+    sessionManager: sdk.SessionManager.inMemory(agentDir),
+  });
+  try {
+    if (session.thinkingLevel !== thinking) throw Error(`Requested thinking level ${thinking} is unsupported; no arms were dispatched`);
+    return { provider: model.provider, model: model.id, effective_thinking: session.thinkingLevel };
+  } finally { session.dispose(); }
+}
+
+function corpusFingerprint(corpus) {
+  const walk = path => readdirSync(path, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name)).flatMap(entry =>
+    entry.isDirectory() ? walk(join(path, entry.name)) : [[join(path, entry.name).slice(corpus.length + 1), digest(readFileSync(join(path, entry.name)))]]);
+  return digest(JSON.stringify(walk(corpus)));
+}
+
+function copyConfig(source, target, provider) {
+  mkdirSync(target, { mode: 0o700 });
+  let providerConfig = null;
+  if (existsSync(join(source, 'models.json'))) {
+    const config = json(join(source, 'models.json'));
+    providerConfig = config.providers?.[provider] ?? null;
+    save(join(target, 'models.json'), { providers: providerConfig ? { [provider]: providerConfig } : {} });
+  }
+  if (existsSync(join(source, 'auth.json'))) {
+    const auth = json(join(source, 'auth.json'));
+    save(join(target, 'auth.json'), auth[provider] ? { [provider]: auth[provider] } : {});
+  }
+  save(join(target, 'settings.json'), settings);
+  // Fingerprint the exact provider config without publishing its endpoints or credentials.
+  return digest(JSON.stringify(providerConfig));
+}
+
+export async function execute(command, args, { cwd, env, prompt, timeout, stdout, stderr }) {
+  return new Promise((resolveRun, reject) => {
+    const started = Date.now();
+    let timedOut = false;
+    let killTimer;
+    const child = spawn(command, args, { cwd, env, detached: process.platform !== 'win32', stdio: ['pipe', 'pipe', 'pipe'] });
+    const kill = signal => { try { process.kill(process.platform === 'win32' ? child.pid : -child.pid, signal); } catch {} };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      kill('SIGTERM');
+      killTimer = setTimeout(() => kill('SIGKILL'), 3000);
+    }, timeout * 1000);
+    child.stdout.on('data', data => appendFileSync(stdout, data, { mode: 0o600 }));
+    child.stderr.on('data', data => appendFileSync(stderr, data, { mode: 0o600 }));
+    child.stdin.on('error', () => {});
+    child.once('error', error => { clearTimeout(timer); clearTimeout(killTimer); reject(error); });
+    child.once('close', (code, signal) => {
+      clearTimeout(timer); clearTimeout(killTimer);
+      resolveRun({ exit_code: code, signal, timed_out: timedOut, seconds: (Date.now() - started) / 1000 });
+    });
+    child.stdin.end(prompt);
+  });
+}
+
+export function report(rows, manifest) {
+  const lines = ['# Pi review comparison', '',
+    'Synthetic development evidence. Completion means usable output, not a correct review.',
+    'Quality grades are intentionally absent until findings are checked against the case oracle and code.', '',
+    `Model requested: ${manifest.model}. Repetitions: ${manifest.runs}. Split: ${manifest.split}.`,
+    'Stock Pi CLI and the SDK adapter use the same pinned Pi release, checkout, common brief, provider configuration, thinking setting, and wall-clock limit.',
+    'The intervention adds structured submission, execution receipts, and their instructions. This compares that bundle, not the SDK alone.', '',
+    '| Case | Repeat | Arm | Output | Seconds | Review |', '|---|---:|---|---|---:|---|'];
+  for (const row of rows) lines.push(`| ${row.case} | ${row.repeat} | ${row.arm} | ${row.status} | ${row.seconds.toFixed(1)} | [read](${row.run_id}/review.md) |`);
+  lines.push('', 'Missing, failed, and partial runs remain visible. Repeat attempts are not independent panel votes.',
+    'See manifest.json for fingerprints, runs.jsonl for measured records, and each run directory for events and results.', '');
+  return lines.join('\n');
+}
+
+export async function compare(options, dependencies = {}) {
+  const corpus = join(here, 'corpus');
+  await verifyCorpus(corpus);
+  const corpusManifest = json(join(corpus, 'manifest.json'));
+  const cases = corpusManifest.cases.filter(c => (options.split === 'all' || c.split === options.split) && (!options.case || c.id === options.case));
+  if (!cases.length) throw Error('No cases selected');
+  const out = resolve(options.out);
+  if (out.startsWith(root + '/') || out === root) throw Error('Put comparison artifacts outside the Cadre worktree');
+  mkdirSync(out, { mode: 0o700 });
+  const pkgDir = join(integration, 'node_modules/@earendil-works/pi-coding-agent');
+  const version = json(join(pkgDir, 'package.json')).version;
+  if (version !== '0.84.4') throw Error('Comparison requires pinned Pi 0.84.4; run npm ci in integrations/pi-review');
+  const prompt = readFileSync(join(here, 'prompt.md'), 'utf8');
+  const source = resolve(options['agent-dir'] ?? process.env.PI_CODING_AGENT_DIR ?? join(homedir(), '.pi/agent'));
+  const provider = options.model.slice(0, options.model.indexOf('/'));
+  const work = mkdtempSync(join(tmpdir(), 'cadre-pi-eval-'));
+  const manifest = {
+    schema: 'cadre/pi-comparison@1', model: options.model, sdk_version: version, runs: options.runs,
+    split: options.split, thinking: options.thinking, timeout: options.timeout, settings,
+    corpus_sha256: corpusFingerprint(corpus), software: softwareHashes(),
+    prompt_sha256: digest(prompt), cases: cases.map(c => c.id), started_at: new Date().toISOString(),
+    intervention: 'submit_review and execution_receipts tools plus their instructions; stock CLI versus SDK lifecycle',
+  };
+  const rows = [];
+  const append = row => appendFileSync(join(out, 'runs.jsonl'), JSON.stringify(row) + '\n', { mode: 0o600 });
+  try {
+    const frozenConfig = join(work, 'config');
+    manifest.provider_config_sha256 = copyConfig(source, frozenConfig, provider);
+    save(join(out, 'manifest.json'), manifest);
+    manifest.preflight = await (dependencies.preflightModel ?? preflightModel)(pkgDir, frozenConfig, options.model, options.thinking);
+    save(join(out, 'manifest.json'), manifest);
+    for (let repeat = 1; repeat <= options.runs; repeat++) {
+      for (let index = 0; index < cases.length; index++) {
+        const item = cases[index];
+        const order = (index + repeat) % 2 ? ['stock', 'review'] : ['review', 'stock'];
+        for (const arm of order) {
+          if (JSON.stringify(softwareHashes()) !== JSON.stringify(manifest.software) || corpusFingerprint(corpus) !== manifest.corpus_sha256) throw Error('Evaluation code or corpus changed during the run; start a fresh comparison');
+          const runId = `run-${String(rows.length + 1).padStart(4, '0')}`;
+          const runOut = join(out, runId);
+          mkdirSync(runOut, { mode: 0o700 });
+          const runWork = mkdtempSync(join(work, 'attempt-'));
+          const cwd = join(runWork, 'checkout');
+          const trees = prepareCheckout(corpus, item, cwd);
+          const agentDir = join(runWork, 'config');
+          cpSync(frozenConfig, agentDir, { recursive: true });
+          const env = { ...process.env, PI_CODING_AGENT_DIR: agentDir, PI_OFFLINE: '1', PI_TELEMETRY: '0' };
+          for (const key of Object.keys(env)) if (key.startsWith('CADRE_')) delete env[key];
+          const stdout = join(runOut, arm === 'stock' ? 'events.jsonl' : 'stdout.txt');
+          const stderr = join(runOut, 'stderr.txt');
+          writeFileSync(stdout, '', { mode: 0o600 }); writeFileSync(stderr, '', { mode: 0o600 });
+          const args = arm === 'stock'
+            ? [join(pkgDir, 'dist/bundle/cli.js'), '-p', '--mode', 'json', '--no-session', '--no-extensions', '--no-skills', '--no-prompt-templates', '--no-themes', '--no-context-files', '--offline', '--tools', 'read,bash,edit,write', '--model', options.model, '--thinking', options.thinking]
+            : [join(integration, 'cli.mjs'), '--cwd', cwd, '--model', options.model, '--out', join(runOut, 'sdk'), '--thinking', options.thinking, '--timeout', String(options.timeout)];
+          const baseRecord = { run_id: runId, case: item.id, arm, repeat, ...trees };
+          append({ event: 'dispatch', ...baseRecord, at: new Date().toISOString() });
+          let execution;
+          const launchTime = Date.now();
+          try { execution = await (dependencies.execute ?? execute)(process.execPath, args, { cwd, env, prompt, timeout: options.timeout, stdout, stderr }); }
+          catch { execution = { exit_code: null, signal: null, timed_out: false, seconds: (Date.now() - launchTime) / 1000, launch_error: true }; }
+          let result;
+          if (arm === 'stock') result = parseStock(readFileSync(stdout, 'utf8'), execution.exit_code, execution.timed_out);
+          else if (existsSync(join(runOut, 'sdk/result.json'))) {
+            try {
+              result = json(join(runOut, 'sdk/result.json'));
+              result.review = readFileSync(join(runOut, 'sdk/review.md'), 'utf8');
+            } catch { result = { status: 'failed', review: '', reason: 'incomplete SDK artifacts', usage: null }; }
+            if ((execution.timed_out || execution.exit_code !== 0) && result.status === 'ok') {
+              result.status = 'degraded';
+              result.reason = execution.timed_out ? 'timeout' : 'process did not finish successfully';
+              // Keep the original SDK artifact intact, but the normalized review
+              // must not present a completed verdict after the outer deadline.
+              result.review = result.findings?.length
+                ? result.review.replace(/\n*Verdict: (blocking|should-fix|no defects found)\s*$/, '')
+                : `DID NOT COMPLETE: ${result.reason}`;
+              result.review += `\n\n_TRUNCATED: ${result.reason}; review did not complete.\n`;
+            }
+          } else result = { status: 'failed', review: '', reason: 'no SDK result', usage: null };
+          const expectedModel = options.model.slice(provider.length + 1);
+          const observed = { provider: result.provider ?? null, model: result.model ?? null };
+          if (result.status === 'ok' && (observed.provider !== provider || observed.model !== expectedModel)) {
+            result.status = 'invalid'; result.reason = 'observed model identity does not match requested model';
+          }
+          let treeUnchanged = false;
+          try {
+            treeUnchanged = git(cwd, ['status', '--porcelain', '--untracked-files=no']) === '' && git(cwd, ['rev-parse', 'HEAD^{tree}']) === trees.reviewed_tree && git(cwd, ['rev-parse', 'BASE^{tree}']) === trees.base_tree;
+          } catch { /* A damaged checkout is an invalid run, not a missing observation. */ }
+          if (!treeUnchanged) { result.status = 'invalid'; result.reason = 'reviewer changed or removed the checkout'; }
+          if (JSON.stringify(softwareHashes()) !== JSON.stringify(manifest.software) || corpusFingerprint(corpus) !== manifest.corpus_sha256) {
+            result.status = 'invalid'; result.reason = 'evaluation software or corpus changed during this run';
+          }
+          writeFileSync(join(runOut, 'review.md'), result.review ?? '', { mode: 0o600 });
+          save(join(runOut, 'result.json'), result);
+          const row = { ...baseRecord, ...execution, status: result.status, reason: result.reason, requested_model: expectedModel, observed,
+            usage: Array.isArray(result.usage) ? sumUsage(result.usage.map(usage => ({ usage }))) : result.usage ?? null,
+            tool_calls: Array.isArray(result.tool_calls) ? result.tool_calls.length : result.tool_calls ?? null, tree_unchanged: treeUnchanged };
+          rows.push(row); append({ event: 'complete', ...row });
+          writeFileSync(join(out, 'report.md'), report(rows, manifest), { mode: 0o600 });
+          console.log(`${runId} ${item.id} r${repeat} ${arm}: ${row.status}, ${execution.seconds.toFixed(1)}s`);
+          rmSync(runWork, { recursive: true, force: true });
+        }
+      }
+    }
+    save(join(out, 'adjudication.template.json'), {
+      schema: 'cadre/pi-adjudication@1', status: 'NOT_ADJUDICATED',
+      instructions: 'Read each complete review against the hidden oracle and code. Record HIT/MISS/DEFER for buggy cases; judge each extra finding separately. Do not label every extra false. Evidence must quote the original review. Keep author identity and grading method explicit.',
+      runs: rows.map(row => ({ run_id: row.run_id, key_verdict: null, evidence: null, extra_findings: null })),
+    });
+    return { out, rows };
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+    manifest.finished_at = new Date().toISOString();
+    manifest.completed_runs = rows.length;
+    manifest.expected_runs = cases.length * options.runs * 2;
+    save(join(out, 'manifest.json'), manifest);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) console.log('node evals/review-v1/compare.mjs --model provider/model --out NEW_DIRECTORY [--runs 2] [--split development|holdout|all] [--case ID] [--thinking off] [--timeout 180] [--agent-dir DIR]');
+    else { const result = await compare(options); if (result.rows.some(r => r.status !== 'ok')) process.exitCode = 1; }
+  } catch (error) { console.error(`comparison: ${error.message}`); process.exitCode = 1; }
+}

--- a/evals/review-v1/compare.mjs
+++ b/evals/review-v1/compare.mjs
@@ -48,7 +48,11 @@ function stockVerdict(review) {
       continue;
     }
     if (fence) continue;
-    const match = line.replace(/\*\*|__/g, '').match(/^Verdict:\s*(blocking|should-fix|no defects found)\s*$/i);
+    let normalized = line.replace(/^[-*][ \t]+/, '');
+    if (/^#{1,6}[ \t]+/.test(normalized)) {
+      normalized = normalized.replace(/^#{1,6}[ \t]+/, '').replace(/[ \t]+#+[ \t]*$/, '');
+    }
+    const match = normalized.replace(/\*\*|__/g, '').match(/^(?:Overall[ \t]+)?Verdict:\s*(blocking|should-fix|no defects found)\s*$/i);
     if (match) verdicts.add(match[1].toLowerCase());
   }
   return verdicts.size === 1 ? [...verdicts][0] : null;
@@ -160,12 +164,37 @@ function copyConfig(source, target, provider) {
   return digest(JSON.stringify(providerConfig));
 }
 
-export async function execute(command, args, { cwd, env, prompt, timeout, stdout, stderr }) {
+export function preflightTemporaryDirectoryIsolation() {
+  const result = spawnSync('/usr/bin/bwrap', ['--bind', '/', '/', '--tmpfs', '/tmp', '--chdir', '/', '--', '/usr/bin/true'], {
+    encoding: 'utf8', timeout: 5000,
+  });
+  if (result.error || result.status !== 0) {
+    throw Error('Comparison requires working /usr/bin/bwrap for a private /tmp per attempt. Install bubblewrap and enable unprivileged user namespaces, then retry; no model arms were dispatched.');
+  }
+}
+
+export function privateTmpCommand(command, args, { cwd, runWork, runOut }) {
+  if (!runWork || !runOut) throw Error('Private /tmp execution requires the current attempt and artifact directories');
+  if (!resolve(cwd).startsWith(resolve(runWork) + '/')) throw Error('Checkout must be inside the current attempt directory');
+  return { command: '/usr/bin/bwrap', args: [
+    '--bind', '/', '/', '--tmpfs', '/tmp',
+    // Re-expose only this attempt's checkout/config and artifacts after hiding
+    // host /tmp. Never bind the parent containing other attempts or results.
+    '--bind', resolve(runWork), resolve(runWork), '--bind', resolve(runOut), resolve(runOut),
+    '--chdir', cwd, '--', command, ...args,
+  ] };
+}
+
+export async function execute(command, args, { cwd, env, prompt, timeout, stdout, stderr, runWork, runOut }) {
+  const isolated = privateTmpCommand(command, args, { cwd, runWork, runOut });
   return new Promise((resolveRun, reject) => {
     const started = Date.now();
     let timedOut = false;
     let killTimer;
-    const child = spawn(command, args, { cwd, env, detached: process.platform !== 'win32', stdio: ['pipe', 'pipe', 'pipe'] });
+    const child = spawn(isolated.command, isolated.args, {
+      cwd, env: { ...env, TMPDIR: '/tmp', TMP: '/tmp', TEMP: '/tmp' },
+      detached: process.platform !== 'win32', stdio: ['pipe', 'pipe', 'pipe'],
+    });
     const kill = signal => { try { process.kill(process.platform === 'win32' ? child.pid : -child.pid, signal); } catch {} };
     const timer = setTimeout(() => {
       timedOut = true;
@@ -190,6 +219,7 @@ export function report(rows, manifest) {
     'Quality grades are intentionally absent until findings are checked against the case oracle and code.', '',
     `Model requested: ${manifest.model}. Repetitions: ${manifest.runs}. Split: ${manifest.split}.`,
     'Stock Pi CLI and the SDK adapter use the same pinned Pi release, checkout, common brief, provider configuration, thinking setting, and wall-clock limit.',
+    'Both arms get a fresh private /tmp through bubblewrap, exposing only the current attempt and its artifacts there. Host networking and the rest of the filesystem remain available; this is not a full sandbox.',
     'The intervention adds structured submission, execution receipts, and their instructions. This compares that bundle, not the SDK alone.', '',
     '| Case | Repeat | Arm | Output | Seconds | Review |', '|---|---:|---|---|---:|---|'];
   for (const row of rows) lines.push(`| ${row.case} | ${row.repeat} | ${row.arm} | ${row.status} | ${row.seconds.toFixed(1)} | [read](${row.run_id}/review.md) |`);
@@ -204,6 +234,7 @@ export async function compare(options, dependencies = {}) {
   const corpusManifest = json(join(corpus, 'manifest.json'));
   const cases = corpusManifest.cases.filter(c => (options.split === 'all' || c.split === options.split) && (!options.case || c.id === options.case));
   if (!cases.length) throw Error('No cases selected');
+  if (!dependencies.execute) await (dependencies.preflightIsolation ?? preflightTemporaryDirectoryIsolation)();
   const out = resolve(options.out);
   if (out.startsWith(root + '/') || out === root) throw Error('Put comparison artifacts outside the Cadre worktree');
   mkdirSync(out, { mode: 0o700 });
@@ -220,6 +251,7 @@ export async function compare(options, dependencies = {}) {
     corpus_sha256: corpusFingerprint(corpus), software: softwareHashes(),
     prompt_sha256: digest(prompt), cases: cases.map(c => c.id), started_at: new Date().toISOString(),
     intervention: 'submit_review and execution_receipts tools plus their instructions; stock CLI versus SDK lifecycle',
+    temporary_directory_isolation: dependencies.execute ? 'injected executor' : 'per-attempt private /tmp via bubblewrap; current attempt and artifact directories rebound; host network unchanged',
   };
   const rows = [];
   const append = row => appendFileSync(join(out, 'runs.jsonl'), JSON.stringify(row) + '\n', { mode: 0o600 });
@@ -255,7 +287,7 @@ export async function compare(options, dependencies = {}) {
           append({ event: 'dispatch', ...baseRecord, at: new Date().toISOString() });
           let execution;
           const launchTime = Date.now();
-          try { execution = await (dependencies.execute ?? execute)(process.execPath, args, { cwd, env, prompt, timeout: options.timeout, stdout, stderr }); }
+          try { execution = await (dependencies.execute ?? execute)(process.execPath, args, { cwd, env, prompt, timeout: options.timeout, stdout, stderr, runWork, runOut }); }
           catch { execution = { exit_code: null, signal: null, timed_out: false, seconds: (Date.now() - launchTime) / 1000, launch_error: true }; }
           let result;
           if (arm === 'stock') result = parseStock(readFileSync(stdout, 'utf8'), execution.exit_code, execution.timed_out);

--- a/evals/review-v1/compare.mjs
+++ b/evals/review-v1/compare.mjs
@@ -165,11 +165,12 @@ function copyConfig(source, target, provider) {
 }
 
 export function preflightTemporaryDirectoryIsolation() {
-  const result = spawnSync('/usr/bin/bwrap', ['--bind', '/', '/', '--tmpfs', '/tmp', '--chdir', '/', '--', '/usr/bin/true'], {
+  const probe = `const {spawnSync}=require('node:child_process'); const result=spawnSync('/bin/bash',['--noprofile','--norc','-c','git --version'],{stdio:['ignore','pipe','pipe']}); if(result.error || result.status !== 0) process.exit(1);`;
+  const result = spawnSync('/usr/bin/bwrap', ['--bind', '/', '/', '--tmpfs', '/tmp', '--dev', '/dev', '--chdir', '/', '--', process.execPath, '-e', probe], {
     encoding: 'utf8', timeout: 5000,
   });
   if (result.error || result.status !== 0) {
-    throw Error('Comparison requires working /usr/bin/bwrap for a private /tmp per attempt. Install bubblewrap and enable unprivileged user namespaces, then retry; no model arms were dispatched.');
+    throw Error('Comparison requires working /usr/bin/bwrap with standard /dev and bash/git subprocesses for a private /tmp per attempt. Install bubblewrap and enable unprivileged user namespaces, then retry; no model arms were dispatched.');
   }
 }
 
@@ -177,7 +178,9 @@ export function privateTmpCommand(command, args, { cwd, runWork, runOut }) {
   if (!runWork || !runOut) throw Error('Private /tmp execution requires the current attempt and artifact directories');
   if (!resolve(cwd).startsWith(resolve(runWork) + '/')) throw Error('Checkout must be inside the current attempt directory');
   return { command: '/usr/bin/bwrap', args: [
-    '--bind', '/', '/', '--tmpfs', '/tmp',
+    '--bind', '/', '/', '--tmpfs', '/tmp', '--dev', '/dev',
+    // Root binds are nodev: standard /dev is necessary for ignored stdio
+    // (/dev/null), including Pi bash tools and git's own subprocesses.
     // Re-expose only this attempt's checkout/config and artifacts after hiding
     // host /tmp. Never bind the parent containing other attempts or results.
     '--bind', resolve(runWork), resolve(runWork), '--bind', resolve(runOut), resolve(runOut),
@@ -219,7 +222,7 @@ export function report(rows, manifest) {
     'Quality grades are intentionally absent until findings are checked against the case oracle and code.', '',
     `Model requested: ${manifest.model}. Repetitions: ${manifest.runs}. Split: ${manifest.split}.`,
     'Stock Pi CLI and the SDK adapter use the same pinned Pi release, checkout, common brief, provider configuration, thinking setting, and wall-clock limit.',
-    'Both arms get a fresh private /tmp through bubblewrap, exposing only the current attempt and its artifacts there. Host networking and the rest of the filesystem remain available; this is not a full sandbox.',
+    'Both arms get a fresh private /tmp and standard /dev through bubblewrap, exposing only the current attempt and its artifacts under /tmp. Host networking and other filesystem paths remain available; this is not a full sandbox.',
     'The intervention adds structured submission, execution receipts, and their instructions. This compares that bundle, not the SDK alone.', '',
     '| Case | Repeat | Arm | Output | Seconds | Review |', '|---|---:|---|---|---:|---|'];
   for (const row of rows) lines.push(`| ${row.case} | ${row.repeat} | ${row.arm} | ${row.status} | ${row.seconds.toFixed(1)} | [read](${row.run_id}/review.md) |`);
@@ -251,7 +254,7 @@ export async function compare(options, dependencies = {}) {
     corpus_sha256: corpusFingerprint(corpus), software: softwareHashes(),
     prompt_sha256: digest(prompt), cases: cases.map(c => c.id), started_at: new Date().toISOString(),
     intervention: 'submit_review and execution_receipts tools plus their instructions; stock CLI versus SDK lifecycle',
-    temporary_directory_isolation: dependencies.execute ? 'injected executor' : 'per-attempt private /tmp via bubblewrap; current attempt and artifact directories rebound; host network unchanged',
+    temporary_directory_isolation: dependencies.execute ? 'injected executor' : 'per-attempt private /tmp and standard /dev via bubblewrap; current attempt and artifact directories rebound; host network unchanged',
   };
   const rows = [];
   const append = row => appendFileSync(join(out, 'runs.jsonl'), JSON.stringify(row) + '\n', { mode: 0o600 });

--- a/evals/review-v1/compare.test.mjs
+++ b/evals/review-v1/compare.test.mjs
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, 
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { compare, parseArgs, parseStock, preflightModel, prepareCheckout, settings } from './compare.mjs';
+import { compare, execute, parseArgs, parseStock, preflightModel, preflightTemporaryDirectoryIsolation, prepareCheckout, privateTmpCommand, settings } from './compare.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const temp = () => mkdtempSync(join(tmpdir(), 'cadre-comparison-test-'));
@@ -159,4 +159,108 @@ test('outer deadline degrades SDK exit-zero success just as it degrades stock su
     assert.match(normalized, /_TRUNCATED: timeout/);
     assert.match(readFileSync(join(result.out, sdk.run_id, 'sdk/review.md'), 'utf8'), /Verdict: no defects found/);
   } finally { rmSync(work, { recursive: true, force: true }); }
+});
+
+test('private /tmp hides host and previous attempt files while exposing current checkout, config and outputs for both arms', async () => {
+  preflightTemporaryDirectoryIsolation();
+  const work = mkdtempSync('/tmp/cadre-private-tmp-test-');
+  const sharedScratch = `/tmp/${work.split('/').at(-1)}-scratch.mjs`;
+  const sentinel = join(work, 'host-sentinel');
+  const previous = join(work, 'previous-attempt');
+  mkdirSync(previous); writeFileSync(join(previous, 'publish.mjs'), 'stale fixture');
+  writeFileSync(sentinel, 'host only');
+  let previousOut = join(work, 'nonexistent-output');
+  try {
+    for (const arm of ['stock', 'review']) {
+      const runWork = join(work, `attempt-${arm}`);
+      const cwd = join(runWork, 'checkout');
+      const config = join(runWork, 'config');
+      const runOut = join(work, `output-${arm}`);
+      mkdirSync(cwd, { recursive: true }); mkdirSync(config); mkdirSync(runOut);
+      writeFileSync(join(cwd, 'fixture.mjs'), arm);
+      writeFileSync(join(config, 'settings.json'), '{}');
+      const stdout = join(runOut, 'stdout.txt'); const stderr = join(runOut, 'stderr.txt');
+      writeFileSync(stdout, ''); writeFileSync(stderr, '');
+      const script = `
+        const fs = require('node:fs');
+        const hidden = ${JSON.stringify([sentinel, join(previous, 'publish.mjs'), previousOut, sharedScratch])};
+        const checks = {
+          hidden: hidden.every(path => !fs.existsSync(path)),
+          checkout: fs.readFileSync(${JSON.stringify(join(cwd, 'fixture.mjs'))}, 'utf8') === ${JSON.stringify(arm)},
+          config: fs.readFileSync(${JSON.stringify(join(config, 'settings.json'))}, 'utf8') === '{}',
+          temp: process.env.TMPDIR === '/tmp' && process.env.TMP === '/tmp' && process.env.TEMP === '/tmp'
+        };
+        fs.writeFileSync(${JSON.stringify(sharedScratch)}, 'private reproduction');
+        fs.writeFileSync(${JSON.stringify(join(runOut, 'sdk-result.json'))}, JSON.stringify(checks));
+        console.log(JSON.stringify(checks));
+        if (Object.values(checks).some(value => !value)) process.exitCode = 1;
+      `;
+      const wrapped = privateTmpCommand(process.execPath, ['-e', script], { cwd, runWork, runOut });
+      assert.equal(wrapped.command, '/usr/bin/bwrap');
+      assert.deepEqual(wrapped.args.slice(0, 5), ['--bind', '/', '/', '--tmpfs', '/tmp']);
+      const result = await execute(process.execPath, ['-e', script], {
+        cwd, runWork, runOut, env: { ...process.env, TMPDIR: '/host/temp' }, prompt: '', timeout: 5, stdout, stderr,
+      });
+      assert.equal(result.exit_code, 0, readFileSync(stderr, 'utf8'));
+      assert.deepEqual(JSON.parse(readFileSync(stdout)), { hidden: true, checkout: true, config: true, temp: true });
+      assert.equal(existsSync(join(runOut, 'sdk-result.json')), true);
+      assert.equal(existsSync(sharedScratch), false);
+      previousOut = runOut;
+    }
+    assert.equal(readFileSync(sentinel, 'utf8'), 'host only');
+    assert.equal(readFileSync(join(previous, 'publish.mjs'), 'utf8'), 'stale fixture');
+  } finally { rmSync(work, { recursive: true, force: true }); rmSync(sharedScratch, { force: true }); }
+});
+
+test('failed private /tmp preflight prevents model preflight and all dispatch', async () => {
+  const work = temp();
+  let modelCalled = false;
+  try {
+    await assert.rejects(compare({ model: 'provider/model', out: join(work, 'output'), runs: 1,
+      split: 'development', case: 'tenant-scope-buggy', thinking: 'off', timeout: 10, 'agent-dir': work }, {
+      preflightIsolation: () => { throw Error('bubblewrap unavailable'); },
+      preflightModel: async () => { modelCalled = true; },
+    }), /bubblewrap unavailable/);
+    assert.equal(modelCalled, false);
+    assert.equal(existsSync(join(work, 'output')), false);
+  } finally { rmSync(work, { recursive: true, force: true }); }
+});
+
+
+test('stock verdict accepts ATX headings, bullets and overall labels', () => {
+  const verdicts = ['blocking', 'should-fix', 'no defects found'];
+  for (const verdict of verdicts) {
+    const headings = Array.from({ length: 6 }, (_, depth) => `${'#'.repeat(depth + 1)} Verdict: ${verdict}`);
+    for (const text of [...headings,
+      `## **Verdict:** ${verdict}`, `## Verdict: ${verdict} ##`,
+      `### **Verdict:** **${verdict}** ###`, `- **Verdict:** ${verdict}`, `* Verdict: ${verdict}`,
+      `Overall verdict: ${verdict}`, `## **Overall verdict:** ${verdict}`, `- ## Verdict: ${verdict}`,
+    ]) {
+      const result = parseStock(stream(message(text), { type: 'agent_end' }), 0);
+      assert.equal(result.status, 'ok', text);
+      assert.equal(result.verdict, verdict, text);
+      assert.equal(result.review, text);
+    }
+  }
+});
+
+test('stock heading normalization preserves quote, example and conflict exclusions', () => {
+  for (const text of [
+    '####### Verdict: blocking', '##Verdict: blocking', '+ Verdict: no defects found',
+    '> ## Verdict: no defects found', '    ## Verdict: no defects found',
+    '```markdown\n## Verdict: no defects found\n```',
+    '~~~\n- **Verdict:** no defects found\n~~~',
+    '## Verdict: no defects found\nOverall verdict: blocking',
+    '- Verdict: no defects found\n## Verdict: should-fix',
+    '## Verdict: blocking##',
+  ]) {
+    const result = parseStock(stream(message(text), { type: 'agent_end' }), 0);
+    assert.equal(result.status, 'inconclusive', text);
+    assert.equal(result.verdict, null, text);
+  }
+  const review = '> ## Verdict: no defects found\n```\n## Verdict: no defects found\n```\n## Verdict: blocking';
+  assert.equal(parseStock(stream(message(review), { type: 'agent_end' }), 0).verdict, 'blocking');
+  for (const [exitCode, timedOut, stopReason] of [[124, true, 'stop'], [1, false, 'stop'], [0, false, 'length']]) {
+    assert.equal(parseStock(stream(message('## Verdict: no defects found', stopReason), { type: 'agent_end' }), exitCode, timedOut).status, 'degraded');
+  }
 });

--- a/evals/review-v1/compare.test.mjs
+++ b/evals/review-v1/compare.test.mjs
@@ -1,0 +1,162 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { compare, parseArgs, parseStock, preflightModel, prepareCheckout, settings } from './compare.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const temp = () => mkdtempSync(join(tmpdir(), 'cadre-comparison-test-'));
+const message = (text, stopReason = 'stop') => ({ type: 'message_end', message: {
+  role: 'assistant', model: 'model', provider: 'provider', stopReason,
+  content: [{ type: 'text', text }], usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15 },
+} });
+const stream = (...events) => events.map(JSON.stringify).join('\n') + '\n';
+
+test('stock exit zero cannot conceal a provider error or incomplete stream', () => {
+  assert.equal(parseStock(stream(message('', 'error'), { type: 'agent_end' }), 0).status, 'failed');
+  assert.equal(parseStock(stream(message('Verdict: no defects found')), 0).status, 'degraded');
+  assert.equal(parseStock(stream(message('Verdict: no defects found'), { type: 'agent_end' }) + '{', 0).status, 'degraded');
+});
+
+test('stock clean requires explicit conclusion and complete terminal event', () => {
+  const valid = parseStock(stream(message('Verdict: no defects found'), { type: 'agent_end' }), 0);
+  assert.equal(valid.status, 'ok'); assert.equal(valid.usage.totalTokens, 15);
+  assert.equal(parseStock(stream(message('I examined the files.'), { type: 'agent_end' }), 0).status, 'inconclusive');
+  assert.equal(parseStock(stream(message('Verdict: no defects found'), { type: 'agent_end' }), 124, true).status, 'degraded');
+});
+
+test('stock verdict accepts equivalent bold Markdown without changing review evidence', () => {
+  for (const verdict of [
+    'Verdict: blocking', '**Verdict: blocking**', '**Verdict:** blocking', 'Verdict: **blocking**',
+    '__Verdict: blocking__', '__Verdict:__ blocking', 'Verdict: __blocking__', '  **vErDiCt: BLOCKING**  ',
+  ]) {
+    const review = `Concrete tenant bypass finding.\n\n${verdict}\n\nThe lookup lost its tenant predicate.`;
+    const result = parseStock(stream(message(review), { type: 'agent_end' }), 0);
+    assert.equal(result.status, 'ok', verdict);
+    assert.equal(result.verdict, 'blocking', verdict);
+    assert.equal(result.review, review);
+  }
+});
+
+test('stock verdict ignores quoted and code examples and rejects conflicting conclusions', () => {
+  for (const review of [
+    '> **Verdict: no defects found**',
+    '```markdown\nVerdict: no defects found\n```',
+    '~~~\n**Verdict: no defects found**\n~~~',
+    '````\n```\nVerdict: no defects found\n````',
+    '    Verdict: no defects found',
+    '\tVerdict: no defects found',
+    '`Verdict: no defects found`',
+    'Verdict: no defects found\n**Verdict: blocking**',
+  ]) {
+    const result = parseStock(stream(message(review), { type: 'agent_end' }), 0);
+    assert.equal(result.status, 'inconclusive', review);
+    assert.equal(result.verdict, null, review);
+  }
+  const review = '> Verdict: no defects found\n```\nVerdict: no defects found\n```\n**Verdict: blocking**';
+  assert.equal(parseStock(stream(message(review), { type: 'agent_end' }), 0).verdict, 'blocking');
+});
+
+test('formatted verdict never rescues a timed out, failed, or truncated stock run', () => {
+  for (const [exitCode, timedOut, stopReason] of [[124, true, 'stop'], [1, false, 'stop'], [0, false, 'length']]) {
+    const result = parseStock(stream(message('**Verdict: no defects found**', stopReason), { type: 'agent_end' }), exitCode, timedOut);
+    assert.equal(result.status, 'degraded');
+  }
+});
+
+test('CLI refuses unknown flags, fractional runs and implicit model', () => {
+  for (const args of [[], ['--model', 'model', '--out', '/tmp/x'], ['--model', 'p/m', '--out', '/tmp/x', '--runs', '1.5'], ['--mystery', 'x']]) {
+    assert.throws(() => parseArgs(args));
+  }
+});
+
+test('real SDK preflight rejects unsupported thinking before either model arm runs', async () => {
+  const work = temp();
+  try {
+    writeFileSync(join(work, 'models.json'), JSON.stringify({ providers: { fixture: {
+      baseUrl: 'https://example.invalid/v1', api: 'openai-completions', apiKey: 'unused-fixture-key',
+      models: [{ id: 'plain', name: 'Fixture', reasoning: false, input: ['text'], contextWindow: 8192, maxTokens: 1024,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } }],
+    } } }));
+    const pkgDir = join(here, '../../integrations/pi-review/node_modules/@earendil-works/pi-coding-agent');
+    await assert.rejects(() => preflightModel(pkgDir, work, 'fixture/plain', 'high'), /unsupported/);
+    const result = await preflightModel(pkgDir, work, 'fixture/plain', 'off');
+    assert.deepEqual(result, { provider: 'fixture', model: 'plain', effective_thinking: 'off' });
+  } finally { rmSync(work, { recursive: true, force: true }); }
+});
+
+test('paired checkouts have identical commits and no key or oracle', () => {
+  const work = temp();
+  try {
+    const corpus = join(here, 'corpus');
+    const item = JSON.parse(readFileSync(join(corpus, 'manifest.json'))).cases[0];
+    const first = prepareCheckout(corpus, item, join(work, 'one'));
+    const second = prepareCheckout(corpus, item, join(work, 'two'));
+    assert.deepEqual(first, second);
+    assert.deepEqual(readdirSync(join(work, 'one')).sort(), ['.git', 'README.md', 'documents.mjs']);
+    assert.equal(existsSync(join(work, 'one/oracle.mjs')), false);
+  } finally { rmSync(work, { recursive: true, force: true }); }
+});
+
+test('comparison persists invalid model and destroyed checkout, hides case labels from both arms', async () => {
+  const work = temp();
+  const observations = [];
+  try {
+    const result = await compare({ model: 'provider/model', out: join(work, 'output'), runs: 1,
+      split: 'development', case: 'tenant-scope-buggy', thinking: 'off', timeout: 10, 'agent-dir': work }, {
+      preflightModel: async () => ({ provider: 'provider', model: 'model', effective_thinking: 'off' }),
+      execute: async (_command, args, options) => {
+        observations.push(options);
+        assert.doesNotMatch(options.cwd, /tenant|buggy|fixed/);
+        assert.doesNotMatch(args.join(' '), /tenant-scope|buggy|fixed/);
+        assert.deepEqual(JSON.parse(readFileSync(join(options.env.PI_CODING_AGENT_DIR, 'settings.json'))), settings);
+        if (args[0].includes('/bundle/')) {
+          const event = message('Verdict: no defects found'); event.message.model = 'wrong-model';
+          writeFileSync(options.stdout, stream(event, { type: 'agent_end' }));
+        } else {
+          const out = args[args.indexOf('--out') + 1]; mkdirSync(out);
+          writeFileSync(join(out, 'result.json'), JSON.stringify({ status: 'ok', model: 'model', provider: 'provider', usage: [], tool_calls: [] }));
+          writeFileSync(join(out, 'review.md'), 'Verdict: no defects found\n');
+          rmSync(join(options.cwd, '.git'), { recursive: true });
+        }
+        return { exit_code: 0, signal: null, timed_out: false, seconds: 0.01 };
+      },
+    });
+    assert.equal(result.rows.length, 2);
+    assert.equal(result.rows.every(r => r.status === 'invalid'), true);
+    assert.equal(observations[0].prompt, observations[1].prompt);
+    for (const row of result.rows) assert.equal(JSON.parse(readFileSync(join(result.out, row.run_id, 'result.json'))).status, 'invalid');
+    assert.equal(observations.every(o => !existsSync(o.cwd)), true);
+    await assert.rejects(() => compare({ model: 'provider/model', out: result.out, runs: 1, split: 'development' }), /EEXIST/);
+  } finally { rmSync(work, { recursive: true, force: true }); }
+});
+
+test('outer deadline degrades SDK exit-zero success just as it degrades stock success', async () => {
+  const work = temp();
+  try {
+    const result = await compare({ model: 'provider/model', out: join(work, 'output'), runs: 1,
+      split: 'development', case: 'tenant-scope-buggy', thinking: 'off', timeout: 10, 'agent-dir': work }, {
+      preflightModel: async () => ({ provider: 'provider', model: 'model', effective_thinking: 'off' }),
+      execute: async (_command, args, options) => {
+        if (args[0].includes('/bundle/')) {
+          writeFileSync(options.stdout, stream(message('Verdict: no defects found'), { type: 'agent_end' }));
+        } else {
+          const out = args[args.indexOf('--out') + 1]; mkdirSync(out);
+          writeFileSync(join(out, 'result.json'), JSON.stringify({ status: 'ok', model: 'model', provider: 'provider',
+            findings: [], verdict: 'no defects found', usage: [], tool_calls: [] }));
+          writeFileSync(join(out, 'review.md'), 'No defects found.\n\nVerdict: no defects found\n');
+        }
+        return { exit_code: 0, signal: null, timed_out: true, seconds: 10 };
+      },
+    });
+    assert.equal(result.rows.length, 2);
+    assert.equal(result.rows.every(row => row.status === 'degraded' && row.reason === 'timeout'), true);
+    const sdk = result.rows.find(row => row.arm === 'review');
+    const normalized = readFileSync(join(result.out, sdk.run_id, 'review.md'), 'utf8');
+    assert.doesNotMatch(normalized, /Verdict: no defects found/);
+    assert.match(normalized, /_TRUNCATED: timeout/);
+    assert.match(readFileSync(join(result.out, sdk.run_id, 'sdk/review.md'), 'utf8'), /Verdict: no defects found/);
+  } finally { rmSync(work, { recursive: true, force: true }); }
+});

--- a/evals/review-v1/compare.test.mjs
+++ b/evals/review-v1/compare.test.mjs
@@ -183,12 +183,14 @@ test('private /tmp hides host and previous attempt files while exposing current 
       writeFileSync(stdout, ''); writeFileSync(stderr, '');
       const script = `
         const fs = require('node:fs');
+        const subprocess = require('node:child_process').spawnSync('/bin/bash', ['--noprofile', '--norc', '-c', 'git --version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
         const hidden = ${JSON.stringify([sentinel, join(previous, 'publish.mjs'), previousOut, sharedScratch])};
         const checks = {
           hidden: hidden.every(path => !fs.existsSync(path)),
           checkout: fs.readFileSync(${JSON.stringify(join(cwd, 'fixture.mjs'))}, 'utf8') === ${JSON.stringify(arm)},
           config: fs.readFileSync(${JSON.stringify(join(config, 'settings.json'))}, 'utf8') === '{}',
-          temp: process.env.TMPDIR === '/tmp' && process.env.TMP === '/tmp' && process.env.TEMP === '/tmp'
+          temp: process.env.TMPDIR === '/tmp' && process.env.TMP === '/tmp' && process.env.TEMP === '/tmp',
+          nested_bash_git: !subprocess.error && subprocess.status === 0 && /^git version /.test(subprocess.stdout)
         };
         fs.writeFileSync(${JSON.stringify(sharedScratch)}, 'private reproduction');
         fs.writeFileSync(${JSON.stringify(join(runOut, 'sdk-result.json'))}, JSON.stringify(checks));
@@ -202,7 +204,7 @@ test('private /tmp hides host and previous attempt files while exposing current 
         cwd, runWork, runOut, env: { ...process.env, TMPDIR: '/host/temp' }, prompt: '', timeout: 5, stdout, stderr,
       });
       assert.equal(result.exit_code, 0, readFileSync(stderr, 'utf8'));
-      assert.deepEqual(JSON.parse(readFileSync(stdout)), { hidden: true, checkout: true, config: true, temp: true });
+      assert.deepEqual(JSON.parse(readFileSync(stdout)), { hidden: true, checkout: true, config: true, temp: true, nested_bash_git: true });
       assert.equal(existsSync(join(runOut, 'sdk-result.json')), true);
       assert.equal(existsSync(sharedScratch), false);
       previousOut = runOut;
@@ -263,4 +265,40 @@ test('stock heading normalization preserves quote, example and conflict exclusio
   for (const [exitCode, timedOut, stopReason] of [[124, true, 'stop'], [1, false, 'stop'], [0, false, 'length']]) {
     assert.equal(parseStock(stream(message('## Verdict: no defects found', stopReason), { type: 'agent_end' }), exitCode, timedOut).status, 'degraded');
   }
+});
+
+test('bubblewrap deadline permits a SIGTERM finalizer to persist artifacts while retaining timed_out', async () => {
+  preflightTemporaryDirectoryIsolation();
+  const work = mkdtempSync('/tmp/cadre-private-tmp-signal-test-');
+  try {
+    const runWork = join(work, 'attempt');
+    const cwd = join(runWork, 'checkout');
+    const runOut = join(work, 'output');
+    mkdirSync(cwd, { recursive: true }); mkdirSync(runOut);
+    const stdout = join(runOut, 'stdout.txt'); const stderr = join(runOut, 'stderr.txt');
+    const artifact = join(runOut, 'partial-result.json');
+    writeFileSync(stdout, ''); writeFileSync(stderr, '');
+    const script = `
+      const fs = require('node:fs');
+      process.on('SIGTERM', () => {
+        setTimeout(() => {
+          fs.writeFileSync(${JSON.stringify(artifact)}, JSON.stringify({ status: 'degraded', reason: 'external_abort' }));
+          process.exit(0);
+        }, 25);
+      });
+      console.log('ready');
+      setInterval(() => {}, 1000);
+    `;
+    const result = await execute(process.execPath, ['-e', script], {
+      cwd, runWork, runOut, env: process.env, prompt: '', timeout: 0.3, stdout, stderr,
+    });
+    assert.match(readFileSync(stdout, 'utf8'), /ready/);
+    assert.equal(result.timed_out, true);
+    assert.deepEqual(JSON.parse(readFileSync(artifact)), { status: 'degraded', reason: 'external_abort' });
+    // Group termination includes bwrap itself; the Node child finalizes and
+    // exits zero, while execute conservatively records its wrapper's SIGTERM.
+    assert.equal(result.exit_code, null, readFileSync(stderr, 'utf8'));
+    assert.equal(result.signal, 'SIGTERM');
+    assert.equal(parseStock(stream(message('Verdict: no defects found'), { type: 'agent_end' }), 0, result.timed_out).status, 'degraded');
+  } finally { rmSync(work, { recursive: true, force: true }); }
 });

--- a/evals/review-v1/corpus.test.mjs
+++ b/evals/review-v1/corpus.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { DEFAULT_CORPUS_DIR, verifyCorpus } from './verify-corpus.mjs';
+
+function temporaryCorpus(t) {
+  const directory = mkdtempSync(join(tmpdir(), 'cadre-corpus-test-'));
+  cpSync(DEFAULT_CORPUS_DIR, directory, { recursive: true });
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+// Updating a test copy's digest lets these tests exercise the behavioral gate,
+// independently of the gate that freezes the checked-in fixture bytes.
+function replaceAndRehash(directory, relative, body) {
+  writeFileSync(join(directory, relative), body);
+  const manifestPath = join(directory, 'manifest.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.hashes[relative] = createHash('sha256').update(body).digest('hex');
+  writeFileSync(manifestPath, JSON.stringify(manifest));
+}
+
+test('frozen original corpus has four behavioral red/green pairs', () => {
+  const results = verifyCorpus();
+  assert.equal(results.length, 8);
+  assert.equal(results.filter(result => result.actual === 'assertion_failed').length, 4);
+  assert.equal(results.filter(result => result.actual === 'pass').length, 4);
+  assert.ok(results.every(result => result.ok));
+});
+
+test('changed fixture bytes are rejected before running oracles', t => {
+  const directory = temporaryCorpus(t);
+  writeFileSync(join(directory, 'tenant-scope/target/documents.mjs'), '// drift\n');
+  assert.throws(() => verifyCorpus(directory), /Corpus hash mismatch/);
+});
+
+test('an erroneously green buggy arm is rejected even with matching hashes', t => {
+  const directory = temporaryCorpus(t);
+  replaceAndRehash(directory, 'tenant-scope/target/documents.mjs',
+    readFileSync(join(directory, 'tenant-scope/fixed/documents.mjs'), 'utf8'));
+  assert.throws(() => verifyCorpus(directory), /expected assertion_failed, got pass/);
+});
+
+test('runtime crashes cannot masquerade as expected red', t => {
+  const directory = temporaryCorpus(t);
+  replaceAndRehash(directory, 'tenant-scope/oracle.mjs', "throw new Error('oracle crashed');\n");
+  assert.throws(() => verifyCorpus(directory), /Oracle crashed or produced invalid output/);
+});
+
+test('module syntax and import failures cannot masquerade as expected red', t => {
+  for (const body of ['export async function {', "import './missing.mjs';"]) {
+    const directory = temporaryCorpus(t);
+    replaceAndRehash(directory, 'tenant-scope/target/documents.mjs', body + '\n\n');
+    assert.throws(() => verifyCorpus(directory), /Oracle crashed or produced invalid output/);
+  }
+});
+
+test('extra untracked fixture files are rejected', t => {
+  const directory = temporaryCorpus(t);
+  writeFileSync(join(directory, 'tenant-scope/target/extra.txt'), 'unexpected');
+  assert.throws(() => verifyCorpus(directory), /Corpus hash inventory mismatch/);
+});

--- a/evals/review-v1/corpus/batch-cleanup/base/README.md
+++ b/evals/review-v1/corpus/batch-cleanup/base/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+publish stages a batch of uploads and commits only when every stage succeeds. Failed batches must leave no staged objects behind. stage can settle in any order; remove accepts the ID returned by stage. Storage cleanup succeeds in this exercise.

--- a/evals/review-v1/corpus/batch-cleanup/base/publish.mjs
+++ b/evals/review-v1/corpus/batch-cleanup/base/publish.mjs
@@ -1,0 +1,10 @@
+export async function publish(files, storage) {
+  const staged = [];
+  try {
+    for (const file of files) staged.push(await storage.stage(file));
+    return await storage.commit(staged);
+  } catch (error) {
+    await Promise.all(staged.map(id => storage.remove(id)));
+    throw error;
+  }
+}

--- a/evals/review-v1/corpus/batch-cleanup/fixed/README.md
+++ b/evals/review-v1/corpus/batch-cleanup/fixed/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+publish stages a batch of uploads and commits only when every stage succeeds. Failed batches must leave no staged objects behind. stage can settle in any order; remove accepts the ID returned by stage. Storage cleanup succeeds in this exercise.

--- a/evals/review-v1/corpus/batch-cleanup/fixed/publish.mjs
+++ b/evals/review-v1/corpus/batch-cleanup/fixed/publish.mjs
@@ -1,0 +1,12 @@
+export async function publish(files, storage) {
+  const outcomes = await Promise.allSettled(files.map(file => storage.stage(file)));
+  const staged = outcomes.filter(result => result.status === 'fulfilled').map(result => result.value);
+  try {
+    const failure = outcomes.find(result => result.status === 'rejected');
+    if (failure) throw failure.reason;
+    return await storage.commit(staged);
+  } catch (error) {
+    await Promise.all(staged.map(id => storage.remove(id)));
+    throw error;
+  }
+}

--- a/evals/review-v1/corpus/batch-cleanup/oracle.mjs
+++ b/evals/review-v1/corpus/batch-cleanup/oracle.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { publish } from './publish.mjs';
+const staged = new Set();
+const stageFailure = new Error('Upload rejected');
+let commits = 0;
+const storage = {
+  async stage(file) {
+    if (file === 'reject') throw stageFailure;
+    await new Promise(resolve => setTimeout(resolve, 15));
+    staged.add(file);
+    return file;
+  },
+  async remove(id) { staged.delete(id); },
+  async commit() { commits++; },
+};
+let rejected = false;
+try { await publish(['one', 'reject', 'two'], storage); }
+catch (error) { if (error !== stageFailure) throw error; rejected = true; }
+await new Promise(resolve => setTimeout(resolve, 30));
+const actual = { rejected, commits, remaining: [...staged].sort() };
+const expected = { rejected: true, commits: 0, remaining: [] };
+try {
+  assert.deepEqual(actual, expected);
+  console.log(JSON.stringify({ protocol: 'cadre/oracle@1', status: 'pass' }));
+} catch (error) {
+  if (!(error instanceof assert.AssertionError)) throw error;
+  console.log(JSON.stringify({ protocol: 'cadre/oracle@1', status: 'assertion_failed' }));
+  process.exitCode = 1;
+}

--- a/evals/review-v1/corpus/batch-cleanup/target/README.md
+++ b/evals/review-v1/corpus/batch-cleanup/target/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+publish stages a batch of uploads and commits only when every stage succeeds. Failed batches must leave no staged objects behind. stage can settle in any order; remove accepts the ID returned by stage. Storage cleanup succeeds in this exercise.

--- a/evals/review-v1/corpus/batch-cleanup/target/publish.mjs
+++ b/evals/review-v1/corpus/batch-cleanup/target/publish.mjs
@@ -1,0 +1,10 @@
+export async function publish(files, storage) {
+  let staged = [];
+  try {
+    staged = await Promise.all(files.map(file => storage.stage(file)));
+    return await storage.commit(staged);
+  } catch (error) {
+    await Promise.all(staged.map(id => storage.remove(id)));
+    throw error;
+  }
+}

--- a/evals/review-v1/corpus/manifest.json
+++ b/evals/review-v1/corpus/manifest.json
@@ -1,0 +1,151 @@
+{
+  "schema": "cadre/review-corpus@1",
+  "description": "Original synthetic fixtures. Keys are provisional guidance, not an independently validated quality benchmark. Holdout is a tuning convention, not a secret corpus.",
+  "cases": [
+    {
+      "id": "tenant-scope-buggy",
+      "scenario": "tenant-scope",
+      "variant": "buggy",
+      "split": "development",
+      "base": "tenant-scope/base",
+      "target": "tenant-scope/target",
+      "oracle": "tenant-scope/oracle.mjs",
+      "key": {
+        "id": "cross-tenant-rename",
+        "severity": "blocking",
+        "claim": "The document lookup no longer restricts results to the caller tenant.",
+        "trigger": "A tenant-a caller supplies the ID of a tenant-b document.",
+        "consequence": "The caller can rename a document owned by another tenant.",
+        "path": "documents.mjs",
+        "line": 2
+      }
+    },
+    {
+      "id": "tenant-scope-fixed",
+      "scenario": "tenant-scope",
+      "variant": "fixed",
+      "split": "development",
+      "base": "tenant-scope/base",
+      "target": "tenant-scope/fixed",
+      "oracle": "tenant-scope/oracle.mjs",
+      "key": null
+    },
+    {
+      "id": "batch-cleanup-buggy",
+      "scenario": "batch-cleanup",
+      "variant": "buggy",
+      "split": "development",
+      "base": "batch-cleanup/base",
+      "target": "batch-cleanup/target",
+      "oracle": "batch-cleanup/oracle.mjs",
+      "key": {
+        "id": "partial-stage-leak",
+        "severity": "should-fix",
+        "claim": "The staged list is assigned only when every parallel upload succeeds.",
+        "trigger": "One stage rejects while another succeeds, including success after rejection.",
+        "consequence": "Cleanup sees an empty staged list and failed batches retain uploaded objects.",
+        "path": "publish.mjs",
+        "line": 4
+      }
+    },
+    {
+      "id": "batch-cleanup-fixed",
+      "scenario": "batch-cleanup",
+      "variant": "fixed",
+      "split": "development",
+      "base": "batch-cleanup/base",
+      "target": "batch-cleanup/fixed",
+      "oracle": "batch-cleanup/oracle.mjs",
+      "key": null
+    },
+    {
+      "id": "revision-race-buggy",
+      "scenario": "revision-race",
+      "variant": "buggy",
+      "split": "development",
+      "base": "revision-race/base",
+      "target": "revision-race/target",
+      "oracle": "revision-race/oracle.mjs",
+      "key": {
+        "id": "non-atomic-revision-check",
+        "severity": "blocking",
+        "claim": "A separate revision read and unconditional write replace the atomic update.",
+        "trigger": "Two concurrent updates read the same revision before either write.",
+        "consequence": "Both callers report success and one accepted update is lost.",
+        "path": "drafts.mjs",
+        "line": 5
+      }
+    },
+    {
+      "id": "revision-race-fixed",
+      "scenario": "revision-race",
+      "variant": "fixed",
+      "split": "development",
+      "base": "revision-race/base",
+      "target": "revision-race/fixed",
+      "oracle": "revision-race/oracle.mjs",
+      "key": null
+    },
+    {
+      "id": "vacuous-test-buggy",
+      "scenario": "vacuous-test",
+      "variant": "buggy",
+      "split": "holdout",
+      "base": "vacuous-test/base",
+      "target": "vacuous-test/target",
+      "oracle": "vacuous-test/oracle.mjs",
+      "key": {
+        "id": "empty-deliveries-vacuous-pass",
+        "severity": "should-fix",
+        "claim": "The regression test has no subscribed recipients and every() accepts zero deliveries.",
+        "trigger": "sendDigest regresses to a no-op that never delivers.",
+        "consequence": "The regression test still passes while subscribed users receive no digest.",
+        "path": "digest.test.mjs",
+        "line": 6
+      }
+    },
+    {
+      "id": "vacuous-test-fixed",
+      "scenario": "vacuous-test",
+      "variant": "fixed",
+      "split": "holdout",
+      "base": "vacuous-test/base",
+      "target": "vacuous-test/fixed",
+      "oracle": "vacuous-test/oracle.mjs",
+      "key": null
+    }
+  ],
+  "hashes": {
+    "batch-cleanup/base/README.md": "b24f996e44bf53519b21c903360482077ae9effa62d3b27447c86154e8df35b6",
+    "batch-cleanup/base/publish.mjs": "f02a98002012273a4938fd0bece2aa5b5a28b6b32ddc2867b486f4189bcaa19e",
+    "batch-cleanup/fixed/README.md": "b24f996e44bf53519b21c903360482077ae9effa62d3b27447c86154e8df35b6",
+    "batch-cleanup/fixed/publish.mjs": "314d3e46895fef8790f0a243fb14ac29e6c21207070c2a1ba9e1bc18f93ecd03",
+    "batch-cleanup/oracle.mjs": "d26519b191c11d890d3f00e086b1702e6dfaa46276a44a02d8251133a7ad2d99",
+    "batch-cleanup/target/README.md": "b24f996e44bf53519b21c903360482077ae9effa62d3b27447c86154e8df35b6",
+    "batch-cleanup/target/publish.mjs": "a95b6d8928382363379d85fbd8359b1e1f9384d98013c14be721cef923e135fb",
+    "revision-race/base/README.md": "b5093bba2eab94ae25848934d0c058f7eb5f0de180ee4e0dfe73410f29f75dbc",
+    "revision-race/base/drafts.mjs": "2c6ae7f1570887124755b6984bf5f34092e805e3a052a43929a349cdb16fed31",
+    "revision-race/fixed/README.md": "b5093bba2eab94ae25848934d0c058f7eb5f0de180ee4e0dfe73410f29f75dbc",
+    "revision-race/fixed/drafts.mjs": "c2256ab58655997ed0b8c0b44a69d9e40c134ae4ffc1933dfba75f0bf992ee61",
+    "revision-race/oracle.mjs": "00e2233dd35e75df12082e6da6b68d73bbc2f4e2da3a63752984186ebca39f90",
+    "revision-race/target/README.md": "b5093bba2eab94ae25848934d0c058f7eb5f0de180ee4e0dfe73410f29f75dbc",
+    "revision-race/target/drafts.mjs": "194ae65cd98b26998cca70983f79146720836218bc7f6d011302ee39191cf800",
+    "tenant-scope/base/README.md": "a6d01a12bda6f66aa0b314c2e2da728ff0e016c82dccf110c8233a75d8236dab",
+    "tenant-scope/base/documents.mjs": "3bd2cb73ef4a841c1e7a6e1f8acddb1658e31e96cb64611168f07b6375d9f372",
+    "tenant-scope/fixed/README.md": "a6d01a12bda6f66aa0b314c2e2da728ff0e016c82dccf110c8233a75d8236dab",
+    "tenant-scope/fixed/documents.mjs": "c247a675b5fd96157de2c1dbb4c2d38404c28ce67896217ddb34c87ec754ca9b",
+    "tenant-scope/oracle.mjs": "b3996ee9cfd9dc851ca7f138cca6e8fb7d4bca8f8e710ef96674323f442a8e03",
+    "tenant-scope/target/README.md": "a6d01a12bda6f66aa0b314c2e2da728ff0e016c82dccf110c8233a75d8236dab",
+    "tenant-scope/target/documents.mjs": "68f0a5ffea22f1de4ebc500af9c966e75c567b83fb34ff1fcd0941816e06883b",
+    "vacuous-test/base/README.md": "2f3408cd52a9b6ace89febcb8c2c0ac03f6c445acb49189f91b5710ea8ec8f7f",
+    "vacuous-test/base/digest.mjs": "0dea1ac71521c3dea10502a2896f00f92f9b73a442382c48aeceafebe0f82dc9",
+    "vacuous-test/base/digest.test.mjs": "9668ed8da6d1d1b9ee82053dfad401f94c7a1947686782e66ab0613bb4fd8ea1",
+    "vacuous-test/fixed/README.md": "2f3408cd52a9b6ace89febcb8c2c0ac03f6c445acb49189f91b5710ea8ec8f7f",
+    "vacuous-test/fixed/digest.mjs": "5f6fc651907950199ddfd4ef0060d44a9542b14efb1e0fa2385821baf53a2fc6",
+    "vacuous-test/fixed/digest.test.mjs": "88d0e0e1b38a1d518a1c83164ac9d6d28349658a595c10ff7185b5fcdd13656b",
+    "vacuous-test/oracle.mjs": "2ce258cd124851ab99c149e92a5b1148be5e12d34d999d6c0994b8a52e2066ea",
+    "vacuous-test/target/README.md": "2f3408cd52a9b6ace89febcb8c2c0ac03f6c445acb49189f91b5710ea8ec8f7f",
+    "vacuous-test/target/digest.mjs": "5f6fc651907950199ddfd4ef0060d44a9542b14efb1e0fa2385821baf53a2fc6",
+    "vacuous-test/target/digest.test.mjs": "3a9de8e8c3969afec2ff090cb82abeed23d8388cd521158d6beb398d1e15f54f"
+  }
+}

--- a/evals/review-v1/corpus/revision-race/base/README.md
+++ b/evals/review-v1/corpus/revision-race/base/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+updateDraft applies editable fields using optimistic concurrency. Concurrent callers can submit the same expected revision; at most one may succeed. store.get returns a snapshot; put unconditionally replaces a row; compareAndSwap atomically checks revision, applies fields, increments revision, and returns a success boolean.

--- a/evals/review-v1/corpus/revision-race/base/drafts.mjs
+++ b/evals/review-v1/corpus/revision-race/base/drafts.mjs
@@ -1,0 +1,3 @@
+export async function updateDraft(store, id, expectedRevision, patch) {
+  return store.compareAndSwap(id, expectedRevision, patch);
+}

--- a/evals/review-v1/corpus/revision-race/fixed/README.md
+++ b/evals/review-v1/corpus/revision-race/fixed/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+updateDraft applies editable fields using optimistic concurrency. Concurrent callers can submit the same expected revision; at most one may succeed. store.get returns a snapshot; put unconditionally replaces a row; compareAndSwap atomically checks revision, applies fields, increments revision, and returns a success boolean.

--- a/evals/review-v1/corpus/revision-race/fixed/drafts.mjs
+++ b/evals/review-v1/corpus/revision-race/fixed/drafts.mjs
@@ -1,0 +1,4 @@
+export async function updateDraft(store, id, expectedRevision, patch) {
+  const fields = { title: patch.title };
+  return store.compareAndSwap(id, expectedRevision, fields);
+}

--- a/evals/review-v1/corpus/revision-race/oracle.mjs
+++ b/evals/review-v1/corpus/revision-race/oracle.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { updateDraft } from './drafts.mjs';
+let draft = { id: 'draft', title: 'Original', revision: 1 };
+const store = {
+  async get() { return { ...draft }; },
+  async put(id, value) { draft = { ...value }; },
+  async compareAndSwap(id, revision, patch) {
+    if (draft.revision !== revision) return false;
+    draft = { ...draft, ...patch, revision: revision + 1 };
+    return true;
+  },
+};
+const results = await Promise.all([
+  updateDraft(store, 'draft', 1, { title: 'First' }),
+  updateDraft(store, 'draft', 1, { title: 'Second' }),
+]);
+const actual = { accepted: results.filter(Boolean).length, revision: draft.revision };
+const expected = { accepted: 1, revision: 2 };
+try {
+  assert.deepEqual(actual, expected);
+  console.log(JSON.stringify({ protocol: 'cadre/oracle@1', status: 'pass' }));
+} catch (error) {
+  if (!(error instanceof assert.AssertionError)) throw error;
+  console.log(JSON.stringify({ protocol: 'cadre/oracle@1', status: 'assertion_failed' }));
+  process.exitCode = 1;
+}

--- a/evals/review-v1/corpus/revision-race/target/README.md
+++ b/evals/review-v1/corpus/revision-race/target/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+updateDraft applies editable fields using optimistic concurrency. Concurrent callers can submit the same expected revision; at most one may succeed. store.get returns a snapshot; put unconditionally replaces a row; compareAndSwap atomically checks revision, applies fields, increments revision, and returns a success boolean.

--- a/evals/review-v1/corpus/revision-race/target/drafts.mjs
+++ b/evals/review-v1/corpus/revision-race/target/drafts.mjs
@@ -1,0 +1,7 @@
+export async function updateDraft(store, id, expectedRevision, patch) {
+  const current = await store.get(id);
+  if (current.revision !== expectedRevision) return false;
+  const fields = { title: patch.title };
+  await store.put(id, { ...current, ...fields, revision: current.revision + 1 });
+  return true;
+}

--- a/evals/review-v1/corpus/tenant-scope/base/README.md
+++ b/evals/review-v1/corpus/tenant-scope/base/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+Document IDs can be supplied by authenticated callers. A caller may rename only documents belonging to their tenant. store.find matches every supplied field and returns null if absent; store.save replaces the record.

--- a/evals/review-v1/corpus/tenant-scope/base/documents.mjs
+++ b/evals/review-v1/corpus/tenant-scope/base/documents.mjs
@@ -1,0 +1,5 @@
+export async function renameDocument(store, actor, id, title) {
+  const document = await store.find({ id, tenantId: actor.tenantId });
+  if (!document) throw new Error('Document not found');
+  return store.save({ ...document, title });
+}

--- a/evals/review-v1/corpus/tenant-scope/fixed/README.md
+++ b/evals/review-v1/corpus/tenant-scope/fixed/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+Document IDs can be supplied by authenticated callers. A caller may rename only documents belonging to their tenant. store.find matches every supplied field and returns null if absent; store.save replaces the record.

--- a/evals/review-v1/corpus/tenant-scope/fixed/documents.mjs
+++ b/evals/review-v1/corpus/tenant-scope/fixed/documents.mjs
@@ -1,0 +1,10 @@
+async function loadDocument(store, actor, id) {
+  const document = await store.find({ id, tenantId: actor.tenantId });
+  if (!document) throw new Error('Document not found');
+  return document;
+}
+
+export async function renameDocument(store, actor, id, title) {
+  const document = await loadDocument(store, actor, id);
+  return store.save({ ...document, title: title.trim() });
+}

--- a/evals/review-v1/corpus/tenant-scope/oracle.mjs
+++ b/evals/review-v1/corpus/tenant-scope/oracle.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { renameDocument } from './documents.mjs';
+let document = { id: 'shared-id', tenantId: 'tenant-b', title: 'Original' };
+let saves = 0;
+const store = {
+  async find(query) {
+    return Object.entries(query).every(([key, value]) => document[key] === value) ? { ...document } : null;
+  },
+  async save(value) { saves++; document = value; return value; },
+};
+try {
+  await renameDocument(store, { tenantId: 'tenant-a' }, document.id, 'Changed');
+} catch (error) {
+  if (error.message !== 'Document not found') throw error;
+}
+const actual = { saves, title: document.title };
+const expected = { saves: 0, title: 'Original' };
+try {
+  assert.deepEqual(actual, expected);
+  console.log(JSON.stringify({ protocol: 'cadre/oracle@1', status: 'pass' }));
+} catch (error) {
+  if (!(error instanceof assert.AssertionError)) throw error;
+  console.log(JSON.stringify({ protocol: 'cadre/oracle@1', status: 'assertion_failed' }));
+  process.exitCode = 1;
+}

--- a/evals/review-v1/corpus/tenant-scope/target/README.md
+++ b/evals/review-v1/corpus/tenant-scope/target/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+Document IDs can be supplied by authenticated callers. A caller may rename only documents belonging to their tenant. store.find matches every supplied field and returns null if absent; store.save replaces the record.

--- a/evals/review-v1/corpus/tenant-scope/target/documents.mjs
+++ b/evals/review-v1/corpus/tenant-scope/target/documents.mjs
@@ -1,0 +1,10 @@
+async function loadDocument(store, id) {
+  const document = await store.find({ id });
+  if (!document) throw new Error('Document not found');
+  return document;
+}
+
+export async function renameDocument(store, actor, id, title) {
+  const document = await loadDocument(store, id);
+  return store.save({ ...document, title: title.trim() });
+}

--- a/evals/review-v1/corpus/vacuous-test/base/README.md
+++ b/evals/review-v1/corpus/vacuous-test/base/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+sendDigest delivers once to each subscribed recipient and skips unsubscribed recipients. Run the public regression test with node digest.test.mjs. The test should protect both delivery and subscription filtering when implementation changes.

--- a/evals/review-v1/corpus/vacuous-test/base/digest.mjs
+++ b/evals/review-v1/corpus/vacuous-test/base/digest.mjs
@@ -1,0 +1,3 @@
+export async function sendDigest(recipients, deliver) {
+  for (const recipient of recipients) await deliver(recipient.id);
+}

--- a/evals/review-v1/corpus/vacuous-test/base/digest.test.mjs
+++ b/evals/review-v1/corpus/vacuous-test/base/digest.test.mjs
@@ -1,0 +1,5 @@
+import assert from 'node:assert/strict';
+import { sendDigest } from './digest.mjs';
+const deliveries = [];
+await sendDigest([{ id: 'a', subscribed: true }], async id => deliveries.push(id));
+assert.deepEqual(deliveries, ['a']);

--- a/evals/review-v1/corpus/vacuous-test/fixed/README.md
+++ b/evals/review-v1/corpus/vacuous-test/fixed/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+sendDigest delivers once to each subscribed recipient and skips unsubscribed recipients. Run the public regression test with node digest.test.mjs. The test should protect both delivery and subscription filtering when implementation changes.

--- a/evals/review-v1/corpus/vacuous-test/fixed/digest.mjs
+++ b/evals/review-v1/corpus/vacuous-test/fixed/digest.mjs
@@ -1,0 +1,5 @@
+export async function sendDigest(recipients, deliver) {
+  for (const recipient of recipients) {
+    if (recipient.subscribed) await deliver(recipient.id);
+  }
+}

--- a/evals/review-v1/corpus/vacuous-test/fixed/digest.test.mjs
+++ b/evals/review-v1/corpus/vacuous-test/fixed/digest.test.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict';
+import { sendDigest } from './digest.mjs';
+const recipients = [{ id: 'a', subscribed: true }, { id: 'b', subscribed: false }];
+const deliveries = [];
+await sendDigest(recipients, async id => deliveries.push(id));
+assert.deepEqual(deliveries, ['a']);

--- a/evals/review-v1/corpus/vacuous-test/oracle.mjs
+++ b/evals/review-v1/corpus/vacuous-test/oracle.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+const original = spawnSync(process.execPath, ['digest.test.mjs'], { encoding: 'utf8', timeout: 1000 });
+if (original.error || original.status !== 0) throw new Error('Original public test did not pass');
+await writeFileSync('digest.mjs', 'export async function sendDigest(recipients, deliver) {}\n');
+const mutant = spawnSync(process.execPath, ['digest.test.mjs'], { encoding: 'utf8', timeout: 1000 });
+if (mutant.error || mutant.signal) throw new Error('Mutation probe did not complete');
+if (mutant.status !== 0 && !mutant.stderr.includes('ERR_ASSERTION')) throw new Error('Mutation probe crashed');
+const actual = { rejectsNoOpMutant: mutant.status !== 0 };
+const expected = { rejectsNoOpMutant: true };
+try {
+  assert.deepEqual(actual, expected);
+  console.log(JSON.stringify({ protocol: 'cadre/oracle@1', status: 'pass' }));
+} catch (error) {
+  if (!(error instanceof assert.AssertionError)) throw error;
+  console.log(JSON.stringify({ protocol: 'cadre/oracle@1', status: 'assertion_failed' }));
+  process.exitCode = 1;
+}

--- a/evals/review-v1/corpus/vacuous-test/target/README.md
+++ b/evals/review-v1/corpus/vacuous-test/target/README.md
@@ -1,0 +1,3 @@
+# Review exercise
+
+sendDigest delivers once to each subscribed recipient and skips unsubscribed recipients. Run the public regression test with node digest.test.mjs. The test should protect both delivery and subscription filtering when implementation changes.

--- a/evals/review-v1/corpus/vacuous-test/target/digest.mjs
+++ b/evals/review-v1/corpus/vacuous-test/target/digest.mjs
@@ -1,0 +1,5 @@
+export async function sendDigest(recipients, deliver) {
+  for (const recipient of recipients) {
+    if (recipient.subscribed) await deliver(recipient.id);
+  }
+}

--- a/evals/review-v1/corpus/vacuous-test/target/digest.test.mjs
+++ b/evals/review-v1/corpus/vacuous-test/target/digest.test.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict';
+import { sendDigest } from './digest.mjs';
+const recipients = [{ id: 'a', subscribed: false }, { id: 'b', subscribed: false }];
+const deliveries = [];
+await sendDigest(recipients, async id => deliveries.push(id));
+assert.ok(deliveries.every(id => recipients.find(recipient => recipient.id === id).subscribed));

--- a/evals/review-v1/prompt.md
+++ b/evals/review-v1/prompt.md
@@ -1,0 +1,16 @@
+Review the change between BASE and HEAD in this checkout. Inspect the diff and
+the surrounding code. Report concrete defects introduced by the change, with
+the input or ordering that triggers each defect and its consequence.
+
+You may run targeted checks. Do not fix the implementation. A passing test is
+evidence only for the behavior it actually exercises. Check whether an apparent
+defect is prevented by a caller or represents documented intended behavior.
+
+Rate data loss, authorization bypass, and silently wrong user output blocking;
+bounded correctness failures should-fix; style preferences nit. Do not pad the
+review with nits. For each finding give file and line, trigger, consequence,
+and evidence. State whether you executed a check or reasoned by inspection.
+
+State each finding under a bold severity label on its own line: **blocking**,
+**should-fix**, or **nit**. End with `Verdict: blocking`, `Verdict: should-fix`,
+or `Verdict: no defects found`. A clean review must be an explicit conclusion.

--- a/evals/review-v1/verify-corpus.mjs
+++ b/evals/review-v1/verify-corpus.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { cpSync, lstatSync, mkdtempSync, readFileSync, readdirSync, rmSync, copyFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, sep } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_CORPUS_DIR = fileURLToPath(new URL('./corpus/', import.meta.url));
+
+function inventory(root, prefix = '') {
+  return readdirSync(join(root, prefix)).sort().flatMap(name => {
+    const relative = prefix ? `${prefix}/${name}` : name;
+    const stat = lstatSync(join(root, relative));
+    if (stat.isSymbolicLink()) throw new Error(`Corpus symlink is forbidden: ${relative}`);
+    if (stat.isDirectory()) return inventory(root, relative);
+    if (!stat.isFile()) throw new Error(`Unsupported corpus entry: ${relative}`);
+    return [relative];
+  });
+}
+
+function localPath(root, relative) {
+  if (typeof relative !== 'string' || !/^[a-zA-Z0-9_./-]+$/.test(relative)) {
+    throw new Error(`Invalid corpus path: ${relative}`);
+  }
+  const full = resolve(root, relative);
+  if (!full.startsWith(`${root}${sep}`)) throw new Error(`Corpus path escapes root: ${relative}`);
+  return full;
+}
+
+export function verifyCorpus(corpusDir = DEFAULT_CORPUS_DIR) {
+  const root = resolve(corpusDir);
+  const files = inventory(root).filter(name => name !== 'manifest.json');
+  const manifest = JSON.parse(readFileSync(join(root, 'manifest.json'), 'utf8'));
+  if (manifest.schema !== 'cadre/review-corpus@1' || !Array.isArray(manifest.cases) || !manifest.cases.length) {
+    throw new Error('Invalid review corpus manifest');
+  }
+  if (!manifest.hashes || JSON.stringify(Object.keys(manifest.hashes).sort()) !== JSON.stringify(files.sort())) {
+    throw new Error('Corpus hash inventory mismatch');
+  }
+  for (const file of files) {
+    const hash = createHash('sha256').update(readFileSync(join(root, file))).digest('hex');
+    if (hash !== manifest.hashes[file]) throw new Error(`Corpus hash mismatch: ${file}`);
+  }
+  const ids = new Set();
+  const pairs = new Map();
+  for (const entry of manifest.cases) {
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(entry.id) || ids.has(entry.id)) throw new Error('Invalid or duplicate case id');
+    ids.add(entry.id);
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(entry.scenario) || !['buggy', 'fixed'].includes(entry.variant) ||
+        !['development', 'holdout'].includes(entry.split)) throw new Error(`Invalid case: ${entry.id}`);
+    for (const field of ['base', 'target', 'oracle']) localPath(root, entry[field]);
+    if (entry.base !== `${entry.scenario}/base` ||
+        entry.target !== `${entry.scenario}/${entry.variant === 'buggy' ? 'target' : 'fixed'}` ||
+        entry.oracle !== `${entry.scenario}/oracle.mjs`) throw new Error(`Invalid case layout: ${entry.id}`);
+    if (!lstatSync(localPath(root, entry.base)).isDirectory() || !lstatSync(localPath(root, entry.target)).isDirectory()) {
+      throw new Error(`Missing case tree: ${entry.id}`);
+    }
+    if (entry.variant === 'fixed' ? entry.key !== null : !entry.key || !entry.key.id || !entry.key.claim ||
+        !entry.key.trigger || !entry.key.consequence || !['blocking', 'should-fix', 'nit'].includes(entry.key.severity) ||
+        !Number.isInteger(entry.key.line) || entry.key.line < 1) throw new Error(`Invalid provisional key: ${entry.id}`);
+    if (entry.key) {
+      const target = localPath(root, entry.target);
+      const source = readFileSync(localPath(target, entry.key.path), 'utf8');
+      if (entry.key.line > source.split('\n').length) throw new Error(`Key line outside file: ${entry.id}`);
+    }
+    const pair = pairs.get(entry.scenario) || [];
+    pair.push(entry);
+    pairs.set(entry.scenario, pair);
+  }
+  for (const [scenario, pair] of pairs) {
+    if (pair.length !== 2 || new Set(pair.map(entry => entry.variant)).size !== 2 ||
+        pair[0].oracle !== pair[1].oracle || pair[0].split !== pair[1].split) {
+      throw new Error(`Missing consistent buggy/fixed pair: ${scenario}`);
+    }
+  }
+  return manifest.cases.map(entry => {
+    const temporary = mkdtempSync(join(tmpdir(), 'cadre-corpus-'));
+    try {
+      cpSync(localPath(root, entry.target), temporary, { recursive: true });
+      copyFileSync(localPath(root, entry.oracle), join(temporary, '__verify.mjs'));
+      const child = spawnSync(process.execPath, ['__verify.mjs'], {
+        cwd: temporary, encoding: 'utf8', timeout: 5000, maxBuffer: 1024 * 1024,
+      });
+      if (child.error || child.signal) throw new Error(`Oracle did not complete for ${entry.id}: ${child.error?.code || child.signal}`);
+      let report;
+      try { report = JSON.parse(child.stdout.trim()); }
+      catch { throw new Error(`Oracle crashed or produced invalid output for ${entry.id}: ${child.stderr.trim()}`); }
+      if (report.protocol !== 'cadre/oracle@1' || !['pass', 'assertion_failed'].includes(report.status) ||
+          child.status !== (report.status === 'pass' ? 0 : 1) || child.stderr.trim()) {
+        throw new Error(`Oracle protocol/runtime failure for ${entry.id}`);
+      }
+      const expected = entry.variant === 'buggy' ? 'assertion_failed' : 'pass';
+      if (report.status !== expected) throw new Error(`Oracle behavior mismatch for ${entry.id}: expected ${expected}, got ${report.status}`);
+      return { id: entry.id, variant: entry.variant, expected, actual: report.status, ok: true };
+    } finally {
+      rmSync(temporary, { recursive: true, force: true });
+    }
+  });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const results = verifyCorpus(process.argv[2]);
+    console.log(JSON.stringify({ schema: 'cadre/corpus-verification@1', ok: true, results }, null, 2));
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/integrations/pi-review/cli.mjs
+++ b/integrations/pi-review/cli.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { runReview, renderReview } from './review.mjs';
+
+const controller = new AbortController();
+process.on('SIGTERM', () => controller.abort('SIGTERM'));
+process.on('SIGINT', () => controller.abort('SIGINT'));
+
+try {
+  const { values } = parseArgs({ options: {
+    cwd: { type: 'string' }, model: { type: 'string' }, out: { type: 'string' },
+    thinking: { type: 'string', default: 'off' }, timeout: { type: 'string', default: '900' },
+  }, allowPositionals: false, strict: true });
+  if (!values.cwd || !values.model || !values.out) throw new Error('Required: --cwd DIR --model provider/model --out NEW_DIRECTORY');
+  const result = await runReview({
+    cwd: resolve(values.cwd), out: resolve(values.out), model: values.model,
+    thinking: values.thinking, timeout: Number(values.timeout), prompt: readFileSync(0, 'utf8'), signal: controller.signal,
+  });
+  process.stdout.write(renderReview(result));
+  process.exit(result.status === 'ok' ? 0 : 1);
+} catch (error) {
+  // CLI validation/file errors only. runReview deliberately does not expose SDK auth errors.
+  process.stderr.write(`pi-review: ${error.message}\n`);
+  process.exit(1);
+}

--- a/integrations/pi-review/package-lock.json
+++ b/integrations/pi-review/package-lock.json
@@ -1,0 +1,1777 @@
+{
+  "name": "@cadre/pi-review",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cadre/pi-review",
+      "version": "0.1.0",
+      "dependencies": {
+        "@earendil-works/pi-coding-agent": "0.84.4"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.4.tgz",
+      "integrity": "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-client": "^0.84.4",
+        "@earendil-works/pi-protocol": "^0.84.4",
+        "@earendil-works/pi-tui": "^0.84.4",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "grok-mermaid": "0.2.2",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/bundle/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.4.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-telemetry": "^0.84.4",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.4",
+        "@google/genai": "1.52.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.4.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.4"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.4.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.4.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/integrations/pi-review/package.json
+++ b/integrations/pi-review/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@cadre/pi-review",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22.19.0" },
+  "scripts": { "test": "node --test review.test.mjs" },
+  "dependencies": { "@earendil-works/pi-coding-agent": "0.84.4" }
+}

--- a/integrations/pi-review/review.mjs
+++ b/integrations/pi-review/review.mjs
@@ -1,0 +1,313 @@
+import { appendFileSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+
+export const SDK_VERSION = '0.84.4';
+export const SETTINGS = { compaction: { enabled: false }, retry: { enabled: false } };
+export const REVIEW_CONTRACT = `Review only; do not repair implementation files. Investigate the supplied review task using the available tools. Before reporting each finding, inspect the strongest evidence that could invalidate it. Submit the complete review exactly once with submit_review. Ordinary prose is not a submission. Cite a repository-relative existing file and line, the concrete trigger, consequence, and evidence. Use execution="by-inspection" unless you actually executed a relevant command; execution="executed" must cite bash tool call IDs that completed with an exit outcome, including nonzero exits for failing reproductions. Before submitting executed findings, call execution_receipts and copy the exact returned id values into tool_call_ids; never guess IDs. Explain the observed outcome in evidence. An executed command alone does not prove a test passed or that your finding is correct. Submit an empty findings array and verdict="no defects found" only when the review completed and found no defects. Do not invent findings to satisfy the schema.`;
+
+const string = { type: 'string', minLength: 1 };
+export const REVIEW_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['findings', 'verdict'],
+  properties: {
+    findings: { type: 'array', items: {
+      type: 'object', additionalProperties: false,
+      required: ['severity', 'title', 'path', 'line', 'trigger', 'consequence', 'evidence', 'execution', 'tool_call_ids'],
+      properties: {
+        severity: { type: 'string', enum: ['blocking', 'should-fix', 'nit'] },
+        title: string, path: string, line: { type: 'integer', minimum: 1 },
+        trigger: string, consequence: string, evidence: string,
+        execution: { type: 'string', enum: ['by-inspection', 'executed'] },
+        tool_call_ids: { type: 'array', items: string, uniqueItems: true },
+      },
+    } },
+    verdict: { type: 'string', enum: ['blocking', 'should-fix', 'no defects found'] },
+  },
+};
+
+export function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function exactKeys(object, keys) {
+  return object && typeof object === 'object' && !Array.isArray(object)
+    && Object.keys(object).length === keys.length && keys.every(key => Object.hasOwn(object, key));
+}
+
+// Structural and provenance checks, not an automated correctness judge.
+export function validateReview(review, cwd, completed = new Map()) {
+  if (!exactKeys(review, ['findings', 'verdict']) || !Array.isArray(review.findings)) {
+    throw new Error('Review must contain findings and verdict only');
+  }
+  const root = realpathSync(cwd);
+  const fields = Object.keys(REVIEW_SCHEMA.properties.findings.items.properties);
+  for (const finding of review.findings) {
+    if (!exactKeys(finding, fields)) throw new Error('Finding fields do not match the schema');
+    for (const field of ['title', 'path', 'trigger', 'consequence', 'evidence']) {
+      if (typeof finding[field] !== 'string' || !finding[field].trim()) throw new Error(`Empty or invalid ${field}`);
+    }
+    if (!['blocking', 'should-fix', 'nit'].includes(finding.severity)) throw new Error('Invalid severity');
+    if (!['by-inspection', 'executed'].includes(finding.execution)) throw new Error('Invalid execution');
+    if (!Number.isInteger(finding.line) || finding.line < 1) throw new Error('Invalid line');
+    if (isAbsolute(finding.path) || finding.path.includes('\\') || finding.path.split('/').some(p => p === '..' || p === '' || p === '.')) {
+      throw new Error('Path must be repository-relative without traversal');
+    }
+    let file;
+    try { file = realpathSync(resolve(root, finding.path)); } catch { throw new Error('Finding file does not exist'); }
+    const rel = relative(root, file);
+    if (!rel || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel) || !statSync(file).isFile()) {
+      throw new Error('Finding path must stay inside the checkout');
+    }
+    const source = readFileSync(file, 'utf8');
+    const lines = source ? source.replace(/\n$/, '').split('\n').length : 0;
+    if (finding.line > lines) throw new Error('Finding line does not exist');
+    if (!Array.isArray(finding.tool_call_ids) || finding.tool_call_ids.some(id => typeof id !== 'string' || !id.trim())
+      || new Set(finding.tool_call_ids).size !== finding.tool_call_ids.length) throw new Error('Invalid tool_call_ids');
+    for (const id of finding.tool_call_ids) {
+      if (!completed.has(id)) throw new Error('Unknown or incomplete tool call ID');
+    }
+    if (finding.execution === 'executed' && (!finding.tool_call_ids.length || finding.tool_call_ids.some(id => {
+      const call = completed.get(id);
+      return call.toolName !== 'bash' || !Number.isInteger(call.exit_code);
+    }))) throw new Error('Executed findings require completed bash calls with an exit outcome');
+  }
+  const expected = review.findings.some(f => f.severity === 'blocking') ? 'blocking'
+    : review.findings.some(f => f.severity === 'should-fix') ? 'should-fix' : 'no defects found';
+  if (review.verdict !== expected) throw new Error('Verdict does not match finding severities');
+  return structuredClone(review);
+}
+
+export function renderReview(result) {
+  const findings = result.findings ?? [];
+  const sections = findings.map(f => `**${f.severity}**\n${f.title}\n\n${f.path}:${f.line}\n\nTrigger: ${f.trigger}\n\nConsequence: ${f.consequence}\n\nEvidence: ${f.evidence}\n\nExecution: ${f.execution}${f.tool_call_ids.length ? ` (${f.tool_call_ids.join(', ')})` : ''}`);
+  if (result.status === 'ok') {
+    if (!findings.length) sections.push('No defects found.');
+    sections.push(`Verdict: ${result.verdict}`);
+  } else {
+    if (!findings.length) sections.push(`DID NOT COMPLETE: ${result.reason}`);
+    sections.push(`_TRUNCATED: ${result.reason}; review did not complete${findings.length ? '; findings above are partial' : ''}.`);
+  }
+  return sections.join('\n\n') + '\n';
+}
+
+function usageOnly(usage = {}) {
+  const output = {};
+  for (const field of ['input', 'output', 'cacheRead', 'cacheWrite', 'totalTokens']) {
+    if (typeof usage[field] === 'number' && Number.isFinite(usage[field])) output[field] = usage[field];
+  }
+  if (usage.cost) output.cost = Object.fromEntries(Object.entries(usage.cost).filter(([key, value]) =>
+    ['input', 'output', 'cacheRead', 'cacheWrite', 'total'].includes(key) && typeof value === 'number' && Number.isFinite(value)));
+  return output;
+}
+
+// Never serialize a runtime, model, credentials, transport headers, or raw SDK error.
+// Tool and assistant content remain review evidence and can contain source code.
+function eventRecord(event) {
+  const base = { type: event.type };
+  if (event.type.startsWith('tool_execution_')) {
+    Object.assign(base, { toolCallId: event.toolCallId, toolName: event.toolName });
+    if (event.type === 'tool_execution_start') base.args = event.args;
+    if (event.type === 'tool_execution_end') {
+      base.isError = event.isError;
+      base.content = (event.result?.content ?? []).filter(part => part.type === 'text').map(part => ({ type: 'text', text: part.text }));
+    }
+  } else if (event.type === 'message_end' && event.message?.role === 'assistant') {
+    base.role = 'assistant';
+    base.stopReason = event.message.stopReason;
+    base.usage = usageOnly(event.message.usage);
+    base.content = (event.message.content ?? []).filter(part => part.type === 'text').map(part => ({ type: 'text', text: part.text }));
+    base.hasError = Boolean(event.message.errorMessage);
+  } else if (event.type === 'message_update') {
+    base.updateType = event.assistantMessageEvent?.type;
+  } else if (event.type === 'agent_end') {
+    base.willRetry = Boolean(event.willRetry);
+  }
+  return base;
+}
+
+export async function runReview(options, deps = {}) {
+  const { cwd, out, prompt, model: requestedModel, thinking = 'off', timeout = 900, signal } = options;
+  if (typeof prompt !== 'string' || !prompt.trim()) throw new Error('A nonempty stdin prompt is required');
+  if (typeof requestedModel !== 'string' || !/^[^/\s]+\/\S+$/.test(requestedModel)) throw new Error('Explicit provider/model is required');
+  if (!['off', 'minimal', 'low', 'medium', 'high', 'xhigh'].includes(thinking)) throw new Error('Invalid thinking level');
+  if (!Number.isFinite(timeout) || timeout <= 0 || timeout > 86400) throw new Error('Timeout must be in (0, 86400] seconds');
+  if (!cwd || !out || !statSync(cwd).isDirectory()) throw new Error('cwd directory and new out directory are required');
+  mkdirSync(out, { mode: 0o700 }); // EEXIST is deliberate: never overwrite a previous run.
+  const started = new Date().toISOString();
+  const provider = requestedModel.slice(0, requestedModel.indexOf('/'));
+  const id = requestedModel.slice(requestedModel.indexOf('/') + 1);
+  const result = {
+    schema: 'cadre/pi-review@1', status: 'failed', provider, model: id,
+    requested_model: requestedModel, thinking, sdk_version: null, expected_sdk_version: SDK_VERSION,
+    prompt_sha256: sha256(prompt), contract_sha256: sha256(REVIEW_CONTRACT),
+    settings_sha256: sha256(JSON.stringify(SETTINGS)), started_at: started,
+    findings: [], verdict: null, reason: 'missing_submission', usage: [], tool_calls: [], finish_reasons: [],
+  };
+  result.source_sha256 = sha256(readFileSync(new URL('./review.mjs', import.meta.url)));
+  try { result.lock_sha256 = sha256(readFileSync(new URL('./package-lock.json', import.meta.url))); }
+  catch { result.lock_sha256 = null; }
+  let session, unsubscribe, submission, terminalReason, settled = false, timer, externalAbort;
+  let sequence = 0;
+  const completed = new Map();
+  const calls = new Map();
+  const controller = new AbortController();
+  const log = event => {
+    if (!settled) appendFileSync(resolve(out, 'events.jsonl'), JSON.stringify({ seq: ++sequence, at: new Date().toISOString(), ...event }) + '\n', { mode: 0o600 });
+  };
+  log({ type: 'run_start', model: requestedModel, thinking });
+  const stopIfTimedOut = () => { if (controller.signal.aborted) throw new Error('timeout'); };
+  try {
+    const timeoutPromise = new Promise((_, reject) => {
+      const cancel = reason => {
+        terminalReason ??= reason;
+        controller.abort();
+        session?.abort().catch(() => {});
+        reject(new Error(reason));
+      };
+      timer = setTimeout(() => cancel('timeout'), timeout * 1000);
+      externalAbort = () => {
+        if (signal.reason === 'SIGINT' || signal.reason === 'SIGTERM') result.interrupted_by = signal.reason;
+        cancel('external_abort');
+      };
+      signal?.addEventListener('abort', externalAbort, { once: true });
+      if (signal?.aborted) externalAbort();
+    });
+    const work = async () => {
+      const sdk = deps.sdk ?? await import('@earendil-works/pi-coding-agent');
+      stopIfTimedOut();
+      if (typeof sdk.getPackageDir === 'function') {
+        let metadata;
+        try { metadata = JSON.parse(readFileSync(resolve(sdk.getPackageDir(), 'package.json'), 'utf8')); }
+        catch { terminalReason = 'sdk_package_unverified'; throw new Error('sdk_package_unverified'); }
+        if (metadata.name !== '@earendil-works/pi-coding-agent' || typeof metadata.version !== 'string') {
+          terminalReason = 'sdk_package_unverified'; throw new Error('sdk_package_unverified');
+        }
+        result.sdk_version = metadata.version;
+        if (result.sdk_version !== SDK_VERSION) { terminalReason = 'sdk_version_mismatch'; throw new Error('sdk_version_mismatch'); }
+      } else if (!deps.sdk) {
+        terminalReason = 'sdk_package_unverified'; throw new Error('sdk_package_unverified');
+      } // Injected unit-test doubles have no installed package and retain sdk_version:null.
+      const runtime = await sdk.ModelRuntime.create({ signal: controller.signal, allowModelNetwork: false });
+      stopIfTimedOut();
+      const model = runtime.getModel(provider, id);
+      if (!model || model.provider !== provider || model.id !== id) { terminalReason = 'model_not_found'; throw new Error('model_not_found'); }
+      result.model_config_sha256 = sha256(JSON.stringify({
+        provider: model.provider, id: model.id, api: model.api,
+        baseUrl: model.baseUrl, reasoning: model.reasoning, input: model.input,
+        contextWindow: model.contextWindow, maxTokens: model.maxTokens,
+        samplingParams: model.samplingParams, compat: model.compat, thinkingLevelMap: model.thinkingLevelMap,
+      }));
+      const settingsManager = sdk.SettingsManager.inMemory(structuredClone(SETTINGS));
+      const loader = new sdk.DefaultResourceLoader({
+        cwd, agentDir: sdk.getAgentDir(), settingsManager,
+        noExtensions: true, noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true,
+        extensionsOverride: base => ({ ...base, extensions: [], errors: [] }),
+        skillsOverride: () => ({ skills: [], diagnostics: [] }),
+        promptsOverride: () => ({ prompts: [], diagnostics: [] }),
+        themesOverride: () => ({ themes: [], diagnostics: [] }),
+        agentsFilesOverride: () => ({ agentsFiles: [] }),
+        systemPromptOverride: () => undefined, appendSystemPromptOverride: () => [],
+      });
+      await loader.reload();
+      stopIfTimedOut();
+      const tool = sdk.defineTool({
+        name: 'submit_review', label: 'Submit review',
+        description: 'Submit the complete review after checking findings against surrounding code. Exactly one successful submission is accepted. Executed means a relevant bash call actually exited (including nonzero failure reproductions), not an automated correctness or test-pass guarantee.',
+        parameters: REVIEW_SCHEMA,
+        execute: async (toolCallId, params) => {
+          stopIfTimedOut();
+          if (submission) {
+            terminalReason ??= 'duplicate_submission';
+            throw new Error('Review already submitted');
+          }
+          submission = validateReview(params, cwd, completed);
+          result.submission_tool_call_id = toolCallId;
+          log({ type: 'review_submitted', toolCallId, review: submission });
+          return { content: [{ type: 'text', text: 'Review accepted. End this review now.' }], details: {} };
+        },
+      });
+      const receiptsTool = sdk.defineTool({
+        name: 'execution_receipts', label: 'Execution receipts',
+        description: 'List exact tool call IDs, commands, and exit codes for completed bash executions. Before submitting executed findings, copy the relevant returned id into tool_call_ids. Nonzero exit codes can be valid failing reproductions; receipts do not establish finding correctness.',
+        parameters: { type: 'object', additionalProperties: false, properties: {} },
+        execute: async () => {
+          stopIfTimedOut();
+          const receipts = [...completed.values()].filter(call => call.toolName === 'bash' && Number.isInteger(call.exit_code))
+            .map(call => ({ id: call.id, command: call.command, exit_code: call.exit_code }));
+          return { content: [{ type: 'text', text: JSON.stringify({ receipts }) }], details: {} };
+        },
+      });
+      const created = await sdk.createAgentSession({
+        cwd, agentDir: sdk.getAgentDir(), model, thinkingLevel: thinking, modelRuntime: runtime,
+        tools: ['read', 'bash', 'edit', 'write', 'submit_review', 'execution_receipts'], customTools: [tool, receiptsTool],
+        resourceLoader: loader, settingsManager, sessionManager: sdk.SessionManager.inMemory(cwd),
+      });
+      session = created.session;
+      if (controller.signal.aborted) session.dispose();
+      stopIfTimedOut();
+      if (created.modelFallbackMessage || session.model?.id !== id || session.model?.provider !== provider) {
+        terminalReason = 'model_fallback'; throw new Error('model_fallback');
+      }
+      result.model = session.model.id;
+      result.provider = session.model.provider;
+      result.effective_thinking = session.thinkingLevel;
+      if (session.thinkingLevel !== thinking) { terminalReason = 'thinking_level_changed'; throw new Error('thinking_level_changed'); }
+      unsubscribe = session.subscribe(event => {
+        if (settled) return;
+        log(eventRecord(event));
+        if (event.type === 'tool_execution_start') {
+          if (submission && event.toolName === 'submit_review') terminalReason ??= 'duplicate_submission';
+          calls.set(event.toolCallId, { id: event.toolCallId, toolName: event.toolName, completed: false,
+            ...(event.toolName === 'bash' && typeof event.args?.command === 'string' ? { command: event.args.command } : {}) });
+        }
+        if (event.type === 'tool_execution_end' && calls.has(event.toolCallId)) {
+          const call = { ...calls.get(event.toolCallId), completed: true, isError: event.isError };
+          if (call.toolName === 'bash') {
+            // In pinned Pi 0.84.4 a nonzero bash exit throws this footer; spawn,
+            // timeout and abort failures do not establish a completed command.
+            const output = (event.result?.content ?? []).filter(p => p.type === 'text').map(p => p.text).join('\n');
+            const nonzero = /Command exited with code (\d+)\s*$/.exec(output);
+            if (event.isError === false) call.exit_code = 0;
+            else if (nonzero) call.exit_code = Number(nonzero[1]);
+          }
+          calls.set(event.toolCallId, call);
+          completed.set(event.toolCallId, call);
+        }
+        if (event.type === 'message_end' && event.message?.role === 'assistant') {
+          const message = event.message;
+          if ((message.model && message.model !== id) || (message.provider && message.provider !== provider)) terminalReason = 'assistant_model_mismatch';
+          result.finish_reasons.push(message.stopReason);
+          result.usage.push(usageOnly(message.usage));
+          if (['error', 'aborted', 'length'].includes(message.stopReason) || message.errorMessage) {
+            terminalReason = `assistant_${['error', 'aborted', 'length'].includes(message.stopReason) ? message.stopReason : 'error'}`;
+          }
+        }
+      });
+      await session.prompt(`${prompt}\n\n${REVIEW_CONTRACT}`, { expandPromptTemplates: false });
+      if (session.agent?.state?.errorMessage) terminalReason ??= 'assistant_error';
+      if (submission && completed.get(result.submission_tool_call_id)?.isError !== false) terminalReason ??= 'submission_not_completed';
+      if (submission && result.finish_reasons.at(-1) !== 'stop') terminalReason ??= 'missing_terminal_stop';
+    };
+    await Promise.race([work(), timeoutPromise]);
+  } catch {
+    terminalReason ??= 'sdk_failure';
+  } finally {
+    clearTimeout(timer);
+    if (externalAbort) signal?.removeEventListener('abort', externalAbort);
+    unsubscribe?.();
+    session?.dispose();
+    if (submission) {
+      result.findings = submission.findings;
+      result.verdict = submission.verdict;
+      result.status = terminalReason ? 'degraded' : 'ok';
+      result.reason = terminalReason ?? null;
+    } else result.reason = terminalReason ?? 'missing_submission';
+    result.tool_calls = [...calls.values()];
+    result.finished_at = new Date().toISOString();
+    log({ type: 'run_end', status: result.status, reason: result.reason });
+    settled = true;
+    writeFileSync(resolve(out, 'result.json'), JSON.stringify(result, null, 2) + '\n', { mode: 0o600 });
+    writeFileSync(resolve(out, 'review.md'), renderReview(result), { mode: 0o600 });
+  }
+  return result;
+}

--- a/integrations/pi-review/review.test.mjs
+++ b/integrations/pi-review/review.test.mjs
@@ -1,0 +1,329 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runReview, validateReview, renderReview, SETTINGS } from './review.mjs';
+
+function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), 'pi-review-test-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const cwd = join(root, 'repo');
+  mkdirSync(cwd);
+  writeFileSync(join(cwd, 'file.js'), 'first\nsecond\n');
+  return { root, cwd, out: join(root, 'artifacts'), prompt: 'Review this change.', model: 'test/model', timeout: 1 };
+}
+
+const finding = () => ({ severity: 'blocking', title: 'Original title', path: 'file.js', line: 2,
+  trigger: 'When request A finishes after request B', consequence: 'A replaces the newer value',
+  evidence: 'The assignment is unconditional.', execution: 'by-inspection', tool_call_ids: [] });
+const review = () => ({ findings: [finding()], verdict: 'blocking' });
+const clean = () => ({ findings: [], verdict: 'no defects found' });
+
+function fakeSdk(program, hooks = {}) {
+  const model = { provider: 'test', id: 'model', samplingParams: { temperature: 0.2 }, headers: { Authorization: 'SECRET' } };
+  return {
+    getAgentDir: () => '/fake-agent',
+    ...(hooks.packageDir ? { getPackageDir: () => hooks.packageDir } : {}),
+    ModelRuntime: { create: async options => {
+      assert.equal(options.allowModelNetwork, false);
+      assert.ok(options.signal);
+      if (hooks.runtime) return hooks.runtime();
+      return { getModel: (provider, id) => provider === 'test' && id === 'model' ? model : undefined };
+    } },
+    SettingsManager: { inMemory: settings => { assert.deepEqual(settings, SETTINGS); return settings; } },
+    SessionManager: { inMemory: cwd => ({ cwd }) },
+    DefaultResourceLoader: class {
+      constructor(options) {
+        for (const flag of ['noExtensions', 'noSkills', 'noPromptTemplates', 'noThemes', 'noContextFiles']) assert.equal(options[flag], true);
+        assert.deepEqual(options.agentsFilesOverride({ agentsFiles: ['secret'] }), { agentsFiles: [] });
+        assert.equal(options.systemPromptOverride('secret'), undefined);
+        assert.deepEqual(options.appendSystemPromptOverride(['secret']), []);
+      }
+      async reload() {}
+    },
+    defineTool: tool => tool,
+    createAgentSession: async options => {
+      assert.equal(options.model, model); // Configured model object must survive intact.
+      assert.deepEqual(options.tools, ['read', 'bash', 'edit', 'write', 'submit_review', 'execution_receipts']);
+      let listener;
+      const emit = event => listener?.(event);
+      const end = (stopReason = 'stop', extra = {}) => emit({ type: 'message_end', message: {
+        role: 'assistant', stopReason, content: [{ type: 'text', text: 'Done.' }],
+        usage: { input: 5, output: 2, totalTokens: 7, cost: { total: 0.01 }, apiKey: 'SECRET' }, ...extra,
+      } });
+      const submit = async value => {
+        emit({ type: 'tool_execution_start', toolName: 'submit_review', toolCallId: 'submission', args: value });
+        const result = await options.customTools[0].execute('submission', value);
+        emit({ type: 'tool_execution_end', toolName: 'submit_review', toolCallId: 'submission', isError: false, result });
+      };
+      const session = {
+        model, thinkingLevel: hooks.thinking ?? options.thinkingLevel, agent: { state: {} },
+        subscribe: fn => { listener = fn; return () => { listener = undefined; }; },
+        abort: async () => {}, dispose: () => {},
+        prompt: async (prompt, promptOptions) => {
+          assert.match(prompt, /submit_review/);
+          assert.equal(promptOptions.expandPromptTemplates, false);
+          await program({ emit, end, submit, session });
+        },
+      };
+      return { session };
+    },
+  };
+}
+
+test('valid submission preserves strings and records tool events, usage and hashes', async t => {
+  const options = fixture(t);
+  const result = await runReview(options, { sdk: fakeSdk(async ({ emit, submit, end }) => {
+    emit({ type: 'agent_start' });
+    await submit(review());
+    end();
+    emit({ type: 'agent_end', willRetry: false });
+  }) });
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.findings, review().findings);
+  assert.deepEqual(result.usage, [{ input: 5, output: 2, totalTokens: 7, cost: { total: 0.01 } }]);
+  assert.match(result.model_config_sha256, /^[a-f0-9]{64}$/);
+  const events = readFileSync(join(options.out, 'events.jsonl'), 'utf8');
+  assert.match(events, /tool_execution_end/);
+  assert.match(events, /review_submitted/);
+  assert.doesNotMatch(events + JSON.stringify(result), /SECRET|Authorization|apiKey/);
+  assert.equal(readFileSync(join(options.out, 'review.md'), 'utf8'), renderReview(result));
+  assert.equal(JSON.parse(readFileSync(join(options.out, 'result.json'))).status, 'ok');
+  assert.equal(statSync(options.out).mode & 0o777, 0o700);
+  assert.equal(statSync(join(options.out, 'events.jsonl')).mode & 0o777, 0o600);
+  assert.equal(statSync(join(options.out, 'result.json')).mode & 0o777, 0o600);
+  assert.equal(statSync(join(options.out, 'review.md')).mode & 0o777, 0o600);
+});
+
+test('an explicit clean submission succeeds; clean-looking prose does not', async t => {
+  const options = fixture(t);
+  const result = await runReview(options, { sdk: fakeSdk(async ({ submit, end }) => { await submit(clean()); end(); }) });
+  assert.equal(result.status, 'ok');
+  assert.match(renderReview(result), /Verdict: no defects found/);
+  const missing = await runReview({ ...options, out: join(options.root, 'missing') }, { sdk: fakeSdk(async ({ end }) => {
+    end('stop', { content: [{ type: 'text', text: 'No defects found. Verdict: no defects found' }] });
+  }) });
+  assert.equal(missing.status, 'failed');
+  assert.equal(missing.reason, 'missing_submission');
+  assert.doesNotMatch(renderReview(missing), /Verdict: no defects found/);
+});
+
+for (const reason of ['error', 'aborted', 'length']) {
+  test(`${reason} after a valid submission retains findings as degraded`, async t => {
+    const options = fixture(t);
+    const result = await runReview(options, { sdk: fakeSdk(async ({ submit, end }) => {
+      await submit(review());
+      end(reason, { errorMessage: 'Authorization Bearer SECRET' });
+    }) });
+    assert.equal(result.status, 'degraded');
+    assert.equal(result.reason, `assistant_${reason}`);
+    assert.deepEqual(result.findings, review().findings);
+    assert.match(renderReview(result), /_TRUNCATED/);
+    assert.doesNotMatch(renderReview(result), /Verdict:/);
+    assert.doesNotMatch(readFileSync(join(options.out, 'events.jsonl'), 'utf8'), /SECRET/);
+  });
+}
+
+test('clean submission followed by provider failure never renders a clean verdict', async t => {
+  const result = await runReview(fixture(t), { sdk: fakeSdk(async ({ submit, end }) => { await submit(clean()); end('error'); }) });
+  assert.equal(result.status, 'degraded');
+  assert.doesNotMatch(renderReview(result), /Verdict: no defects found/);
+});
+
+test('corrected duplicate submission cannot leave the original clean verdict successful', async t => {
+  const options = fixture(t);
+  const result = await runReview(options, { sdk: fakeSdk(async ({ submit, end }) => {
+    await submit(clean());
+    await assert.rejects(submit(review()), /already submitted/);
+    end();
+  }) });
+  assert.equal(result.status, 'degraded');
+  assert.equal(result.reason, 'duplicate_submission');
+  assert.deepEqual(result.findings, []);
+  assert.equal(result.verdict, 'no defects found'); // Original submission is evidence, never overwritten.
+  assert.doesNotMatch(renderReview(result), /Verdict: no defects found/);
+  assert.equal(JSON.parse(readFileSync(join(options.out, 'result.json'))).status, 'degraded');
+});
+
+test('external termination retains submitted findings and aborts the active session', async t => {
+  const controller = new AbortController();
+  let aborted = false;
+  const options = { ...fixture(t), signal: controller.signal };
+  const result = await runReview(options, { sdk: fakeSdk(async ({ submit, session }) => {
+    session.abort = async () => { aborted = true; };
+    await submit(review());
+    controller.abort('SIGTERM');
+    await new Promise(() => {});
+  }) });
+  assert.equal(aborted, true);
+  assert.equal(result.status, 'degraded');
+  assert.equal(result.reason, 'external_abort');
+  assert.equal(result.interrupted_by, 'SIGTERM');
+  assert.deepEqual(result.findings, review().findings);
+  assert.match(readFileSync(join(options.out, 'events.jsonl'), 'utf8'), /run_end/);
+});
+
+test('external termination also interrupts pending SDK initialization', async t => {
+  const controller = new AbortController();
+  const options = { ...fixture(t), signal: controller.signal };
+  const result = await runReview(options, { sdk: fakeSdk(async () => {}, { runtime: () => {
+    controller.abort('SIGINT');
+    return new Promise(() => {});
+  } }) });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.reason, 'external_abort');
+  assert.equal(result.interrupted_by, 'SIGINT');
+  assert.match(readFileSync(join(options.out, 'review.md'), 'utf8'), /DID NOT COMPLETE/);
+});
+
+test('submission without final stop is degraded', async t => {
+  const result = await runReview(fixture(t), { sdk: fakeSdk(async ({ submit }) => { await submit(review()); }) });
+  assert.equal(result.reason, 'missing_terminal_stop');
+});
+
+test('validation checks schema, location, verdict and execution provenance', t => {
+  const { cwd, root } = fixture(t);
+  assert.deepEqual(validateReview(review(), cwd), review());
+  for (const patch of [
+    { severity: 'critical' }, { execution: 'tested' }, { title: ' ' }, { line: 3 }, { line: 1.5 },
+    { path: '../file.js' }, { path: '/tmp/file.js' }, { path: 'missing.js' }, { tool_call_ids: ['missing'] },
+    { execution: 'executed' }, { extra: true },
+  ]) assert.throws(() => validateReview({ findings: [{ ...finding(), ...patch }], verdict: 'blocking' }, cwd));
+  assert.throws(() => validateReview({ ...review(), verdict: 'no defects found' }, cwd));
+  writeFileSync(join(root, 'outside.js'), 'code');
+  symlinkSync(join(root, 'outside.js'), join(cwd, 'escape.js'));
+  assert.throws(() => validateReview({ findings: [{ ...finding(), path: 'escape.js', line: 1 }], verdict: 'blocking' }, cwd));
+  const executed = { findings: [{ ...finding(), execution: 'executed', tool_call_ids: ['call'] }], verdict: 'blocking' };
+  for (const call of [{ toolName: 'read', isError: false }, { toolName: 'bash', isError: true }]) {
+    assert.throws(() => validateReview(executed, cwd, new Map([['call', call]])));
+  }
+  for (const exit_code of [0, 1]) assert.deepEqual(validateReview(executed, cwd, new Map([['call', { toolName: 'bash', exit_code }]])), executed);
+});
+
+test('actual successful bash completion permits execution attribution', async t => {
+  const result = await runReview(fixture(t), { sdk: fakeSdk(async ({ emit, submit, end }) => {
+    emit({ type: 'tool_execution_start', toolCallId: 'bash1', toolName: 'bash', args: { command: 'node reproduce.mjs' } });
+    emit({ type: 'tool_execution_end', toolCallId: 'bash1', toolName: 'bash', isError: false, result: { content: [{ type: 'text', text: 'reproduced' }] } });
+    await submit({ findings: [{ ...finding(), execution: 'executed', tool_call_ids: ['bash1'] }], verdict: 'blocking' });
+    end();
+  }) });
+  assert.equal(result.status, 'ok');
+  assert.equal(result.tool_calls[0].completed, true);
+});
+
+test('a failing reproduction is executed evidence; an aborted bash is not', async t => {
+  const options = fixture(t);
+  for (const [name, output, expected] of [['nonzero', 'assertion failed\n\nCommand exited with code 1', 'ok'], ['aborted', 'Command aborted', 'failed']]) {
+    const result = await runReview({ ...options, out: join(options.root, name) }, { sdk: fakeSdk(async ({ emit, submit, end }) => {
+      emit({ type: 'tool_execution_start', toolCallId: 'bash1', toolName: 'bash', args: { command: 'node reproduce.mjs' } });
+      emit({ type: 'tool_execution_end', toolCallId: 'bash1', toolName: 'bash', isError: true, result: { content: [{ type: 'text', text: output }] } });
+      await submit({ findings: [{ ...finding(), execution: 'executed', tool_call_ids: ['bash1'] }], verdict: 'blocking' });
+      end();
+    }) });
+    assert.equal(result.status, expected);
+  }
+});
+
+test('runtime timeout persists failed artifacts without waiting for initialization', async t => {
+  const options = { ...fixture(t), timeout: 0.02 };
+  const result = await runReview(options, { sdk: fakeSdk(async () => {}, { runtime: () => new Promise(() => {}) }) });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.reason, 'timeout');
+  assert.match(readFileSync(join(options.out, 'events.jsonl'), 'utf8'), /run_end/);
+});
+
+test('timeout after submission retains a degraded record', async t => {
+  const result = await runReview({ ...fixture(t), timeout: 0.02 }, { sdk: fakeSdk(async ({ submit }) => {
+    await submit(review());
+    await new Promise(() => {});
+  }) });
+  assert.equal(result.status, 'degraded');
+  assert.equal(result.reason, 'timeout');
+  assert.equal(result.findings.length, 1);
+});
+
+test('rejects reused output paths and mismatched model/thinking', async t => {
+  const options = fixture(t);
+  mkdirSync(options.out);
+  await assert.rejects(runReview(options), /EEXIST/);
+  const model = await runReview({ ...options, out: join(options.root, 'unknown'), model: 'test/missing' }, { sdk: fakeSdk(async () => {}) });
+  assert.equal(model.reason, 'model_not_found');
+  const thinking = await runReview({ ...options, out: join(options.root, 'thinking') }, { sdk: fakeSdk(async () => {}, { thinking: 'high' }) });
+  assert.equal(thinking.reason, 'thinking_level_changed');
+});
+
+test('verifies installed SDK version and rejects package drift before runtime initialization', async t => {
+  const options = fixture(t);
+  writeFileSync(join(options.root, 'package.json'), JSON.stringify({ name: '@earendil-works/pi-coding-agent', version: '0.84.5' }));
+  let initialized = false;
+  const result = await runReview(options, { sdk: fakeSdk(async () => {}, { packageDir: options.root, runtime: () => { initialized = true; } }) });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.reason, 'sdk_version_mismatch');
+  assert.equal(result.sdk_version, '0.84.5');
+  assert.equal(result.expected_sdk_version, '0.84.4');
+  assert.equal(initialized, false);
+});
+
+test('installed SDK exposes real nonzero bash receipt IDs to the model before executed submission', async t => {
+  let sdk;
+  try { sdk = await import('@earendil-works/pi-coding-agent'); }
+  catch (error) {
+    if (error.code !== 'ERR_MODULE_NOT_FOUND') throw error;
+    t.skip('Optional pinned SDK not installed; run npm ci in integrations/pi-review');
+    return;
+  }
+  const options = { ...fixture(t), timeout: 5 };
+  const command = 'printf "reproduced\\n"; exit 1';
+  let observedReceipt;
+  const actualSdk = {
+    ...sdk,
+    getAgentDir: () => options.root,
+    ModelRuntime: { create: async () => {
+      const runtime = await sdk.ModelRuntime.create({ authPath: join(options.root, 'auth.json'), modelsPath: null, allowModelNetwork: false, refreshOnCreate: false });
+      runtime.registerProvider('test', { api: 'openai-completions', baseUrl: 'http://127.0.0.1:1', apiKey: 'fake-test-key', models: [{
+        id: 'model', name: 'Fake model', reasoning: false, input: ['text'], contextWindow: 100000, maxTokens: 1000,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      }] });
+      return runtime;
+    } },
+    createAgentSession: async settings => {
+      const created = await sdk.createAgentSession(settings);
+      let turn = 0;
+      created.session.agent.streamFunction = (_model, context) => {
+        let content;
+        if (turn === 0) content = [{ type: 'toolCall', id: 'actual-bash-id', name: 'bash', arguments: { command } }];
+        else if (turn === 1) content = [{ type: 'toolCall', id: 'receipt-request', name: 'execution_receipts', arguments: {} }];
+        else if (turn === 2) {
+          const response = context.messages.find(message => message.role === 'toolResult' && message.toolName === 'execution_receipts');
+          observedReceipt = JSON.parse(response.content.find(part => part.type === 'text').text).receipts[0];
+          content = [{ type: 'toolCall', id: 'real-submit', name: 'submit_review', arguments: {
+            findings: [{ ...finding(), execution: 'executed', tool_call_ids: [observedReceipt.id] }], verdict: 'blocking',
+          } }];
+        } else content = [{ type: 'text', text: 'Done.' }];
+        const stopReason = turn++ < 3 ? 'toolUse' : 'stop';
+        const message = { role: 'assistant', api: 'openai-completions', provider: 'test', model: 'model',
+          content, stopReason, timestamp: Date.now(),
+          usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+        };
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'start', partial: message };
+            yield { type: 'done', reason: message.stopReason, message };
+          },
+          async result() { return message; },
+        };
+      };
+      return created;
+    },
+  };
+  const result = await runReview(options, { sdk: actualSdk });
+  assert.equal(result.status, 'ok', result.reason);
+  assert.equal(result.sdk_version, '0.84.4');
+  assert.deepEqual(observedReceipt, { id: 'actual-bash-id', command, exit_code: 1 });
+  assert.deepEqual(result.findings[0].tool_call_ids, [observedReceipt.id]);
+  assert.equal(result.findings[0].execution, 'executed');
+  assert.deepEqual(result.finish_reasons, ['toolUse', 'toolUse', 'toolUse', 'stop']);
+  assert.equal(result.tool_calls[0].isError, true);
+  assert.equal(result.tool_calls[0].exit_code, 1);
+});

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -139,6 +139,12 @@ adapter_files() {
       fi
     done
   done
+  # The optional SDK adapter executes these files; its shell shim alone is not its identity.
+  if [ "$a" = pireview ]; then
+    for f in cli.mjs review.mjs package.json package-lock.json; do
+      printf '%s\n' "$CADRE_ROOT/integrations/pi-review/$f"
+    done
+  fi
 }
 
 adapter_sha() {

--- a/lib/run-pass.sh
+++ b/lib/run-pass.sh
@@ -266,6 +266,7 @@ for r in "${reviewers[@]}"; do
       "v#=$SLOTS_SCHEMA_V" prompt_sha="$prompt_sha" \
       adapter_sha="$(adapter_sha "$agent")" harness_sha="$HARNESS_SHA" \
       model="$(sed -n 's/^model=//p' "$f.part.meta" 2>/dev/null | tail -1)" \
+      adapter_note="$(sed -n 's/^note=//p' "$f.part.meta" 2>/dev/null | tail -1)" \
       "adapter_attempts#=$(sed -n 's/^attempts=//p' "$f.part.meta" 2>/dev/null | tail -1)" \
       language="$CHANGE_LANG" "ts#=$(date +%s)"
     # Same rule as the panel path: the declaration is consumed, the state lives

--- a/lib/run-review.sh
+++ b/lib/run-review.sh
@@ -537,6 +537,7 @@ record_complete() {  # <slug> <spec> <state> [rc] [secs]
     adapter_sha="$(sed -n 2p "$shaf" 2>/dev/null)" \
     harness_sha="$HARNESS_SHA" \
     model="$(sed -n 's/^model=//p' "$OUT/$sl.md.part.meta" 2>/dev/null | tail -1)" \
+    adapter_note="$(sed -n 's/^note=//p' "$OUT/$sl.md.part.meta" 2>/dev/null | tail -1)" \
     "adapter_attempts#=$(sed -n 's/^attempts=//p' "$OUT/$sl.md.part.meta" 2>/dev/null | tail -1)" \
     language="$CHANGE_LANG" "ts#=$(date +%s)"
 }

--- a/tests/pi-review.sh
+++ b/tests/pi-review.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+mkdir -p "$T/bin" "$T/home" "$T/artifacts"
+cat > "$T/bin/node" <<'STUB'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = --out ]; then out="$2"; shift; fi
+  shift
+done
+mkdir -p "$out"
+case "$PI_TEST_STATE" in
+  ok) printf '{"status":"ok"}\n' > "$out/result.json"; printf 'Verdict: no defects found\n' > "$out/review.md" ;;
+  degraded) printf '{"status":"degraded"}\n' > "$out/result.json"; printf '**blocking**\nA real partial finding\n_TRUNCATED: timeout\n' > "$out/review.md" ;;
+  lie) printf '{"status":"ok"}\n' > "$out/result.json"; printf 'Verdict: no defects found\n' > "$out/review.md" ;;
+  failed) printf '{"status":"failed"}\n' > "$out/result.json"; printf 'DID NOT COMPLETE\n' > "$out/review.md" ;;
+esac
+echo 'CLI stdout is not the persisted review'
+[ "$PI_TEST_STATE" = ok ]
+STUB
+chmod +x "$T/bin/node"
+for state in ok degraded lie failed; do
+  : > "$T/meta"
+  rc=0
+  out=$(printf 'Review this tree\n' | env PATH="$T/bin:$PATH" PI_TEST_STATE="$state" \
+    CADRE_HOME="$T/home" CADRE_RUN_META="$T/meta" CADRE_PI_REVIEW_ARTIFACTS="$T/artifacts" \
+    bash "$ROOT/bin/agentcall" pireview -d "$T" -M provider/model) || rc=$?
+  if [ "$state" = ok ]; then
+    [ "$rc" -eq 0 ]; grep -q '^state=ok$' "$T/meta"; grep -q '^Verdict: no defects found$' <<< "$out"
+  elif [ "$state" = degraded ]; then
+    [ "$rc" -ne 0 ]; grep -q '^state=degraded$' "$T/meta"; grep -q '^\*\*blocking\*\*$' <<< "$out"
+    ! grep -q '^DID NOT COMPLETE' <<< "$out"
+  else
+    [ "$rc" -ne 0 ]; grep -q '^state=failed$' "$T/meta"; ! grep -q '^Verdict:' <<< "$out"
+  fi
+  ! grep -q 'CLI stdout' <<< "$out"
+  echo "ok adapter $state"
+done
+
+# A change to SDK code must change the adapter fingerprint.
+mkdir -p "$T/repo/agents.d" "$T/repo/integrations/pi-review"
+cp "$ROOT/agents.d/pireview.sh" "$T/repo/agents.d/"
+for f in cli.mjs review.mjs package.json package-lock.json; do
+  cp "$ROOT/integrations/pi-review/$f" "$T/repo/integrations/pi-review/$f"
+done
+first=$(CADRE_ROOT="$T/repo" CADRE_HOME="$T/home" bash -c 'source "$1/lib/common.sh"; adapter_sha pireview' _ "$ROOT")
+echo '// changed execution behavior' >> "$T/repo/integrations/pi-review/review.mjs"
+second=$(CADRE_ROOT="$T/repo" CADRE_HOME="$T/home" bash -c 'source "$1/lib/common.sh"; adapter_sha pireview' _ "$ROOT")
+[ -n "$first" ]; [ -n "$second" ]; [ "$first" != "$second" ]
+echo 'ok SDK source participates in adapter fingerprint'
+
+mkdir "$T/src"
+git -C "$T/src" init -q -b main
+git -C "$T/src" config user.name Fixture
+git -C "$T/src" config user.email fixture@example.invalid
+echo before > "$T/src/app.js"
+git -C "$T/src" add app.js
+git -C "$T/src" -c core.hooksPath=/dev/null commit -qm base
+echo after > "$T/src/app.js"
+env PATH="$T/bin:$PATH" PI_TEST_STATE=ok CADRE_HOME="$T/home" CADRE_WORK="$T/work" \
+  CADRE_PI_REVIEW_ARTIFACTS="$T/artifacts" \
+  bash "$ROOT/bin/cadre" review --roster pireview:provider/model --base main --synth none --label sdk "$T/src" > "$T/panel.log" 2>&1
+note=$(jq -r 'select(.event == "complete") | .adapter_note' "$T/home/reviews/sdk/runs.jsonl")
+[ -n "$note" ]; [ "$note" != null ]
+artifact="${note#pi-review artifacts: }"
+[ -s "$artifact/result.json" ]
+echo 'ok panel retains durable SDK artifact location'

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -20,6 +20,9 @@ trap 'rm -rf "$SANDBOX"' EXIT
 # One stub agent that echoes what it can see, one that truncates, one that dies.
 setup_agents() {
   mkdir -p "$1/bin" "$1/agents.d"
+  # The optional SDK may be installed locally, and Node survives the tests'
+  # /usr/bin-only PATH. Keep adapter inventory dependent on these stubs alone.
+  printf 'bin_pireview() { echo cadre-smoke-pireview-not-installed; }\n' > "$1/agents.d/pireview.sh"
   local n
   for n in good good2 trunc dead echoer chrome terse ratepart ratelim \
            synthquote synthtrunc synthrate synthtiny waffle parrot slow slow2 \
@@ -1279,7 +1282,7 @@ D=$(case_dir nudge)
 # stubs to delete, so adding a stub anywhere else in this file silently gave the
 # case two reviewers and the nudge stopped firing.
 find "$D/bin" -type f ! -name good -delete
-find "$D/agents.d" -type f ! -name good.sh -delete
+find "$D/agents.d" -type f ! -name good.sh ! -name pireview.sh -delete
 OUT=$(env -i PATH="$D/bin:/usr/bin:/bin" CADRE_HOME="$D/state" CADRE_WORK="$D/work" \
         CADRE_AGENTS_D="$D/agents.d" "$ROOT/bin/cadre" doctor 2>&1); RC=$?
 check "nudge shown at one reviewer" "grep -q 'one reviewer installed' <<<\"\$OUT\""


### PR DESCRIPTION
Add an optional `pireview` adapter on pinned Pi 0.84.4. Reviews submit structured findings with source locations and evidence. Executed claims must reference completed bash calls, and timeouts or provider failures preserve partial findings without producing a clean success. Cadre retains the artifact location in `runs.jsonl`.

Add eight original synthetic cases with paired buggy/repaired behavior checks, plus a runner that compares stock Pi CLI with the SDK adapter under matched inputs. Each attempt gets a private `/tmp` to prevent stale reproduction imports. The runner preserves failed attempts and rejects model, checkout, or input drift. It leaves quality grades blank for separate adjudication. This is an experiment; it does not establish a review-quality gain.

Validation:

- 39 SDK, evaluator, and corpus tests passed, including real temporary-directory isolation, nested Bash/Git execution, and artifact persistence on termination. The 18 SDK tests also pass inside the corrected wrapper with a fake model stream.
- Six adapter checks passed, including durable artifact links through a Cadre panel.
- Cadre smoke: 1,125 passed. Engine seam: 37 passed.
- Final paired live check: stock Pi and `pireview` both completed and caught the partial-stage cleanup defect, with unchanged review trees. A broader 24-attempt diagnostic run encountered provider failures and exposed temporary-file contamination, which the private-directory change fixes. That diagnostic run cannot establish a quality winner.

Setup and evaluation instructions: `docs/PI-REVIEW.md`. Related to #8 and #39; this slice does not close either issue.
