### PR TITLE
Classify a stated-reset quota exhaustion as a closed window, not a rate limit

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1036,7 +1036,17 @@ provider_window_closed() {
   if grep -qiE 'reached your [a-z0-9. ]{0,20}limit' "$f" \
      && grep -qiE '(^|[.!?][[:space:]]+)switch to another model' "$f" \
      && ! rate_limited "$f" && ! quota_exhausted "$f"; then return 0; fi
-  grep -qiE '(session|weekly|daily|hourly|usage|[0-9]+[ -]?hour) limit|quota reached' "$f" || return 1
+  # ★ muse on the free tier, verbatim from the WOWnet bot 2026-09-05:
+  #
+  #   API error 429 [...]: Subscription quota exhausted. Your usage window
+  #   resets at 2026-09-07T00:00:00Z. (rate_limit_error)
+  #
+  # "usage window" is not "usage limit", "quota exhausted" is not "quota
+  # reached", and the sentence break before "usage window" keeps it out of
+  # quota_exhausted's period-word tail. So it fell through to rate_limited on
+  # the 429 and was retried 60/120s against a window two days out -- on every
+  # review. A stated reset is the test, and this one states it to the second.
+  grep -qiE '(session|weekly|daily|hourly|usage|[0-9]+[ -]?hour) (limit|window)|quota (reached|exhausted)' "$f" || return 1
   grep -qiE 'reset' "$f"
 }
 

--- a/tests/review-smoke.sh
+++ b/tests/review-smoke.sh
@@ -2974,6 +2974,13 @@ printf 'Individual quota reached. Please upgrade your subscription to increase y
 check "window: agy bundled quota caught" "$WC"
 check "window: agy is NOT a budget"      "! $QE"
 check "window: agy is NOT a rate limit"  "! $RL"
+# ★ muse free tier, verbatim from the WOWnet review bot 2026-09-05. It carries
+# a 429 AND "quota exhausted", so rate_limited claims it -- and did, three
+# retries at 60/120s per review against a window that reopens in two days.
+# The reset is stated to the second; the window matcher has to take it first.
+printf 'agent loop failed: model failed: API error 429 [request_id=b6e40701]: Subscription quota exhausted. Your usage window resets at 2026-09-07T00:00:00Z. (rate_limit_error)\n' > "$QB"
+check "window: muse quota window caught" "$WC"
+check "window: muse is NOT a budget"     "! $QE"
 # ★★ THE SHADOWING TEST. quota_exhausted's pattern list contains `usage limit`,
 # which is a WINDOW phrasing sitting in the BUDGET matcher, added speculatively in
 # 96b9697 rather than from any observed string. Both functions claim this one, so


### PR DESCRIPTION
muse's free tier refuses with a 429 plus "Subscription quota exhausted. Your usage window resets at 2026-09-07T00:00:00Z". Neither window phrasing matched, so `rate_limited` claimed it and the WOWnet bot retried the seat at 60/120s on every review against a window two days out.

`provider_window_closed` now also takes "usage window" and "quota exhausted" when a reset is stated. kiro's "Request quota exceeded" and a 60s-reset 429 still stay on the retry path (checked). Fixture added verbatim.

Smoke suite: 1127 passed, 0 failed.